### PR TITLE
Simplify stored attribute data

### DIFF
--- a/example/airtable/elden-ring-map/register.php
+++ b/example/airtable/elden-ring-map/register.php
@@ -37,4 +37,4 @@ function register_airtable_elden_ring_map_block() {
 	wp_register_script( 'leaflet-script', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', [], '1.9.4', true );
 	register_block_type( $elden_ring_map_block_path );
 }
-add_action( 'register_remote_blocks', __NAMESPACE__ . '\\register_airtable_elden_ring_map_block' );
+add_action( 'register_remote_data_blocks', __NAMESPACE__ . '\\register_airtable_elden_ring_map_block' );

--- a/example/airtable/events/register.php
+++ b/example/airtable/events/register.php
@@ -29,4 +29,4 @@ function register_airtable_events_block() {
 	ConfigurationLoader::register_loop_block( 'Airtable Event List', $airtable_list_events_query );
 	ConfigurationLoader::register_page( $block_name, 'airtable-event' );
 }
-add_action( 'register_remote_blocks', __NAMESPACE__ . '\\register_airtable_events_block' );
+add_action( 'register_remote_data_blocks', __NAMESPACE__ . '\\register_airtable_events_block' );

--- a/example/rest-api/art-institute/register.php
+++ b/example/rest-api/art-institute/register.php
@@ -16,4 +16,4 @@ function register_aic_block() {
 	ConfigurationLoader::register_block( 'Art Institute of Chicago', $get_art_query );
 	ConfigurationLoader::register_list_panel( 'Art Institute of Chicago', 'List art', $search_art_query );
 }
-add_action( 'register_remote_blocks', __NAMESPACE__ . '\\register_aic_block' );
+add_action( 'register_remote_data_blocks', __NAMESPACE__ . '\\register_aic_block' );

--- a/example/rest-api/zip-code/register.php
+++ b/example/rest-api/zip-code/register.php
@@ -13,4 +13,4 @@ function register_zipcode_block() {
 
 	ConfigurationLoader::register_block( 'Zip Code', $zipcode_query );
 }
-add_action( 'register_remote_blocks', __NAMESPACE__ . '\\register_zipcode_block' );
+add_action( 'register_remote_data_blocks', __NAMESPACE__ . '\\register_zipcode_block' );

--- a/example/shopify/register.php
+++ b/example/shopify/register.php
@@ -58,4 +58,4 @@ function register_shopify_block() {
 		]
 	);
 }
-add_action( 'register_remote_blocks', __NAMESPACE__ . '\\register_shopify_block' );
+add_action( 'register_remote_data_blocks', __NAMESPACE__ . '\\register_shopify_block' );

--- a/inc/config/query-runner/query-runner.php
+++ b/inc/config/query-runner/query-runner.php
@@ -108,25 +108,15 @@ class QueryRunner implements QueryRunnerInterface {
 			$logger->warning( sprintf( 'Query error: %s', esc_html( $response_data['errors'][0]['message'] ) ) );
 		}
 
-		// Set available bindings, hiding fields that are irrelevant to frontend.
-		$available_bindings = [];
-		foreach ( $this->query_context->output_variables['mappings'] ?? [] as $key => $mapping ) {
-			$available_bindings[ $key ] = [
-				'name' => $mapping['name'],
-				'type' => $mapping['type'],
-			];
-		}
-
 		// This method always returns an array, even if it's a single item. This
 		// ensures a consistent response shape. The requestor is expected to inspect
 		// is_collection and unwrap if necessary.
 		$results = $this->map_fields( $response_data, $is_collection );
 
 		return [
-			'available_bindings' => $available_bindings,
-			'is_collection'      => $is_collection,
-			'metadata'           => $this->query_context->get_metadata( $response, $results ),
-			'results'            => $results,
+			'is_collection' => $is_collection,
+			'metadata'      => $this->query_context->get_metadata( $response, $results ),
+			'results'       => $results,
 		];
 	}
 

--- a/inc/editor/block-registration/block-registration.php
+++ b/inc/editor/block-registration/block-registration.php
@@ -26,12 +26,22 @@ class BlockRegistration {
 				return isset( $input_var['overrides'] );
 			} );
 
+			// Set available bindings from the display query output mappings.
+			$available_bindings = [];
+			foreach ( $config['queries']['__DISPLAY__']->output_variables['mappings'] ?? [] as $key => $mapping ) {
+				$available_bindings[ $key ] = [
+					'name' => $mapping['name'],
+					'type' => $mapping['type'],
+				];
+			}
+
 			$remote_data_blocks_config[ $block_name ] = [
-				'loop'      => $config['loop'],
-				'name'      => $block_name,
-				'overrides' => $overrides,
-				'panels'    => $config['panels'],
-				'settings'  => [
+				'availableBindings' => $available_bindings,
+				'loop'              => $config['loop'],
+				'name'              => $block_name,
+				'overrides'         => $overrides,
+				'panels'            => $config['panels'],
+				'settings'          => [
 					'category' => 'remote-data-blocks',
 					'title'    => $config['title'],
 				],

--- a/inc/editor/block-registration/block-registration.php
+++ b/inc/editor/block-registration/block-registration.php
@@ -5,13 +5,28 @@ namespace RemoteDataBlocks\Editor;
 defined( 'ABSPATH' ) || exit();
 
 use RemoteDataBlocks\REST\RemoteData;
-
+use WP_Block_Editor_Context;
 use function register_block_pattern;
 use function register_block_type;
 
 class BlockRegistration {
-	public static function init() {
+	public static $block_category = [
+		'icon'  => null,
+		'slug'  => 'remote-data-blocks',
+		'title' => 'Remote Data Blocks',
+	];
+
+	public static function init(): void {
 		add_action( 'init', [ __CLASS__, 'register_blocks' ], 50, 0 );
+		add_filter( 'block_categories_all', [ __CLASS__, 'add_block_category' ], 10, 2 );
+	}
+
+	public static function add_block_category( array $block_categories, WP_Block_Editor_Context $editor_context ): array {
+		if ( ! empty( $editor_context->post ) ) {
+			array_push( $block_categories, self::$block_category );
+		}
+
+		return $block_categories;
 	}
 
 	public static function register_blocks() {

--- a/inc/editor/block-registration/block-registration.php
+++ b/inc/editor/block-registration/block-registration.php
@@ -27,12 +27,14 @@ class BlockRegistration {
 			} );
 
 			$remote_data_blocks_config[ $block_name ] = [
-				'category'  => 'widgets',
 				'loop'      => $config['loop'],
 				'name'      => $block_name,
 				'overrides' => $overrides,
 				'panels'    => $config['panels'],
-				'title'     => $config['title'],
+				'settings'  => [
+					'category' => 'remote-data-blocks',
+					'title'    => $config['title'],
+				],
 			];
 
 			$block_options = [

--- a/inc/editor/configuration-loader/configuration-loader.php
+++ b/inc/editor/configuration-loader/configuration-loader.php
@@ -22,12 +22,12 @@ class ConfigurationLoader {
 	public static function init() {
 		self::$logger = LoggerManager::instance();
 
-		add_action( 'init', [ __CLASS__, 'register_remote_blocks' ], 10, 0 );
+		add_action( 'init', [ __CLASS__, 'register_remote_data_blocks' ], 10, 0 );
 	}
 
-	public static function register_remote_blocks() {
+	public static function register_remote_data_blocks() {
 		// Allow other plugins to register their blocks.
-		do_action( 'register_remote_blocks' );
+		do_action( 'register_remote_data_blocks' );
 	}
 
 	/**

--- a/inc/rest/remote-data/remote-data.php
+++ b/inc/rest/remote-data/remote-data.php
@@ -61,6 +61,10 @@ class RemoteData {
 		$block_config = ConfigurationLoader::get_configuration( $block_name );
 		$query        = $block_config['queries'][ $query_key ];
 
+		// The frontend might send more input variables than the query needs or
+		// expects, so only include those defined by the query.
+		$query_input = array_intersect_key( $query_input, $query->input_variables );
+
 		$query_runner = $query->get_query_runner();
 		$query_result = $query_runner->execute( $query_input );
 

--- a/src/blocks/context-container/components/context-controls.tsx
+++ b/src/blocks/context-container/components/context-controls.tsx
@@ -2,19 +2,17 @@ import { SelectControl } from '@wordpress/components';
 
 interface ContextControlsProps {
 	attributes: ContextInnerBlockAttributes;
+	availableBindings: AvailableBindings;
 	blockName: string;
-	remoteData: RemoteData;
 	updateBinding: ( target: string, field?: string ) => void;
 }
 
 export function ContextControls( props: ContextControlsProps ) {
-	const { attributes, blockName, remoteData, updateBinding } = props;
+	const { attributes, availableBindings, blockName, updateBinding } = props;
 
-	const contextOptions = Object.entries( remoteData.availableBindings ).map(
-		( [ key, mapping ] ) => {
-			return { label: mapping.name, value: key };
-		}
-	);
+	const contextOptions = Object.entries( availableBindings ).map( ( [ key, mapping ] ) => {
+		return { label: mapping.name, value: key };
+	} );
 
 	switch ( blockName ) {
 		case 'core/heading':

--- a/src/blocks/context-container/components/field-shortcode-select-existing.tsx
+++ b/src/blocks/context-container/components/field-shortcode-select-existing.tsx
@@ -1,7 +1,7 @@
 import { __experimentalHeading as Heading } from '@wordpress/components';
 
 import { FieldSelectionFromAvailableBindings } from './field-shortcode-select-field';
-import { getBlocksConfig } from '../../../utils/localized-data';
+import { getBlocksConfig } from '../../../utils/localized-block-data';
 import { useExistingRemoteData } from '../hooks/use-existing-remote-data';
 
 interface FieldShortcodeSelectExistingProps {

--- a/src/blocks/context-container/components/field-shortcode-select-existing.tsx
+++ b/src/blocks/context-container/components/field-shortcode-select-existing.tsx
@@ -27,7 +27,7 @@ export function FieldShortcodeSelectExisting( props: FieldShortcodeSelectExistin
 			{ remoteDatas.map( remoteData => (
 				<div className="remote-data-blocks-existing-item" key={ remoteData.blockName }>
 					<Heading className="remote-data-blocks-item-heading" level="4">
-						{ blockConfigs[ remoteData.blockName ]?.title ?? remoteData.blockName }
+						{ blockConfigs[ remoteData.blockName ]?.settings.title ?? remoteData.blockName }
 					</Heading>
 
 					<FieldSelectionFromAvailableBindings

--- a/src/blocks/context-container/components/field-shortcode-select-field.tsx
+++ b/src/blocks/context-container/components/field-shortcode-select-field.tsx
@@ -2,6 +2,7 @@ import { Spinner } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { check } from '@wordpress/icons';
 
+import { getBlockAvailableBindings } from '../../../utils/localized-block-data';
 import { DISPLAY_QUERY_KEY } from '../config/constants';
 import { useRemoteData } from '../hooks/use-remote-data';
 
@@ -56,22 +57,25 @@ type FieldSelectionWithFieldsProps = Omit< FieldSelectionProps, 'fields' | 'fiel
 
 export function FieldSelectionFromAvailableBindings( props: FieldSelectionWithFieldsProps ) {
 	const supportedBindingTypes = [ 'id', 'number', 'string' ];
-	const fields = Object.entries( props.remoteData.availableBindings ).reduce<
-		FieldSelectionProps[ 'fields' ]
-	>( ( acc, [ fieldName, binding ] ) => {
-		const fieldValue = props.remoteData.results[ 0 ]?.[ fieldName ] ?? '';
-		if ( ! fieldValue || ! supportedBindingTypes.includes( binding.type ) ) {
-			return acc;
-		}
+	const availableBindings = getBlockAvailableBindings( props.remoteData.blockName );
 
-		return {
-			...acc,
-			[ fieldName ]: {
-				name: binding.name,
-				value: fieldValue,
-			},
-		};
-	}, {} );
+	const fields = Object.entries( availableBindings ).reduce< FieldSelectionProps[ 'fields' ] >(
+		( acc, [ fieldName, binding ] ) => {
+			const fieldValue = props.remoteData.results[ 0 ]?.[ fieldName ] ?? '';
+			if ( ! fieldValue || ! supportedBindingTypes.includes( binding.type ) ) {
+				return acc;
+			}
+
+			return {
+				...acc,
+				[ fieldName ]: {
+					name: binding.name,
+					value: fieldValue,
+				},
+			};
+		},
+		{}
+	);
 
 	return <FieldSelection { ...props } fields={ fields } fieldType="field" />;
 }

--- a/src/blocks/context-container/components/field-shortcode-select-meta.tsx
+++ b/src/blocks/context-container/components/field-shortcode-select-meta.tsx
@@ -25,7 +25,7 @@ export function FieldShortcodeSelectMeta( props: FieldShortcodeSelectMetaProps )
 			{ remoteDatas.map( remoteData => (
 				<div className="remote-data-blocks-meta-item" key={ remoteData.blockName }>
 					<Heading className="remote-data-blocks-item-heading" level="4">
-						{ blockConfigs[ remoteData.blockName ]?.title ?? remoteData.blockName }
+						{ blockConfigs[ remoteData.blockName ]?.settings.title ?? remoteData.blockName }
 					</Heading>
 
 					<FieldSelectionFromMetaFields

--- a/src/blocks/context-container/components/field-shortcode-select-meta.tsx
+++ b/src/blocks/context-container/components/field-shortcode-select-meta.tsx
@@ -1,7 +1,7 @@
 import { __experimentalHeading as Heading } from '@wordpress/components';
 
 import { FieldSelectionFromMetaFields } from './field-shortcode-select-field';
-import { getBlocksConfig } from '../../../utils/localized-data';
+import { getBlocksConfig } from '../../../utils/localized-block-data';
 import { useExistingRemoteData } from '../hooks/use-existing-remote-data';
 
 interface FieldShortcodeSelectMetaProps {

--- a/src/blocks/context-container/components/field-shortcode-select-new.tsx
+++ b/src/blocks/context-container/components/field-shortcode-select-new.tsx
@@ -1,7 +1,7 @@
 import { __experimentalHeading as Heading } from '@wordpress/components';
 
 import { ItemSelectQueryType } from './item-select-query-type';
-import { getBlocksConfig } from '../../../utils/localized-data';
+import { getBlocksConfig } from '../../../utils/localized-block-data';
 
 interface FieldShortcodeSelectNewProps {
 	onSelectItem: ( config: BlockConfig, data: RemoteDataQueryInput ) => void;

--- a/src/blocks/context-container/components/field-shortcode-select-new.tsx
+++ b/src/blocks/context-container/components/field-shortcode-select-new.tsx
@@ -15,7 +15,7 @@ export function FieldShortcodeSelectNew( props: FieldShortcodeSelectNewProps ) {
 				.map( blockConfig => (
 					<div className="remote-data-blocks-new-item" key={ blockConfig.name }>
 						<Heading className="remote-data-blocks-new-item-heading" level="4">
-							{ blockConfig.title }
+							{ blockConfig.settings.title }
 						</Heading>
 						<ItemSelectQueryType
 							blockConfig={ blockConfig }

--- a/src/blocks/context-container/components/placeholder-loop.tsx
+++ b/src/blocks/context-container/components/placeholder-loop.tsx
@@ -9,7 +9,9 @@ interface PlaceholderLoopProps {
 
 export function PlaceholderLoop( props: PlaceholderLoopProps ) {
 	const {
-		blockConfig: { title },
+		blockConfig: {
+			settings: { title },
+		},
 		onSelect,
 	} = props;
 

--- a/src/blocks/context-container/components/placeholder-single.tsx
+++ b/src/blocks/context-container/components/placeholder-single.tsx
@@ -15,7 +15,7 @@ export function PlaceholderSingle( props: PlaceholderSingleProps ) {
 	return (
 		<Placeholder
 			icon={ cloud }
-			label={ blockConfig.title }
+			label={ blockConfig.settings.title }
 			instructions={ __( 'This block requires selection of a single item for display.' ) }
 		>
 			<ItemSelectQueryType blockConfig={ blockConfig } onSelect={ onSelect } />

--- a/src/blocks/context-container/config/constants.ts
+++ b/src/blocks/context-container/config/constants.ts
@@ -1,4 +1,4 @@
-import { getRestUrl } from '../../../utils/localized-data';
+import { getRestUrl } from '../../../utils/localized-block-data';
 
 export const BLOCK_BINDING_SOURCE = 'remote-data/binding';
 export const PATTERN_OVERRIDES_BINDING_SOURCE = 'core/pattern-overrides';

--- a/src/blocks/context-container/edit.tsx
+++ b/src/blocks/context-container/edit.tsx
@@ -12,12 +12,11 @@ import { DISPLAY_QUERY_KEY } from './config/constants';
 import { usePatterns } from './hooks/use-patterns';
 import { useRemoteData } from './hooks/use-remote-data';
 import { hasRemoteDataChanged } from '../../utils/block-binding';
-import { getBlocksConfig } from '../../utils/localized-data';
+import { getBlockConfig } from '../../utils/localized-block-data';
 import './editor.scss';
 
 export function Edit( props: BlockEditProps< ContextBlockAttributes > ) {
-	const blocksConfig = getBlocksConfig();
-	const blockConfig = blocksConfig[ props.name ];
+	const blockConfig = getBlockConfig( props.name );
 
 	if ( ! blockConfig ) {
 		throw new Error( `Block configuration not found for block: ${ props.name }` );

--- a/src/blocks/context-container/hooks/use-existing-remote-data.ts
+++ b/src/blocks/context-container/hooks/use-existing-remote-data.ts
@@ -1,12 +1,12 @@
 import { BlockEditorStoreSelectors, store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
-import { getBlocksConfig } from '../../../utils/localized-data';
+import { getBlocksConfig } from '../../../utils/localized-block-data';
 
 // In contrast to `useRemoteData`, this hook is used to retrieve existing remote
 // from all blocks in the editors. This is useful when we want to display a list
 // of data that has already been fetched and stored in block attributes.
-export function useExistingRemoteData() {
+export function useExistingRemoteData(): RemoteData[] {
 	const { getBlocksByName, getBlocksByClientId } = useSelect< BlockEditorStoreSelectors >(
 		blockEditorStore,
 		[]

--- a/src/blocks/context-container/hooks/use-remote-data.ts
+++ b/src/blocks/context-container/hooks/use-remote-data.ts
@@ -15,7 +15,6 @@ async function fetchRemoteData( requestData: RemoteDataApiRequest ): Promise< Re
 	}
 
 	return {
-		availableBindings: body.available_bindings,
 		blockName: body.block_name,
 		isCollection: body.is_collection,
 		metadata: body.metadata,

--- a/src/blocks/context-container/hooks/with-block-binding.tsx
+++ b/src/blocks/context-container/hooks/with-block-binding.tsx
@@ -145,4 +145,4 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 			</BoundBlockEdit>
 		);
 	};
-}, 'withToolbarButton' );
+}, 'withBlockBinding' );

--- a/src/blocks/context-container/hooks/with-block-binding.tsx
+++ b/src/blocks/context-container/hooks/with-block-binding.tsx
@@ -6,6 +6,7 @@ import { useContext, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { getMismatchedAttributes } from '../../../utils/block-binding';
+import { getBlockAvailableBindings } from '../../../utils/localized-block-data';
 import { ContextControls } from '../components/context-controls';
 import {
 	BLOCK_BINDING_SOURCE,
@@ -17,6 +18,7 @@ import { LoopIndexContext } from '../context/loop-index-context';
 
 interface BoundBlockEditProps {
 	attributes: ContextInnerBlockAttributes;
+	availableBindings: AvailableBindings;
 	blockName: string;
 	children: JSX.Element;
 	loopIndex: number;
@@ -25,8 +27,7 @@ interface BoundBlockEditProps {
 }
 
 function BoundBlockEdit( props: BoundBlockEditProps ) {
-	const { attributes, blockName, loopIndex, remoteData, setAttributes } = props;
-	const availableBindings = remoteData?.availableBindings ?? {};
+	const { attributes, availableBindings, blockName, loopIndex, remoteData, setAttributes } = props;
 	const existingBindings = attributes.metadata?.bindings ?? {};
 
 	function removeBinding( target: string ) {
@@ -72,8 +73,8 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 				<PanelBody title={ __( 'Remote Data', 'remote-data-blocks' ) }>
 					<ContextControls
 						attributes={ attributes }
+						availableBindings={ availableBindings }
 						blockName={ blockName }
-						remoteData={ remoteData }
 						updateBinding={ updateBinding }
 					/>
 				</PanelBody>
@@ -87,7 +88,7 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 	return ( props: BlockEditProps< ContextInnerBlockAttributes > ) => {
 		const { attributes, context, name, setAttributes } = props;
 		const remoteData = context[ REMOTE_DATA_CONTEXT_KEY ] as RemoteData | undefined;
-		const availableBindings = remoteData?.availableBindings ?? {};
+		const availableBindings = getBlockAvailableBindings( name );
 		const hasAvailableBindings = Boolean( Object.keys( availableBindings ).length );
 
 		// If the block does not have a remote data context, render it as usual.
@@ -134,6 +135,7 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 		return (
 			<BoundBlockEdit
 				attributes={ mergedAttributes }
+				availableBindings={ availableBindings }
 				blockName={ name }
 				loopIndex={ index }
 				remoteData={ remoteData }

--- a/src/blocks/context-container/index.ts
+++ b/src/blocks/context-container/index.ts
@@ -12,16 +12,14 @@ import './style.scss';
 // Register a unique block definition for each of the context blocks.
 Object.values( getBlocksConfig() ).forEach( blockConfig => {
 	registerBlockType< ContextBlockAttributes >( blockConfig.name, {
+		...blockConfig.settings,
 		attributes: {
 			remoteData: {
 				type: 'object',
 			},
 		},
-		category: blockConfig.category,
-		description: blockConfig.description,
 		edit: Edit,
 		save: Save,
-		title: blockConfig.title,
 	} );
 } );
 

--- a/src/blocks/context-container/index.ts
+++ b/src/blocks/context-container/index.ts
@@ -6,7 +6,7 @@ import { formatTypeSettings } from './components/field-shortcode';
 import { Edit } from './edit';
 import { withBlockBinding } from './hooks/with-block-binding';
 import { Save } from './save';
-import { getBlocksConfig } from '../../utils/localized-data';
+import { getBlocksConfig } from '../../utils/localized-block-data';
 import './style.scss';
 
 // Register a unique block definition for each of the context blocks.

--- a/src/utils/localized-block-data.ts
+++ b/src/utils/localized-block-data.ts
@@ -1,3 +1,7 @@
+export function getBlockConfig( blockName: string ): BlockConfig | undefined {
+	return window.REMOTE_DATA_BLOCKS?.config?.[ blockName ];
+}
+
 export function getBlocksConfig(): BlocksConfig {
 	return window.REMOTE_DATA_BLOCKS?.config ?? {};
 }

--- a/src/utils/localized-block-data.ts
+++ b/src/utils/localized-block-data.ts
@@ -1,3 +1,7 @@
+export function getBlockAvailableBindings( blockName: string ): AvailableBindings {
+	return getBlockConfig( blockName )?.availableBindings ?? {};
+}
+
 export function getBlockConfig( blockName: string ): BlockConfig | undefined {
 	return window.REMOTE_DATA_BLOCKS?.config?.[ blockName ];
 }

--- a/tests/inc/config/QueryRunnerTest.php
+++ b/tests/inc/config/QueryRunnerTest.php
@@ -112,7 +112,6 @@ class QueryRunnerTest extends TestCase {
 		$result       = $query_runner->execute( $input_variables );
 
 		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'available_bindings', $result );
 		$this->assertArrayHasKey( 'is_collection', $result );
 		$this->assertArrayHasKey( 'results', $result );
 	}
@@ -190,15 +189,8 @@ class QueryRunnerTest extends TestCase {
 		$result       = $query_runner->execute( $input_variables );
 
 		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'available_bindings', $result );
 		$this->assertArrayHasKey( 'is_collection', $result );
 		$this->assertArrayHasKey( 'results', $result );
 		$this->assertFalse( $result['is_collection'] );
-		$this->assertEquals( [
-			'test' => [
-				'name' => 'Test Field',
-				'type' => 'string',
-			],
-		], $result['available_bindings'] );
 	}
 }

--- a/tests/inc/integrations/vip-block-data-api/VipBlockDataApiTest.php
+++ b/tests/inc/integrations/vip-block-data-api/VipBlockDataApiTest.php
@@ -24,8 +24,8 @@ class VipBlockDataApiTest extends TestCase {
 		'name'        => 'remote-data-blocks/events',
 		'attributes'  => [
 			'remoteData' => [
-				'blockName'         => 'remote-data-blocks/events',
-				'queryInput'        => [
+				'blockName'  => 'remote-data-blocks/events',
+				'queryInput' => [
 					'event_id' => 'rec9H65WdbaeuxxaU',
 				],
 			],
@@ -72,8 +72,8 @@ class VipBlockDataApiTest extends TestCase {
 		'blockName'    => 'remote-data-blocks/events',
 		'attrs'        => [
 			'remoteData' => [
-				'blockName'         => 'remote-data-blocks/events',
-				'queryInput'        => [
+				'blockName'  => 'remote-data-blocks/events',
+				'queryInput' => [
 					'event_id' => 'rec9H65WdbaeuxxaU',
 				],
 			],

--- a/tests/inc/integrations/vip-block-data-api/VipBlockDataApiTest.php
+++ b/tests/inc/integrations/vip-block-data-api/VipBlockDataApiTest.php
@@ -24,32 +24,6 @@ class VipBlockDataApiTest extends TestCase {
 		'name'        => 'remote-data-blocks/events',
 		'attributes'  => [
 			'remoteData' => [
-				'availableBindings' => [
-					'id'       => [
-						'name'  => 'Event ID',
-						'path'  => '$.id',
-						'type'  => 'id',
-						'value' => 'rec9H65WdbaeuxxaU',
-					],
-					'title'    => [
-						'name'  => 'Title',
-						'path'  => '$.fields.Activity',
-						'type'  => 'string',
-						'value' => 'Happy hour & networking',
-					],
-					'location' => [
-						'name'  => 'Location',
-						'path'  => '$.fields.Location',
-						'type'  => 'string',
-						'value' => "President's dining hall",
-					],
-					'type'     => [
-						'name'  => 'Type',
-						'path'  => '$.fields.Type',
-						'type'  => 'string',
-						'value' => 'Networking',
-					],
-				],
 				'blockName'         => 'remote-data-blocks/events',
 				'queryInput'        => [
 					'event_id' => 'rec9H65WdbaeuxxaU',
@@ -98,32 +72,6 @@ class VipBlockDataApiTest extends TestCase {
 		'blockName'    => 'remote-data-blocks/events',
 		'attrs'        => [
 			'remoteData' => [
-				'availableBindings' => [
-					'id'       => [
-						'name'  => 'Event ID',
-						'path'  => '$.id',
-						'type'  => 'id',
-						'value' => 'rec9H65WdbaeuxxaU',
-					],
-					'title'    => [
-						'name'  => 'Title',
-						'path'  => '$.fields.Activity',
-						'type'  => 'string',
-						'value' => 'Happy hour & networking',
-					],
-					'location' => [
-						'name'  => 'Location',
-						'path'  => '$.fields.Location',
-						'type'  => 'string',
-						'value' => "President's dining hall",
-					],
-					'type'     => [
-						'name'  => 'Type',
-						'path'  => '$.fields.Type',
-						'type'  => 'string',
-						'value' => 'Networking',
-					],
-				],
 				'blockName'         => 'remote-data-blocks/events',
 				'queryInput'        => [
 					'event_id' => 'rec9H65WdbaeuxxaU',

--- a/tests/src/blocks/context-container/components/loop-template.test.tsx
+++ b/tests/src/blocks/context-container/components/loop-template.test.tsx
@@ -6,7 +6,6 @@ import { LoopTemplate } from '../../../../../src/blocks/context-container/compon
 describe( 'LoopTemplate', () => {
 	const mockGetInnerBlocks = () => [];
 	const mockRemoteData: RemoteData = {
-		availableBindings: {},
 		blockName: 'test-block',
 		isCollection: true,
 		metadata: {},
@@ -23,7 +22,6 @@ describe( 'LoopTemplate', () => {
 
 	it( 'renders "No results found" when there are no results', () => {
 		const emptyRemoteData: RemoteData = {
-			availableBindings: {},
 			blockName: 'test-block',
 			isCollection: true,
 			metadata: {},

--- a/tests/src/blocks/context-container/hooks/with-block-bindings.test.tsx
+++ b/tests/src/blocks/context-container/hooks/with-block-bindings.test.tsx
@@ -25,9 +25,26 @@ vi.mock( '@wordpress/components', () => ( {
 describe( 'withBlockBinding', () => {
 	const MockBlockEdit = vi.fn( () => <div data-testid="mock-block-edit" /> );
 	const WrappedComponent = withBlockBinding( MockBlockEdit );
+	const testBlockConfig = {
+		config: {
+			'test-block': {
+				availableBindings: { field1: { name: 'Field 1', type: 'string' } },
+				loop: false,
+				name: 'test-block',
+				overrides: {},
+				panels: [],
+				settings: {
+					category: 'widget',
+					title: 'Test block',
+				},
+			},
+		},
+		rest_url: 'http://example.com/wp-json',
+	};
 
 	beforeEach( () => {
 		vi.useFakeTimers();
+		window.REMOTE_DATA_BLOCKS = testBlockConfig;
 	} );
 
 	afterEach( () => {
@@ -55,7 +72,6 @@ describe( 'withBlockBinding', () => {
 
 	it( 'renders BoundBlockEdit when remote data is available', async () => {
 		const remoteData = {
-			availableBindings: { field1: { name: 'Field 1' } },
 			results: [ { field1: 'value1' } ],
 		};
 		render(
@@ -79,7 +95,6 @@ describe( 'withBlockBinding', () => {
 
 	it( 'does not render BoundBlockEdit for synced pattern without enabled overrides', () => {
 		const remoteData = {
-			availableBindings: { field1: { name: 'Field 1' } },
 			results: [ { field1: 'value1' } ],
 		};
 		render(
@@ -118,7 +133,6 @@ describe( 'withBlockBinding', () => {
 			context: {
 				[ REMOTE_DATA_CONTEXT_KEY ]: {
 					results: [ { title: 'New Title' } ],
-					availableBindings: { title: { name: 'Title' } },
 				},
 			},
 			name: 'test-block',
@@ -158,7 +172,6 @@ describe( 'withBlockBinding', () => {
 			context: {
 				[ REMOTE_DATA_CONTEXT_KEY ]: {
 					results: [ { title: 'Matching Title' } ],
-					availableBindings: { title: { name: 'Title' } },
 				},
 			},
 			name: 'test-block',

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,5 +1,5 @@
 declare global {
-	var REMOTE_DATA_BLOCKS: LocalizedData | undefined;
+	var REMOTE_DATA_BLOCKS: LocalizedBlockData | undefined;
 	var REMOTE_DATA_BLOCKS_SETTINGS: LocalizedSettingsData | undefined;
 }
 

--- a/types/localized-block-data.d.ts
+++ b/types/localized-block-data.d.ts
@@ -12,8 +12,6 @@ interface InputVariable {
 }
 
 interface BlockConfig {
-	category: string;
-	description: string;
 	loop: boolean;
 	name: string;
 	overrides: Record< string, InputVariableOverrides >;
@@ -23,7 +21,11 @@ interface BlockConfig {
 		query_key: string;
 		type: string;
 	}[];
-	title: string;
+	settings: {
+		category: string;
+		description?: string;
+		title: string;
+	};
 }
 
 interface BlocksConfig {

--- a/types/localized-block-data.d.ts
+++ b/types/localized-block-data.d.ts
@@ -1,3 +1,6 @@
+type RemoteDataBinding = Pick< RemoteDataResultFields, 'name' | 'type' >;
+type AvailableBindings = Record< string, RemoteDataBinding >;
+
 interface InputVariableOverrides {
 	name: string;
 	overrides: QueryInputOverride[];
@@ -12,6 +15,7 @@ interface InputVariable {
 }
 
 interface BlockConfig {
+	availableBindings: AvailableBindings;
 	loop: boolean;
 	name: string;
 	overrides: Record< string, InputVariableOverrides >;

--- a/types/localized-block-data.d.ts
+++ b/types/localized-block-data.d.ts
@@ -30,7 +30,7 @@ interface BlocksConfig {
 	[ blockName: string ]: BlockConfig;
 }
 
-interface LocalizedData {
+interface LocalizedBlockData {
 	config: BlocksConfig;
 	rest_url: string;
 }

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -8,16 +8,12 @@ interface RemoteDataResultFields {
 	value: string;
 }
 
-type RemoteDataBinding = Pick< RemoteDataResultFields, 'name' | 'type' >;
-type AvailableBindings = Record< string, RemoteDataBinding >;
-
 interface QueryInputOverride {
 	target: string;
 	type: 'query_var' | 'url';
 }
 
 interface RemoteData {
-	availableBindings: AvailableBindings;
 	blockName: string;
 	isCollection: boolean;
 	metadata: Record< string, RemoteDataResultFields >;
@@ -72,11 +68,9 @@ interface RemoteDataApiResult {
 }
 
 interface RemoteDataApiResponseBody {
-	available_bindings: AvailableBindings;
 	block_name: string;
 	is_collection: boolean;
 	metadata: Record< string, RemoteDataResultFields >;
-	query_key: string;
 	query_input: RemoteDataQueryInput;
 	result_id: string;
 	results: RemoteDataApiResult[];


### PR DESCRIPTION
This is a pile of misc improvements, mostly with the `context-container` block:

- Minor name changes
  - [Rename localized-data to localized-block-data](https://github.com/Automattic/remote-data-blocks/commit/713f0cf520d1afb926d38588e91ea68f6d9660c4)
  - [Rename register block action](https://github.com/Automattic/remote-data-blocks/commit/f19e2132314e4d0269549c7cf62544c0e44ed8e5)
  - [Improve/fix withBlockBinding HOC name](https://github.com/Automattic/remote-data-blocks/commit/7f616abdebb8b90d04a304b3506242a7c6b8dedc)
  - [Move block registration settings to subproperty](https://github.com/Automattic/remote-data-blocks/commit/9a1e2e25c1bcdde5415aecb527507a7e02671f47)
- [Trim query input to only necessary variables](https://github.com/Automattic/remote-data-blocks/commit/1d0970d84d26e90d6774fef67ed0628ef4f042ab). Before we were passing all output variables into query input and storing them unnecessarily.
- [Register a "Remote Data Blocks" category for our custom blocks](https://github.com/Automattic/remote-data-blocks/commit/ca46d1e667ee5d894c330104b5f073b2f84c9866)
- [Remove available bindings from remote data response and stored attribute](https://github.com/Automattic/remote-data-blocks/commit/2b8a814d0273f8eab25ecb51ae29d6f6c7f6e445). These are better stored in the localized block config, since they are not specific to the block instance.