### PR TITLE
Fix available bindings using incorrect block name

### DIFF
--- a/src/blocks/context-container/hooks/with-block-binding.tsx
+++ b/src/blocks/context-container/hooks/with-block-binding.tsx
@@ -88,7 +88,7 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 	return ( props: BlockEditProps< ContextInnerBlockAttributes > ) => {
 		const { attributes, context, name, setAttributes } = props;
 		const remoteData = context[ REMOTE_DATA_CONTEXT_KEY ] as RemoteData | undefined;
-		const availableBindings = getBlockAvailableBindings( name );
+		const availableBindings = getBlockAvailableBindings( remoteData?.blockName ?? '' );
 		const hasAvailableBindings = Boolean( Object.keys( availableBindings ).length );
 
 		// If the block does not have a remote data context, render it as usual.

--- a/tests/src/blocks/context-container/hooks/with-block-bindings.test.tsx
+++ b/tests/src/blocks/context-container/hooks/with-block-bindings.test.tsx
@@ -72,6 +72,7 @@ describe( 'withBlockBinding', () => {
 
 	it( 'renders BoundBlockEdit when remote data is available', async () => {
 		const remoteData = {
+			blockName: 'test-block',
 			results: [ { field1: 'value1' } ],
 		};
 		render(
@@ -95,6 +96,7 @@ describe( 'withBlockBinding', () => {
 
 	it( 'does not render BoundBlockEdit for synced pattern without enabled overrides', () => {
 		const remoteData = {
+			blockName: 'test-block',
 			results: [ { field1: 'value1' } ],
 		};
 		render(
@@ -132,6 +134,7 @@ describe( 'withBlockBinding', () => {
 			},
 			context: {
 				[ REMOTE_DATA_CONTEXT_KEY ]: {
+					blockName: 'test-block',
 					results: [ { title: 'New Title' } ],
 				},
 			},
@@ -171,6 +174,7 @@ describe( 'withBlockBinding', () => {
 			},
 			context: {
 				[ REMOTE_DATA_CONTEXT_KEY ]: {
+					blockName: 'test-block',
 					results: [ { title: 'Matching Title' } ],
 				},
 			},


### PR DESCRIPTION
Fix bug in #4 that fetched available bindings using incorrect block name