### PR TITLE
Add stylelint as a dev dependency & extend rules used by lint:css script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "phplint": "2.0.5",
         "prettier": "npm:wp-prettier@2.8.5",
         "react": "18.3.1",
+        "stylelint": "14.16.1",
         "ts-loader": "9.5.1",
         "typescript": "5.5.4",
         "vitest": "2.0.5"

--- a/package.json
+++ b/package.json
@@ -74,8 +74,12 @@
     "phplint": "2.0.5",
     "prettier": "npm:wp-prettier@2.8.5",
     "react": "18.3.1",
+    "stylelint": "14.16.1",
     "ts-loader": "9.5.1",
     "typescript": "5.5.4",
     "vitest": "2.0.5"
+  },
+  "stylelint": {
+    "extends": "./node_modules/@wordpress/scripts/config/.stylelintrc.json"
   }
 }


### PR DESCRIPTION
We're checking for style linting issues in CI:

https://github.com/Automattic/remote-data-blocks/blob/1b29e7def8a84d5a02caa4a805badc5c2dacf4c8/.github/workflows/lint.yml#L33-L34

This makes it easier to configure your IDE to highlight issues that will cause the job to fail.

For VSCode, we can use this plugin:

https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint

With settings:

```
"stylelint.validate": [
  "css",
  "postcss",
  "scss"
]
```

Note: `scss` is non-default and needs to be added.

## After setting up in Editor

![Screenshot 2024-08-22 at 12 42 22 PM](https://github.com/user-attachments/assets/148e379e-5b4d-4967-aad5-78df6fea075d)

## Further Integration Opportunity

I looked into integrating this into our prettier config so we could auto-run the fix on save, but it wasn't trivial, so I settled for this.