### PR TITLE
Add block name to binding args

### DIFF
--- a/src/blocks/remote-data-container/hooks/with-block-binding.tsx
+++ b/src/blocks/remote-data-container/hooks/with-block-binding.tsx
@@ -58,6 +58,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 					[ target ]: {
 						source: BLOCK_BINDING_SOURCE,
 						args: {
+							blockName,
 							field,
 						},
 					},

--- a/tests/src/blocks/remote-data-container/components/loop-template.test.tsx
+++ b/tests/src/blocks/remote-data-container/components/loop-template.test.tsx
@@ -6,7 +6,7 @@ import { LoopTemplate } from '@/blocks/remote-data-container/components/loop-tem
 describe( 'LoopTemplate', () => {
 	const mockGetInnerBlocks = () => [];
 	const mockRemoteData: RemoteData = {
-		blockName: 'test-block',
+		blockName: 'test/block',
 		isCollection: true,
 		metadata: {},
 		queryInput: {},
@@ -22,7 +22,7 @@ describe( 'LoopTemplate', () => {
 
 	it( 'renders "No results found" when there are no results', () => {
 		const emptyRemoteData: RemoteData = {
-			blockName: 'test-block',
+			blockName: 'test/block',
 			isCollection: true,
 			metadata: {},
 			queryInput: {},

--- a/tests/src/blocks/remote-data-container/hooks/with-block-bindings.test.tsx
+++ b/tests/src/blocks/remote-data-container/hooks/with-block-bindings.test.tsx
@@ -124,7 +124,7 @@ describe( 'withBlockBinding', () => {
 					bindings: {
 						content: {
 							source: BLOCK_BINDING_SOURCE,
-							args: { field: 'title' },
+							args: { blockName: 'test/block', field: 'title' },
 						},
 					},
 				},
@@ -164,7 +164,7 @@ describe( 'withBlockBinding', () => {
 					bindings: {
 						content: {
 							source: BLOCK_BINDING_SOURCE,
-							args: { field: 'title' },
+							args: { blockName: 'test/block', field: 'title' },
 						},
 					},
 				},

--- a/tests/src/blocks/remote-data-container/hooks/with-block-bindings.test.tsx
+++ b/tests/src/blocks/remote-data-container/hooks/with-block-bindings.test.tsx
@@ -24,10 +24,10 @@ describe( 'withBlockBinding', () => {
 	const WrappedComponent = withBlockBinding( MockBlockEdit );
 	const testBlockConfig = {
 		config: {
-			'test-block': {
+			'test/block': {
 				availableBindings: { field1: { name: 'Field 1', type: 'string' } },
 				loop: false,
-				name: 'test-block',
+				name: 'test/block',
 				overrides: {},
 				selectors: [],
 				settings: {
@@ -55,7 +55,7 @@ describe( 'withBlockBinding', () => {
 			<WrappedComponent
 				attributes={ {} }
 				context={ {} }
-				name="test-block"
+				name="test/block"
 				setAttributes={ () => {} }
 				clientId="test-client-id"
 				isSelected={ false }
@@ -69,14 +69,14 @@ describe( 'withBlockBinding', () => {
 
 	it( 'renders BoundBlockEdit when remote data is available', async () => {
 		const remoteData = {
-			blockName: 'test-block',
+			blockName: 'test/block',
 			results: [ { field1: 'value1' } ],
 		};
 		render(
 			<WrappedComponent
 				attributes={ {} }
 				context={ { [ REMOTE_DATA_CONTEXT_KEY ]: remoteData } }
-				name="test-block"
+				name="test/block"
 				setAttributes={ () => {} }
 				clientId="test-client-id"
 				isSelected={ false }
@@ -93,7 +93,7 @@ describe( 'withBlockBinding', () => {
 
 	it( 'does not render BoundBlockEdit for synced pattern without enabled overrides', () => {
 		const remoteData = {
-			blockName: 'test-block',
+			blockName: 'test/block',
 			results: [ { field1: 'value1' } ],
 		};
 		render(
@@ -103,7 +103,7 @@ describe( 'withBlockBinding', () => {
 					[ REMOTE_DATA_CONTEXT_KEY ]: remoteData,
 					[ PATTERN_OVERRIDES_CONTEXT_KEY ]: [ 'test-pattern' ],
 				} }
-				name="test-block"
+				name="test/block"
 				setAttributes={ () => {} }
 				clientId="test-client-id"
 				isSelected={ false }
@@ -131,11 +131,11 @@ describe( 'withBlockBinding', () => {
 			},
 			context: {
 				[ REMOTE_DATA_CONTEXT_KEY ]: {
-					blockName: 'test-block',
+					blockName: 'test/block',
 					results: [ { title: 'New Title' } ],
 				},
 			},
-			name: 'test-block',
+			name: 'test/block',
 			setAttributes: mockSetAttributes,
 			clientId: 'test-client-id',
 			isSelected: false,
@@ -171,11 +171,11 @@ describe( 'withBlockBinding', () => {
 			},
 			context: {
 				[ REMOTE_DATA_CONTEXT_KEY ]: {
-					blockName: 'test-block',
+					blockName: 'test/block',
 					results: [ { title: 'Matching Title' } ],
 				},
 			},
-			name: 'test-block',
+			name: 'test/block',
 			setAttributes: mockSetAttributes,
 			clientId: 'test-client-id',
 			isSelected: false,

--- a/tests/src/utils/block-binding.test.ts
+++ b/tests/src/utils/block-binding.test.ts
@@ -6,12 +6,13 @@ import { getBoundAttributeEntries, getMismatchedAttributes } from '@/utils/block
 describe( 'block-binding utils', () => {
 	describe( 'getBoundAttributeEntries', () => {
 		it( 'should return bound attribute entries', () => {
+			const blockName = 'test/block';
 			const attributes: ContextInnerBlockAttributes = {
 				metadata: {
 					bindings: {
-						content: { source: BLOCK_BINDING_SOURCE, args: { field: 'title' } },
-						url: { source: BLOCK_BINDING_SOURCE, args: { field: 'link' } },
-						alt: { source: 'other', args: { field: 'description' } },
+						content: { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'title' } },
+						url: { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'link' } },
+						alt: { source: 'other', args: { blockName, field: 'description' } },
 					},
 				},
 			};
@@ -19,8 +20,8 @@ describe( 'block-binding utils', () => {
 			const result = getBoundAttributeEntries( attributes );
 
 			expect( result ).toEqual( [
-				[ 'content', { source: BLOCK_BINDING_SOURCE, args: { field: 'title' } } ],
-				[ 'url', { source: BLOCK_BINDING_SOURCE, args: { field: 'link' } } ],
+				[ 'content', { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'title' } } ],
+				[ 'url', { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'link' } } ],
 			] );
 		} );
 
@@ -35,14 +36,15 @@ describe( 'block-binding utils', () => {
 
 	describe( 'getMismatchedAttributes', () => {
 		it( 'should return mismatched attributes', () => {
+			const blockName = 'test/block';
 			const attributes: ContextInnerBlockAttributes = {
 				content: 'Old content',
 				url: 'https://old-url.com',
 				alt: 'Old alt',
 				metadata: {
 					bindings: {
-						content: { source: BLOCK_BINDING_SOURCE, args: { field: 'title' } },
-						url: { source: BLOCK_BINDING_SOURCE, args: { field: 'link' } },
+						content: { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'title' } },
+						url: { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'link' } },
 					},
 				},
 			};
@@ -58,13 +60,14 @@ describe( 'block-binding utils', () => {
 		} );
 
 		it( 'should return an empty object when no mismatches are found', () => {
+			const blockName = 'test/block';
 			const attributes: ContextInnerBlockAttributes = {
 				content: 'Current content',
 				url: 'https://current-url.com',
 				metadata: {
 					bindings: {
-						content: { source: BLOCK_BINDING_SOURCE, args: { field: 'title' } },
-						url: { source: BLOCK_BINDING_SOURCE, args: { field: 'link' } },
+						content: { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'title' } },
+						url: { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'link' } },
 					},
 				},
 			};
@@ -77,13 +80,14 @@ describe( 'block-binding utils', () => {
 		} );
 
 		it( 'should handle missing results', () => {
+			const blockName = 'test/block';
 			const attributes: ContextInnerBlockAttributes = {
 				content: 'Old content',
 				url: 'https://old-url.com',
 				metadata: {
 					bindings: {
-						content: { source: BLOCK_BINDING_SOURCE, args: { field: 'title' } },
-						url: { source: BLOCK_BINDING_SOURCE, args: { field: 'link' } },
+						content: { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'title' } },
+						url: { source: BLOCK_BINDING_SOURCE, args: { blockName, field: 'link' } },
 					},
 				},
 			};

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -39,6 +39,7 @@ interface MetaFieldSelection extends FieldSelection {
 interface ContextBinding {
 	source: string;
 	args: {
+		blockName: string;
 		field: string;
 	};
 }


### PR DESCRIPTION
Add block name to binding args. While not required when the block is inside a context container, it will be useful in other contexts like editing patterns, when the block is necessarily disconnected from its parent.