### PR TITLE
Update tsconfig target to ES6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "typeRoots": [ "./types", "./node_modules/@types" ]
   },
   "include": [ "./types/*.d.ts", "./example/**/*", "./src/**/*", "./tests/**/*" ]


### PR DESCRIPTION
The minimum supported WP version of the plugin is `6.6` which uses Gutenberg editor having ES6 configured as `target` version ([src](https://github.com/WordPress/gutenberg/blob/wp/6.6/packages/eslint-plugin/configs/esnext.js#L12)) so updating the tsconfig `target` version in the plugin.