### PR TITLE
Fix category registration and meta registration

### DIFF
--- a/inc/editor/block-patterns/block-patterns.php
+++ b/inc/editor/block-patterns/block-patterns.php
@@ -141,7 +141,7 @@ class BlockPatterns {
 			[
 				'title'      => sprintf( '%s Data', $block_title ),
 				'blockTypes' => [ $block_name ],
-				'categories' => [ 'Remote Data' ],
+				'categories' => [ 'Remote Data Blocks' ],
 				'content'    => $content,
 				'inserter'   => true,
 				'source'     => 'plugin',

--- a/inc/editor/block-registration/block-registration.php
+++ b/inc/editor/block-registration/block-registration.php
@@ -18,13 +18,11 @@ class BlockRegistration {
 
 	public static function init(): void {
 		add_action( 'init', [ __CLASS__, 'register_blocks' ], 50, 0 );
-		add_filter( 'block_categories_all', [ __CLASS__, 'add_block_category' ], 10, 2 );
+		add_filter( 'block_categories_all', [ __CLASS__, 'add_block_category' ], 10, 1 );
 	}
 
-	public static function add_block_category( array $block_categories, WP_Block_Editor_Context $editor_context ): array {
-		if ( ! empty( $editor_context->post ) ) {
-			array_push( $block_categories, self::$block_category );
-		}
+	public static function add_block_category( array $block_categories ): array {
+		array_push( $block_categories, self::$block_category );
 
 		return $block_categories;
 	}

--- a/inc/editor/pattern-editor/pattern-editor.php
+++ b/inc/editor/pattern-editor/pattern-editor.php
@@ -5,25 +5,33 @@ namespace RemoteDataBlocks\Editor;
 defined( 'ABSPATH' ) || exit();
 
 class PatternEditor {
-	public static function init() {
-		register_post_meta( 'wp_block', '_remote_data_blocks_block_type', [
-			'show_in_rest' => true,
-			'single'       => true,
-			'type'         => 'string',
-		] );
+	public static $block_type_meta_key = '_remote_data_blocks_block_type';
 
-		add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\PatternEditor::enqueue_block_editor_assets' );
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_meta' ], 10, 0 );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ], 10, 0 );
+	}
+
+	public static function register_meta() {
+		register_post_meta( 'wp_block', self::$block_type_meta_key, [
+			'auth_callback' => function ( bool $_allowed, string $meta_key, int $object_id ) {
+				return current_user_can( 'edit_post_meta', $object_id );
+			},
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'string',
+		] );
 	}
 
 	public static function enqueue_block_editor_assets() {
 		$asset_file = REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/pattern-editor/index.asset.php';
-	
+
 		if ( ! file_exists( $asset_file ) ) {
 			wp_die( 'The settings asset file is missing. Run `npm run build` to generate it.' );
 		}
-	
+
 		$asset = include $asset_file;
-	
+
 		wp_enqueue_script(
 			'remote-data-blocks-pattern-editor',
 			plugins_url( 'build/pattern-editor/index.js', REMOTE_DATA_BLOCKS__PLUGIN_ROOT ),


### PR DESCRIPTION
Two small miscellaneous fixes:

- [Use categories consistently across blocks and patterns](https://github.com/Automattic/remote-data-blocks/commit/ef60cbd6092622724de0d371af36eb646fe3860d) (prevents console error in pattern editor)
- [Move register_meta to init hook](https://github.com/Automattic/remote-data-blocks/commit/bcb87559fb4ecc899f367d38f7f42753a9e637b9) (best practice alignment)