### PR TITLE
Add block identifier to binding args in patterns

### DIFF
--- a/inc/editor/block-bindings/block-bindings.php
+++ b/inc/editor/block-bindings/block-bindings.php
@@ -214,7 +214,7 @@ class BlockBindings {
 		$field_name = $source_args['field'];
 		$index      = $source_args['index'] ?? 0; // Index is only set for loop queries.
 
-		if ( isset( $source_args['name'] ) && $source_args['name'] !== $block_name ) {
+		if ( isset( $source_args['block'] ) && $source_args['block'] !== $block_name ) {
 			self::log_error( 'Block binding belongs to a different remote data block', $block_name, $field_name );
 			return null;
 		}

--- a/inc/editor/block-patterns/block-patterns.php
+++ b/inc/editor/block-patterns/block-patterns.php
@@ -22,7 +22,7 @@ class BlockPatterns {
 		self::$templates['paragraph'] = file_get_contents( __DIR__ . '/templates/paragraph.html', false );
 	}
 
-	private static function generate_attribute_bindings( array $bindings ): array {
+	private static function generate_attribute_bindings( string $block_name, array $bindings ): array {
 		$attributes = [
 			'metadata' => [
 				'bindings' => [],
@@ -38,6 +38,7 @@ class BlockPatterns {
 				'source' => 'remote-data/binding',
 				'args'   => [
 					'field' => $binding[0],
+					'name'  => $block_name,
 				],
 			];
 
@@ -122,16 +123,16 @@ class BlockPatterns {
 		}
 
 		if ( ! empty( $bindings['heading']['content'] ) ) {
-			$content .= self::populate_template( 'heading', self::generate_attribute_bindings( $bindings['heading'] ) );
+			$content .= self::populate_template( 'heading', self::generate_attribute_bindings( $block_name, $bindings['heading'] ) );
 		}
 
 		foreach ( $bindings['paragraphs'] as $paragraph ) {
-			$content .= self::populate_template( 'paragraph', self::generate_attribute_bindings( $paragraph ) );
+			$content .= self::populate_template( 'paragraph', self::generate_attribute_bindings( $block_name, $paragraph ) );
 		}
 
 		// If there is an image URL, create two-column layout with left-aligned image.
 		if ( ! empty( $bindings['image']['url'] ) ) {
-			$image_bindings = self::generate_attribute_bindings( $bindings['image'] );
+			$image_bindings = self::generate_attribute_bindings( $block_name, $bindings['image'] );
 			$image_content  = self::populate_template( 'image', $image_bindings );
 			$content        = sprintf( self::$templates['columns'], $image_content, $content );
 		}

--- a/inc/editor/block-patterns/block-patterns.php
+++ b/inc/editor/block-patterns/block-patterns.php
@@ -37,8 +37,8 @@ class BlockPatterns {
 			$attributes['metadata']['bindings'][ $attribute ] = [
 				'source' => 'remote-data/binding',
 				'args'   => [
+					'block' => $block_name,
 					'field' => $binding[0],
-					'name'  => $block_name,
 				],
 			];
 

--- a/src/blocks/remote-data-container/components/block-binding-controls.tsx
+++ b/src/blocks/remote-data-container/components/block-binding-controls.tsx
@@ -35,7 +35,7 @@ interface BlockBindingControlsProps {
 	availableBindings: AvailableBindings;
 	blockName: string;
 	removeBinding: ( target: string ) => void;
-	updateBinding: ( target: string, args: Omit< RemoteDataBlockBindingArgs, 'name' > ) => void;
+	updateBinding: ( target: string, args: Omit< RemoteDataBlockBindingArgs, 'block' > ) => void;
 }
 
 export function BlockBindingControls( props: BlockBindingControlsProps ) {

--- a/src/blocks/remote-data-container/components/item-list/item-list.tsx
+++ b/src/blocks/remote-data-container/components/item-list/item-list.tsx
@@ -33,7 +33,9 @@ export function ItemList( props: ItemListProps ) {
 	}
 
 	return props.results.map( ( result, index ) => {
-		const blocks = pattern?.blocks.map( block => cloneBlockWithAttributes( block, result ) ) ?? [];
+		const blocks =
+			pattern?.blocks.map( block => cloneBlockWithAttributes( block, result, props.blockName ) ) ??
+			[];
 
 		return (
 			<ItemPreview key={ index } blocks={ blocks } onSelect={ () => props.onSelect( result ) } />

--- a/src/blocks/remote-data-container/filters/with-block-binding.tsx
+++ b/src/blocks/remote-data-container/filters/with-block-binding.tsx
@@ -40,7 +40,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 		} );
 	}
 
-	function updateBinding( target: string, args: Omit< RemoteDataBlockBindingArgs, 'name' > ) {
+	function updateBinding( target: string, args: Omit< RemoteDataBlockBindingArgs, 'block' > ) {
 		setAttributes( {
 			className: getBoundBlockClassName( attributes, remoteDataName ),
 			metadata: {
@@ -51,7 +51,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 						source: BLOCK_BINDING_SOURCE,
 						args: {
 							...args,
-							name: remoteDataName, // Remote Data Block name
+							block: remoteDataName, // Remote Data Block name
 						},
 					},
 				},
@@ -116,7 +116,7 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 		// values, update and merge the attributes.
 		const mergedAttributes = {
 			...attributes,
-			...getMismatchedAttributes( attributes, remoteData.results, index ),
+			...getMismatchedAttributes( attributes, remoteData.results, remoteData.blockName, index ),
 		};
 
 		// If the block is not writable, render it as usual.

--- a/src/blocks/remote-data-container/filters/with-block-binding.tsx
+++ b/src/blocks/remote-data-container/filters/with-block-binding.tsx
@@ -42,7 +42,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 
 	function updateBinding( target: string, args: Omit< RemoteDataBlockBindingArgs, 'name' > ) {
 		setAttributes( {
-			className: getBoundBlockClassName( attributes ),
+			className: getBoundBlockClassName( attributes, remoteDataName ),
 			metadata: {
 				...attributes.metadata,
 				bindings: {

--- a/src/blocks/remote-data-container/hooks/use-patterns.ts
+++ b/src/blocks/remote-data-container/hooks/use-patterns.ts
@@ -31,7 +31,7 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string )
 	const { replaceInnerBlocks } = useDispatch< BlockEditorStoreActions >( blockEditorStore );
 	const { getBlocks, getPatternsByBlockTypes } = useSelect< BlockEditorStoreSelectors >(
 		blockEditorStore,
-		[ blockName, rootClientId ]
+		[ remoteDataBlockName, rootClientId ]
 	);
 	const [ showPatternSelection, setShowPatternSelection ] = useState< boolean >( false );
 
@@ -40,12 +40,12 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string )
 			result: Record< string, string >
 		): BlockInstance< RemoteDataInnerBlockAttributes >[] => {
 			return getBlocks< RemoteDataInnerBlockAttributes >( rootClientId ).map( block =>
-				cloneBlockWithAttributes( block, result )
+				cloneBlockWithAttributes( block, result, remoteDataBlockName )
 			);
 		},
 		getPatternsByBlockTypes,
 		getSupportedPatterns: ( result?: Record< string, string > ): BlockPattern[] => {
-			const supportedPatterns = getPatternsByBlockTypes( blockName, rootClientId );
+			const supportedPatterns = getPatternsByBlockTypes( remoteDataBlockName, rootClientId );
 
 			// If no result is provided, return the supported patterns as is.
 			if ( ! result ) {

--- a/src/blocks/remote-data-container/hooks/use-patterns.ts
+++ b/src/blocks/remote-data-container/hooks/use-patterns.ts
@@ -12,17 +12,22 @@ import { getBoundAttributeEntries, getMismatchedAttributes } from '@/utils/block
 
 export function cloneBlockWithAttributes(
 	block: BlockInstance,
-	attributes: Record< string, string >
+	attributes: Record< string, string >,
+	remoteDataBlockName: string
 ): BlockInstance {
-	const mismatchedAttributes = getMismatchedAttributes( block.attributes, [ attributes ] );
+	const mismatchedAttributes = getMismatchedAttributes(
+		block.attributes,
+		[ attributes ],
+		remoteDataBlockName
+	);
 	const newInnerBlocks = block.innerBlocks?.map( innerBlock =>
-		cloneBlockWithAttributes( innerBlock, attributes )
+		cloneBlockWithAttributes( innerBlock, attributes, remoteDataBlockName )
 	);
 
 	return cloneBlock( block, mismatchedAttributes, newInnerBlocks );
 }
 
-export function usePatterns( blockName: string, rootClientId: string ) {
+export function usePatterns( remoteDataBlockName: string, rootClientId: string ) {
 	const { replaceInnerBlocks } = useDispatch< BlockEditorStoreActions >( blockEditorStore );
 	const { getBlocks, getPatternsByBlockTypes } = useSelect< BlockEditorStoreSelectors >(
 		blockEditorStore,
@@ -51,7 +56,9 @@ export function usePatterns( blockName: string, rootClientId: string ) {
 			// it can be previewed.
 			return supportedPatterns.map( pattern => ( {
 				...pattern,
-				blocks: pattern.blocks.map( block => cloneBlockWithAttributes( block, result ) ),
+				blocks: pattern.blocks.map( block =>
+					cloneBlockWithAttributes( block, result, remoteDataBlockName )
+				),
 			} ) );
 		},
 		insertPatternBlocks: ( pattern: BlockPattern ): void => {
@@ -61,7 +68,7 @@ export function usePatterns( blockName: string, rootClientId: string ) {
 			// of the collection.
 			const patternBlocks =
 				pattern.blocks.map( block => {
-					const boundAttributes = getBoundAttributeEntries( block.attributes );
+					const boundAttributes = getBoundAttributeEntries( block.attributes, remoteDataBlockName );
 
 					if ( ! boundAttributes.length ) {
 						return block;

--- a/src/utils/block-binding.ts
+++ b/src/utils/block-binding.ts
@@ -38,7 +38,7 @@ export function getBoundAttributeEntries(
 ): [ string, RemoteDataBlockBinding ][] {
 	return Object.entries( attributes.metadata?.bindings ?? {} ).filter(
 		( [ _target, binding ] ) =>
-			binding.source === BLOCK_BINDING_SOURCE && binding.args?.name === remoteDataBlockName
+			binding.source === BLOCK_BINDING_SOURCE && binding.args?.block === remoteDataBlockName
 	);
 }
 

--- a/src/utils/block-binding.ts
+++ b/src/utils/block-binding.ts
@@ -33,20 +33,25 @@ function getExpectedAttributeValue(
 }
 
 export function getBoundAttributeEntries(
-	attributes: RemoteDataInnerBlockAttributes
+	attributes: RemoteDataInnerBlockAttributes,
+	remoteDataBlockName: string
 ): [ string, RemoteDataBlockBinding ][] {
 	return Object.entries( attributes.metadata?.bindings ?? {} ).filter(
-		( [ _target, binding ] ) => binding.source === BLOCK_BINDING_SOURCE
+		( [ _target, binding ] ) =>
+			binding.source === BLOCK_BINDING_SOURCE && binding.args?.name === remoteDataBlockName
 	);
 }
 
-export function getBoundBlockClassName( attributes: RemoteDataInnerBlockAttributes ): string {
+export function getBoundBlockClassName(
+	attributes: RemoteDataInnerBlockAttributes,
+	remoteDataBlockName: string
+): string {
 	const existingClassNames = ( attributes.className ?? '' )
 		.split( /\s/ )
 		.filter( className => ! className.startsWith( 'rdb-block-data-' ) );
 	const classNames = new Set< string | undefined >( [
 		...existingClassNames,
-		...getBoundAttributeEntries( attributes ).map( ( [ _target, binding ] ) =>
+		...getBoundAttributeEntries( attributes, remoteDataBlockName ).map( ( [ _target, binding ] ) =>
 			getClassName( `block-data-${ binding.args.field }` )
 		),
 	] );
@@ -57,10 +62,11 @@ export function getBoundBlockClassName( attributes: RemoteDataInnerBlockAttribut
 export function getMismatchedAttributes(
 	attributes: RemoteDataInnerBlockAttributes,
 	results: RemoteData[ 'results' ],
+	remoteDataBlockName: string,
 	index = 0
 ): Partial< RemoteDataInnerBlockAttributes > {
 	return Object.fromEntries(
-		getBoundAttributeEntries( attributes )
+		getBoundAttributeEntries( attributes, remoteDataBlockName )
 			.map( ( [ target, binding ] ) => [
 				target,
 				getExpectedAttributeValue( results[ index ], binding.args ),

--- a/tests/src/blocks/remote-data-container/filters/with-block-bindings.test.tsx
+++ b/tests/src/blocks/remote-data-container/filters/with-block-bindings.test.tsx
@@ -124,7 +124,7 @@ describe( 'withBlockBinding', () => {
 					bindings: {
 						content: {
 							source: BLOCK_BINDING_SOURCE,
-							args: { name: 'test/block', field: 'title' },
+							args: { block: 'test/block', field: 'title' },
 						},
 					},
 				},
@@ -164,7 +164,7 @@ describe( 'withBlockBinding', () => {
 					bindings: {
 						content: {
 							source: BLOCK_BINDING_SOURCE,
-							args: { name: 'test/block', field: 'title' },
+							args: { block: 'test/block', field: 'title' },
 						},
 					},
 				},

--- a/tests/src/utils/block-binding.test.ts
+++ b/tests/src/utils/block-binding.test.ts
@@ -11,13 +11,14 @@ describe( 'block-binding utils', () => {
 				metadata: {
 					bindings: {
 						content: { source: BLOCK_BINDING_SOURCE, args: { name, field: 'title' } },
+						text: { source: BLOCK_BINDING_SOURCE, args: { name: 'test/block2', field: 'text' } },
 						url: { source: BLOCK_BINDING_SOURCE, args: { name, field: 'link' } },
 						alt: { source: 'other', args: { name, field: 'description' } },
 					},
 				},
 			};
 
-			const result = getBoundAttributeEntries( attributes );
+			const result = getBoundAttributeEntries( attributes, name );
 
 			expect( result ).toEqual( [
 				[ 'content', { source: BLOCK_BINDING_SOURCE, args: { name, field: 'title' } } ],
@@ -28,7 +29,7 @@ describe( 'block-binding utils', () => {
 		it( 'should return an empty array when no bindings are present', () => {
 			const attributes: RemoteDataInnerBlockAttributes = {};
 
-			const result = getBoundAttributeEntries( attributes );
+			const result = getBoundAttributeEntries( attributes, 'test/block' );
 
 			expect( result ).toEqual( [] );
 		} );
@@ -51,7 +52,7 @@ describe( 'block-binding utils', () => {
 
 			const results = [ { title: 'New content', link: 'https://new-url.com' } ];
 
-			const result = getMismatchedAttributes( attributes, results );
+			const result = getMismatchedAttributes( attributes, results, name );
 
 			expect( result ).toEqual( {
 				content: 'New content',
@@ -77,7 +78,7 @@ describe( 'block-binding utils', () => {
 
 			const results = [ { title: 'Current content', link: 'https://current-url.com' } ];
 
-			const result = getMismatchedAttributes( attributes, results );
+			const result = getMismatchedAttributes( attributes, results, name );
 
 			expect( result ).toEqual( {} );
 		} );
@@ -97,7 +98,7 @@ describe( 'block-binding utils', () => {
 
 			const results: Record< string, string >[] = [ { title: 'New content' } ];
 
-			const result = getMismatchedAttributes( attributes, results );
+			const result = getMismatchedAttributes( attributes, results, name );
 
 			expect( result ).toEqual( {
 				content: 'New content',
@@ -120,7 +121,7 @@ describe( 'block-binding utils', () => {
 
 			const results: Record< string, string >[] = [ { title: 'My Title' } ];
 
-			const result = getMismatchedAttributes( attributes, results );
+			const result = getMismatchedAttributes( attributes, results, name );
 
 			expect( result ).toEqual( {
 				content: '<span class="rdb-block-label">Title</span> My Title',

--- a/tests/src/utils/block-binding.test.ts
+++ b/tests/src/utils/block-binding.test.ts
@@ -6,23 +6,23 @@ import { getBoundAttributeEntries, getMismatchedAttributes } from '@/utils/block
 describe( 'block-binding utils', () => {
 	describe( 'getBoundAttributeEntries', () => {
 		it( 'should return bound attribute entries', () => {
-			const name = 'test/block';
+			const block = 'test/block';
 			const attributes: RemoteDataInnerBlockAttributes = {
 				metadata: {
 					bindings: {
-						content: { source: BLOCK_BINDING_SOURCE, args: { name, field: 'title' } },
-						text: { source: BLOCK_BINDING_SOURCE, args: { name: 'test/block2', field: 'text' } },
-						url: { source: BLOCK_BINDING_SOURCE, args: { name, field: 'link' } },
-						alt: { source: 'other', args: { name, field: 'description' } },
+						content: { source: BLOCK_BINDING_SOURCE, args: { block, field: 'title' } },
+						text: { source: BLOCK_BINDING_SOURCE, args: { block: 'test/block2', field: 'text' } },
+						url: { source: BLOCK_BINDING_SOURCE, args: { block, field: 'link' } },
+						alt: { source: 'other', args: { block, field: 'description' } },
 					},
 				},
 			};
 
-			const result = getBoundAttributeEntries( attributes, name );
+			const result = getBoundAttributeEntries( attributes, block );
 
 			expect( result ).toEqual( [
-				[ 'content', { source: BLOCK_BINDING_SOURCE, args: { name, field: 'title' } } ],
-				[ 'url', { source: BLOCK_BINDING_SOURCE, args: { name, field: 'link' } } ],
+				[ 'content', { source: BLOCK_BINDING_SOURCE, args: { block, field: 'title' } } ],
+				[ 'url', { source: BLOCK_BINDING_SOURCE, args: { block, field: 'link' } } ],
 			] );
 		} );
 
@@ -37,22 +37,22 @@ describe( 'block-binding utils', () => {
 
 	describe( 'getMismatchedAttributes', () => {
 		it( 'should return mismatched attributes', () => {
-			const name = 'test/block';
+			const block = 'test/block';
 			const attributes: RemoteDataInnerBlockAttributes = {
 				content: 'Old content',
 				url: 'https://old-url.com',
 				alt: 'Old alt',
 				metadata: {
 					bindings: {
-						content: { source: BLOCK_BINDING_SOURCE, args: { name, field: 'title' } },
-						url: { source: BLOCK_BINDING_SOURCE, args: { name, field: 'link' } },
+						content: { source: BLOCK_BINDING_SOURCE, args: { block, field: 'title' } },
+						url: { source: BLOCK_BINDING_SOURCE, args: { block, field: 'link' } },
 					},
 				},
 			};
 
 			const results = [ { title: 'New content', link: 'https://new-url.com' } ];
 
-			const result = getMismatchedAttributes( attributes, results, name );
+			const result = getMismatchedAttributes( attributes, results, block );
 
 			expect( result ).toEqual( {
 				content: 'New content',
@@ -61,7 +61,7 @@ describe( 'block-binding utils', () => {
 		} );
 
 		it( 'should return an empty object when no mismatches are found', () => {
-			const name = 'test/block';
+			const block = 'test/block';
 			const attributes: RemoteDataInnerBlockAttributes = {
 				content: '<span class="rdb-block-label">Title</span> Current content',
 				url: 'https://current-url.com',
@@ -69,36 +69,36 @@ describe( 'block-binding utils', () => {
 					bindings: {
 						content: {
 							source: BLOCK_BINDING_SOURCE,
-							args: { name, field: 'title', label: 'Title' },
+							args: { block, field: 'title', label: 'Title' },
 						},
-						url: { source: BLOCK_BINDING_SOURCE, args: { name, field: 'link' } },
+						url: { source: BLOCK_BINDING_SOURCE, args: { block, field: 'link' } },
 					},
 				},
 			};
 
 			const results = [ { title: 'Current content', link: 'https://current-url.com' } ];
 
-			const result = getMismatchedAttributes( attributes, results, name );
+			const result = getMismatchedAttributes( attributes, results, block );
 
 			expect( result ).toEqual( {} );
 		} );
 
 		it( 'should handle missing results', () => {
-			const name = 'test/block';
+			const block = 'test/block';
 			const attributes: RemoteDataInnerBlockAttributes = {
 				content: 'Old content',
 				url: 'https://old-url.com',
 				metadata: {
 					bindings: {
-						content: { source: BLOCK_BINDING_SOURCE, args: { name, field: 'title' } },
-						url: { source: BLOCK_BINDING_SOURCE, args: { name, field: 'link' } },
+						content: { source: BLOCK_BINDING_SOURCE, args: { block, field: 'title' } },
+						url: { source: BLOCK_BINDING_SOURCE, args: { block, field: 'link' } },
 					},
 				},
 			};
 
 			const results: Record< string, string >[] = [ { title: 'New content' } ];
 
-			const result = getMismatchedAttributes( attributes, results, name );
+			const result = getMismatchedAttributes( attributes, results, block );
 
 			expect( result ).toEqual( {
 				content: 'New content',
@@ -106,14 +106,14 @@ describe( 'block-binding utils', () => {
 		} );
 
 		it( 'should handle missing label', () => {
-			const name = 'test/block';
+			const block = 'test/block';
 			const attributes: RemoteDataInnerBlockAttributes = {
 				content: 'My Title',
 				metadata: {
 					bindings: {
 						content: {
 							source: BLOCK_BINDING_SOURCE,
-							args: { name, field: 'title', label: 'Title' },
+							args: { block, field: 'title', label: 'Title' },
 						},
 					},
 				},
@@ -121,7 +121,7 @@ describe( 'block-binding utils', () => {
 
 			const results: Record< string, string >[] = [ { title: 'My Title' } ];
 
-			const result = getMismatchedAttributes( attributes, results, name );
+			const result = getMismatchedAttributes( attributes, results, block );
 
 			expect( result ).toEqual( {
 				content: '<span class="rdb-block-label">Title</span> My Title',

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -37,9 +37,9 @@ interface MetaFieldSelection extends FieldSelection {
 }
 
 interface RemoteDataBlockBindingArgs {
+	block: string;
 	field: string;
 	label?: string;
-	name: string;
 }
 
 interface RemoteDataBlockBinding {


### PR DESCRIPTION
Fix: In the block editor, we were adding the remote data block identifier (currently the block name) to the binding args so that the binding could be identified even if it was separated from its parent container / context. However, we were not adding the block identifier in registered patterns (despite the fact that they are always separated!).

1. This PR addresses that, helping us to make connections between patterns and the remote data blocks that they may be associated with.
2. Bugfix enabled by 1: We now pass the block identifier into additional utility functions so that we only operate on bindings that are relevant to the current remote data block.
3. Improvement enabled by 1: We rename the property used to store the block identifier from `name` to `block`. The former is very vague and used in multiple places for other purposes. The latter is more specific. We may want to move from a block name identifier to something immutable, but for now block name is all we have available and it unblocks other progress.