### PR TITLE
Fix wp.components.TextControl is deprecated notice

### DIFF
--- a/src/blocks/remote-data-container/components/modals/input-modal.tsx
+++ b/src/blocks/remote-data-container/components/modals/input-modal.tsx
@@ -49,6 +49,7 @@ export function InputModal( props: InputModalProps ) {
 						value={ inputState[ input.slug ] ?? '' }
 						onChange={ ( value: string ) => onChange( input.slug, value ) }
 						__nextHasNoMarginBottom
+						style={ { marginBottom: '8px' } }
 					/>
 				) ) }
 				<Button variant="primary" onClick={ wrappedOnSelect }>

--- a/src/blocks/remote-data-container/components/modals/input-modal.tsx
+++ b/src/blocks/remote-data-container/components/modals/input-modal.tsx
@@ -48,6 +48,7 @@ export function InputModal( props: InputModalProps ) {
 						required={ input.required }
 						value={ inputState[ input.slug ] ?? '' }
 						onChange={ ( value: string ) => onChange( input.slug, value ) }
+						__nextHasNoMarginBottom
 					/>
 				) ) }
 				<Button variant="primary" onClick={ wrappedOnSelect }>


### PR DESCRIPTION
Our tests have exposed this:

```
stderr | tests/src/blocks/remote-data-container/components/modals/input-modal.test.tsx > InputModal > opens the modal when the button is clicked
Bottom margin styles for wp.components.TextControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.
```