### PR TITLE
Add static example API

### DIFF
--- a/example/remote-data-blocks-example-code.php
+++ b/example/remote-data-blocks-example-code.php
@@ -35,7 +35,6 @@ function load_only_if_parent_plugin_is_active() {
 	}
 
 	require_once __DIR__ . '/airtable/elden-ring-map/register.php';
-	require_once __DIR__ . '/airtable/events/register.php';
 	require_once __DIR__ . '/github/remote-data-blocks/register.php';
 	require_once __DIR__ . '/rest-api/art-institute/register.php';
 	require_once __DIR__ . '/rest-api/zip-code/register.php';

--- a/inc/Config/QueryContext/HttpQueryContext.php
+++ b/inc/Config/QueryContext/HttpQueryContext.php
@@ -9,7 +9,6 @@
 
 namespace RemoteDataBlocks\Config\QueryContext;
 
-use Psr\Http\Message\ResponseInterface;
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
@@ -94,16 +93,16 @@ class HttpQueryContext implements QueryContextInterface, HttpQueryContextInterfa
 	 * query. This method is called after the query is run or is returned from
 	 * cache. These variables will be available as bindings for field shortcodes.
 	 *
-	 * @param ResponseInterface $response The response object from the query.
-	 * @param array             $results  The results of the query.
+	 * @param array $response_metadata The response metadata returned by the query runner.
+	 * @param array $query_results     The results of the query.
 	 * @return array $var_name {
 	 *   @type string $name  Display name of the variable.
 	 *   @type string $type  The variable type (string, number, boolean)
 	 *   @type string $value Value of the variable.
 	 * }
 	 */
-	public function get_metadata( ResponseInterface $response, array $query_results ): array {
-		$age  = intval( $response->getHeader( 'age' )[0] ?? 0 );
+	public function get_metadata( array $response_metadata, array $query_results ): array {
+		$age  = intval( $response_metadata['age'] ?? 0 );
 		$time = time() - $age;
 
 		return [
@@ -168,7 +167,7 @@ class HttpQueryContext implements QueryContextInterface, HttpQueryContextInterfa
 	/**
 	 * Override this method to process the raw response data from the query before
 	 * it is passed to the query runner and the output variables are extracted. The
-	 * result can be  a JSON string, a PHP associative array, a PHP object, or null.
+	 * result can be a JSON string, a PHP associative array, a PHP object, or null.
 	 *
 	 * @param string $raw_response_data The raw response data.
 	 * @param array  $input_variables   The input variables for this query.

--- a/inc/Config/QueryContext/QueryContextInterface.php
+++ b/inc/Config/QueryContext/QueryContextInterface.php
@@ -9,14 +9,13 @@
 
 namespace RemoteDataBlocks\Config\QueryContext;
 
-use Psr\Http\Message\ResponseInterface;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
 
 interface QueryContextInterface {
 	public function get_image_url(): string|null;
-	public function get_metadata( ResponseInterface $response, array $query_results ): array;
+	public function get_metadata( array $response_metadata, array $query_results ): array;
 	public function get_query_name(): string;
 	public function get_query_runner(): QueryRunnerInterface;
 	public function is_response_data_collection(): bool;
-	public function process_response( string $raw_response_data, array $input_variables ): string|array|object|null;
+	public function process_response( string $raw_response_string, array $input_variables ): string|array|object|null;
 }

--- a/inc/ExampleApi/Data/ExampleApiData.php
+++ b/inc/ExampleApi/Data/ExampleApiData.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace RemoteDataBlocks\ExampleApi\Data;
+
+use WP_Error;
+
+class ExampleApiData {
+	/**
+	 * Hold the API data in memory to avoid repeated calls to wp_json_file_decode.
+	 */
+	private static array|null|WP_Error $api_data = null;
+
+	/**
+	 * Load the example data from a static file. The data is a collection of
+	 * records from an Airtable table.
+	 *
+	 * @return array|WP_Error
+	 */
+	public static function get_items(): array|WP_Error {
+		if ( is_wp_error( self::$api_data ) ) {
+			return self::$api_data;
+		}
+
+		if ( is_null( self::$api_data ) ) {
+			self::$api_data = wp_json_file_decode( __DIR__ . '/items.json', [ 'associative' => true ] );
+		}
+
+		// If $api_data is *still* null, it could not be loaded. Store an error so
+		// that we don't attempt endlessly.
+		if ( is_null( self::$api_data ) || ! isset( self::$api_data['records'] ) ) {
+			self::$api_data = new WP_Error( 'remote-data-blocks-missing-example-api-data', 'Could not load example API data' );
+		}
+
+		return self::$api_data;
+	}
+
+	/**
+	 * Extract a single record from the example table data.
+	 *
+	 * @param string $record_id The ID of the record to extract.
+	 * @return array|WP_Error
+	 */
+	public static function get_item( string $item_id ): array|null|WP_Error {
+		$items = self::get_items();
+
+		if ( is_wp_error( $items ) ) {
+			return $items;
+		}
+
+		foreach ( $items['records'] as $item ) {
+			if ( $item['id'] === $item_id ) {
+				return $item;
+			}
+		}
+
+		return null;
+	}
+}

--- a/inc/ExampleApi/Data/items.json
+++ b/inc/ExampleApi/Data/items.json
@@ -1,0 +1,250 @@
+{
+  "records": [
+    {
+      "id": "rec1eYD2JFtevz39u",
+      "createdTime": "2016-10-30T21:36:48.000Z",
+      "fields": {
+        "Notes": "Make sure that post-its are available for everyone at the start of the session",
+        "End": "2021-11-19T12:00:00.000Z",
+        "Activity": "Break",
+        "Type": "Panel",
+        "Start": "2021-11-19T11:00:00.000Z",
+        "Location": "Pearl room",
+        "Test": 0
+      }
+    },
+    {
+      "id": "rec2uM1inwuvs9oPz",
+      "createdTime": "2016-10-30T21:36:48.000Z",
+      "fields": {
+        "Speaker(s)": [ "receO5YaIPmz8n8CP" ],
+        "End": "2021-11-19T14:00:00.000Z",
+        "Activity": "Community building workshop",
+        "Type": "Workshop",
+        "Start": "2021-11-19T13:20:00.000Z",
+        "Location": "Emerald room",
+        "Test": 0
+      }
+    },
+    {
+      "id": "rec6ZhfNMq1xlX2og",
+      "createdTime": "2016-10-30T21:17:58.000Z",
+      "fields": {
+        "Speaker(s)": [ "recdPZnGnEVpnXYaa" ],
+        "End": "2021-11-18T12:00:00.000Z",
+        "Activity": "Building an alert system that works for everyone",
+        "Type": "Panel",
+        "Start": "2021-11-18T11:00:00.000Z",
+        "Location": "Sapphire room",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recA2yRHgDOgktPpe",
+      "createdTime": "2016-10-30T21:41:29.000Z",
+      "fields": {
+        "Speaker(s)": [ "recF7J8ttCyPkQIMm" ],
+        "End": "2021-11-19T17:30:00.000Z",
+        "Activity": "Happy hour & networking",
+        "Type": "Networking",
+        "Start": "2021-11-19T16:30:00.000Z",
+        "Location": "President's dining hall",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recJWv3uyaKA25jgD",
+      "createdTime": "2016-10-30T21:36:46.000Z",
+      "fields": {
+        "End": "2021-11-18T16:00:00.000Z",
+        "Activity": "Closing remarks",
+        "Type": "Keynote",
+        "Start": "2021-11-18T15:30:00.000Z",
+        "Location": "Grand ballroom",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recK92XgSXg3Sf65c",
+      "createdTime": "2016-10-30T21:36:45.000Z",
+      "fields": {
+        "Speaker(s)": [ "rec2lsSiZ2xyStxO4", "recYm7H5gpMERlCB1" ],
+        "Notes": "This session will be led by Deepa",
+        "End": "2021-11-18T13:00:00.000Z",
+        "Activity": "Workshop for security novices",
+        "Type": "Workshop",
+        "Start": "2021-11-18T12:30:00.000Z",
+        "Location": "Emerald room",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recVWFedR7rws8n1O",
+      "createdTime": "2016-10-30T21:17:58.000Z",
+      "fields": {
+        "Speaker(s)": [ "recORaJ2XM78pUdGR" ],
+        "Notes": "Katina is subbing in for Russell, because he's coming in on a flight",
+        "End": "2021-11-18T11:00:00.000Z",
+        "Activity": "Opening remarks",
+        "Type": "Keynote",
+        "Start": "2021-11-18T10:30:00.000Z",
+        "Location": "Picnic area",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recWxXU9pqsq4GvqE",
+      "createdTime": "2016-10-30T21:36:46.000Z",
+      "fields": {
+        "End": "2021-11-18T15:20:00.000Z",
+        "Activity": "Breakout session",
+        "Type": "Breakout session",
+        "Start": "2021-11-18T14:30:00.000Z",
+        "Location": "Sapphire room",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recX9Ehj81QgVzeqX",
+      "createdTime": "2016-10-30T21:36:46.000Z",
+      "fields": {
+        "Speaker(s)": [ "recWLbvPvdaM54hQL", "rec2lsSiZ2xyStxO4" ],
+        "Notes": "Belinda's going to need a projector for her presentation",
+        "End": "2021-11-19T09:30:00.000Z",
+        "Activity": "Lunch",
+        "Type": "Meal",
+        "Start": "2021-11-19T09:00:00.000Z",
+        "Location": "President's dining hall",
+        "Test": 0
+      }
+    },
+    {
+      "id": "reccZPVmlRClMHMZm",
+      "createdTime": "2016-10-30T21:36:45.000Z",
+      "fields": {
+        "Speaker(s)": [ "recWLbvPvdaM54hQL", "rec9BK8S9HYi2Tah8", "recF7J8ttCyPkQIMm" ],
+        "End": "2021-11-18T13:30:00.000Z",
+        "Activity": "Which security solution is best for you?",
+        "Type": "Panel",
+        "Start": "2021-11-18T13:00:00.000Z",
+        "Location": "Emerald room",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recikyA9ojNSnIHjO",
+      "createdTime": "2016-10-30T21:41:29.000Z",
+      "fields": {
+        "Speaker(s)": [ "recORaJ2XM78pUdGR" ],
+        "Notes": "Expecting a lower turnout because it's the 2nd day",
+        "End": "2021-11-19T16:15:00.000Z",
+        "Activity": "Closing remarks",
+        "Type": "Keynote",
+        "Start": "2021-11-19T16:00:00.000Z",
+        "Location": "Grand ballroom",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recj4iTWLPfV5Vcsf",
+      "createdTime": "2016-10-30T21:17:58.000Z",
+      "fields": {
+        "End": "2021-11-18T10:30:00.000Z",
+        "Activity": "Welcome breakfast",
+        "Type": "Meal",
+        "Start": "2021-11-18T09:00:00.000Z",
+        "Location": "President's dining hall",
+        "Test": 1
+      }
+    },
+    {
+      "id": "recmKumKU4rnjgLkA",
+      "createdTime": "2016-10-30T21:36:46.000Z",
+      "fields": {
+        "Speaker(s)": [ "rec9BK8S9HYi2Tah8", "receO5YaIPmz8n8CP" ],
+        "End": "2021-11-19T10:30:00.000Z",
+        "Activity": "Morning keynote",
+        "Type": "Keynote",
+        "Start": "2021-11-19T09:30:00.000Z",
+        "Location": "Grand ballroom",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recp8wDYSljOiEXSy",
+      "createdTime": "2016-10-30T21:36:48.000Z",
+      "fields": {
+        "Notes": "Will be an open happy hour",
+        "End": "2021-11-19T15:00:00.000Z",
+        "Activity": "Breakout presentation",
+        "Type": "Breakout session",
+        "Start": "2021-11-19T14:30:00.000Z",
+        "Location": "Ruby room",
+        "Test": 0
+      }
+    },
+    {
+      "id": "rectd91GeUgTqAXYb",
+      "createdTime": "2016-10-30T21:36:46.000Z",
+      "fields": {
+        "Notes": "We'll have vegetarian and pescatarian friendly meals available!",
+        "End": "2021-11-18T17:00:00.000Z",
+        "Activity": "Happy hour & networking",
+        "Type": "Networking",
+        "Start": "2021-11-18T16:00:00.000Z",
+        "Location": "President's dining hall",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recv1YMICxsJDYfoH",
+      "createdTime": "2016-10-30T21:40:35.000Z",
+      "fields": {
+        "End": "2021-11-19T13:00:00.000Z",
+        "Activity": "Lunch",
+        "Type": "Meal",
+        "Start": "2021-11-19T12:00:00.000Z",
+        "Location": "President's dining hall",
+        "Test": 0
+      }
+    },
+    {
+      "id": "recycoRKLwhfJYHX3",
+      "createdTime": "2016-10-30T21:36:45.000Z",
+      "fields": {
+        "Speaker(s)": [ "receO5YaIPmz8n8CP" ],
+        "End": "2021-11-18T12:30:00.000Z",
+        "Activity": "Lunch",
+        "Type": "Meal",
+        "Start": "2021-11-18T12:00:00.000Z",
+        "Location": "President's dining hall",
+        "Test": 0
+      }
+    },
+    {
+      "id": "reczWtXtVrRSKjA5B",
+      "createdTime": "2016-10-30T21:36:49.000Z",
+      "fields": {
+        "Speaker(s)": [ "recORaJ2XM78pUdGR" ],
+        "End": "2021-11-19T14:30:00.000Z",
+        "Activity": "Case study: Home SecurTech",
+        "Type": "Panel",
+        "Start": "2021-11-19T14:00:00.000Z",
+        "Location": "\"Garnet room, Jade room\"",
+        "Test": 0
+      }
+    },
+    {
+      "id": "reczzez7XmnNmwTIg",
+      "createdTime": "2016-10-30T21:36:49.000Z",
+      "fields": {
+        "End": "2021-11-19T16:00:00.000Z",
+        "Activity": "Afternoon keynote",
+        "Type": "Keynote",
+        "Start": "2021-11-19T15:00:00.000Z",
+        "Location": "Grand ballroom",
+        "Test": 0
+      }
+    }
+  ]
+}

--- a/inc/ExampleApi/ExampleApi.php
+++ b/inc/ExampleApi/ExampleApi.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace RemoteDataBlocks\ExampleApi;
+
+use RemoteDataBlocks\ExampleApi\Queries\ExampleApiGetRecordQuery;
+use RemoteDataBlocks\ExampleApi\Queries\ExampleApiGetTableQuery;
+use function register_remote_data_block;
+use function register_remote_data_list_query;
+
+class ExampleApi {
+	private static string $block_name = 'Conference Event';
+
+	public static function init(): void {
+		add_action( 'init', [ __CLASS__, 'register_remote_data_block' ] );
+	}
+
+	private static function should_register(): bool {
+		/**
+		 * Determines whether the example remote data block should be registered.
+		 *
+		 * @param bool $should_register
+		 * @return bool
+		 */
+		return apply_filters( 'remote_data_blocks_register_example_block', true );
+	}
+
+	public static function register_remote_data_block(): void {
+		if ( true !== self::should_register() ) {
+			return;
+		}
+
+		$get_record_query = new ExampleApiGetRecordQuery();
+		$get_table_query  = new ExampleApiGetTableQuery();
+
+		register_remote_data_block( self::$block_name, $get_record_query );
+		register_remote_data_list_query( self::$block_name, $get_table_query );
+	}
+}

--- a/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace RemoteDataBlocks\ExampleApi\Queries;
+
+use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
+use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
+
+class ExampleApiGetRecordQuery extends HttpQueryContext {
+	public array $input_variables = [
+		'record_id' => [
+			'name'      => 'Record ID',
+			'overrides' => [
+				[
+					'target' => 'utm_content',
+					'type'   => 'query_var',
+				],
+			],
+			'type'      => 'id',
+		],
+	];
+
+	public array $output_variables = [
+		'is_collection' => false,
+		'mappings'      => [
+			'id'       => [
+				'name' => 'Record ID',
+				'path' => '$.id',
+				'type' => 'id',
+			],
+			'title'    => [
+				'name' => 'Title',
+				'path' => '$.fields.Activity',
+				'type' => 'string',
+			],
+			'location' => [
+				'name' => 'Location',
+				'path' => '$.fields.Location',
+				'type' => 'string',
+			],
+			'type'     => [
+				'name' => 'Type',
+				'path' => '$.fields.Type',
+				'type' => 'string',
+			],
+		],
+	];
+
+	public function __construct() {}
+
+	public function get_image_url(): null {
+		return null;
+	}
+
+	public function get_query_name(): string {
+		return 'Get event';
+	}
+
+	public function get_query_runner(): QueryRunnerInterface {
+		return new ExampleApiQueryRunner( $this );
+	}
+}

--- a/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace RemoteDataBlocks\ExampleApi\Queries;
+
+use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
+use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
+
+class ExampleApiGetTableQuery extends HttpQueryContext {
+	public array $input_variables = [];
+
+	public array $output_variables = [
+		'root_path'     => '$.records[*]',
+		'is_collection' => true,
+		'mappings'      => [
+			'record_id' => [
+				'name' => 'Record ID',
+				'path' => '$.id',
+				'type' => 'id',
+			],
+			'title'     => [
+				'name' => 'Title',
+				'path' => '$.fields.Activity',
+				'type' => 'string',
+			],
+			'location'  => [
+				'name' => 'Location',
+				'path' => '$.fields.Location',
+				'type' => 'string',
+			],
+			'type'      => [
+				'name' => 'Type',
+				'path' => '$.fields.Type',
+				'type' => 'string',
+			],
+		],
+	];
+
+	public function __construct() {}
+
+	public function get_image_url(): null {
+		return null;
+	}
+
+	public function get_query_name(): string {
+		return 'List events';
+	}
+
+	public function get_query_runner(): QueryRunnerInterface {
+		return new ExampleApiQueryRunner( $this );
+	}
+}

--- a/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
+++ b/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ExampleApiQueryRunner class
+ *
+ * @package remote-data-blocks
+ */
+
+namespace RemoteDataBlocks\ExampleApi\Queries;
+
+use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
+use RemoteDataBlocks\ExampleApi\Data\ExampleApiData;
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * Execute the query by making an internal REST API request. This allows the
+ * example API to work when running locally (inside a container). Otherwise,
+ * there would be a mismatch between the public address (e.g., localhost:888) and
+ * what is reachable inside a container.
+ *
+ * A nice side effect is that we avoid using Guzzle/cURL for this example, which
+ * makes it runnable in environments like WP Now.
+ */
+class ExampleApiQueryRunner extends QueryRunner {
+	protected function get_raw_response_data( array $input_variables ): array|WP_Error {
+		if ( isset( $input_variables['record_id'] ) ) {
+			return [
+				'metadata'      => [],
+				'response_data' => ExampleApiData::get_item( $input_variables['record_id'] ),
+			];
+		}
+
+		return [
+			'metadata'      => [],
+			'response_data' => ExampleApiData::get_items(),
+		];
+	}
+}

--- a/remote-data-blocks.php
+++ b/remote-data-blocks.php
@@ -43,6 +43,9 @@ Editor\BlockManagement\BlockRegistration::init();
 Editor\BlockManagement\ConfigRegistry::init();
 Editor\PatternEditor\PatternEditor::init();
 
+// Example API
+ExampleApi\ExampleApi::init();
+
 // Load Settings Page
 PluginSettings\PluginSettings::init();
 

--- a/tests/inc/Config/QueryContextTest.php
+++ b/tests/inc/Config/QueryContextTest.php
@@ -3,7 +3,6 @@
 namespace RemoteDataBlocks\Tests\Config;
 
 use PHPUnit\Framework\TestCase;
-use GuzzleHttp\Psr7\Response;
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
 use RemoteDataBlocks\Tests\Mocks\MockDatasource;
 
@@ -28,10 +27,10 @@ class QueryContextTest extends TestCase {
 	}
 
 	public function testGetMetadata() {
-		$mock_response = new Response( 200, [ 'Age' => '60' ] );
-		$results       = [ [ 'id' => 1 ], [ 'id' => 2 ] ];
+		$mock_response_metadata = [ 'age' => '60' ];
+		$mock_results           = [ [ 'id' => 1 ], [ 'id' => 2 ] ];
 
-		$metadata = $this->query_context->get_metadata( $mock_response, $results );
+		$metadata = $this->query_context->get_metadata( $mock_response_metadata, $mock_results );
 
 		$this->assertArrayHasKey( 'last_updated', $metadata );
 		$this->assertArrayHasKey( 'total_count', $metadata );

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -4,7 +4,6 @@ namespace RemoteDataBlocks\Tests\Config;
 
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface;
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
@@ -65,7 +64,7 @@ class QueryRunnerTest extends TestCase {
 				return null;
 			}
 
-			public function get_metadata( ResponseInterface $response, array $query_results ): array {
+			public function get_metadata( array $response_metadata, array $query_results ): array {
 				return [];
 			}
 


### PR DESCRIPTION
This implements the task of creating a "static" toy API that is bundled with the plugin. This allows new users and explorers to immediately begin using the plugin meaningfully without any configuration or provisioning credentials.

This API mirrors the "Event Planning" template from Airtable, but it is easily swappable with another API.

This API is not implemented an HTTP API, mainly because it complicates local development: routing a request from inside a container to a knowable URL is non-trivial and requires configuration (which we want to avoid). Instead the queries implement a custom `QueryRunner` in order to serve data from a static JSON file.

Along the way, we have made some improvements to the `QueryRunner` that will benefit other implementors of a non-HTTP API:

- We separate the `execute` method (which handles field mapping) from the actual HTTP request, which more flexibly allows for custom transports.
- We prevent `ResponseInterface` from leaking into `QueryContextInterface`. Fixing this mistake allows queries to be truly agnostic towards their transport.