### PR TITLE
Add placeholder data source since our settings page requires it

### DIFF
--- a/inc/ExampleApi/ExampleApi.php
+++ b/inc/ExampleApi/ExampleApi.php
@@ -2,6 +2,7 @@
 
 namespace RemoteDataBlocks\ExampleApi;
 
+use RemoteDataBlocks\ExampleApi\Queries\ExampleApiDataSource;
 use RemoteDataBlocks\ExampleApi\Queries\ExampleApiGetRecordQuery;
 use RemoteDataBlocks\ExampleApi\Queries\ExampleApiGetTableQuery;
 use function register_remote_data_block;
@@ -29,8 +30,9 @@ class ExampleApi {
 			return;
 		}
 
-		$get_record_query = new ExampleApiGetRecordQuery();
-		$get_table_query  = new ExampleApiGetTableQuery();
+		$datasource       = new ExampleApiDataSource();
+		$get_record_query = new ExampleApiGetRecordQuery( $datasource );
+		$get_table_query  = new ExampleApiGetTableQuery( $datasource );
 
 		register_remote_data_block( self::$block_name, $get_record_query );
 		register_remote_data_list_query( self::$block_name, $get_table_query );

--- a/inc/ExampleApi/Queries/ExampleApiDataSource.php
+++ b/inc/ExampleApi/Queries/ExampleApiDataSource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace RemoteDataBlocks\ExampleApi\Queries;
+
+use RemoteDataBlocks\Config\Datasource\HttpDatasource;
+
+/**
+ * This is a placeholder datasource used only to represent the data source in the
+ * settings UI. The actual data loading is implemented by ExampleApiQueryRunner.
+ */
+class ExampleApiDataSource extends HttpDatasource {
+	/**
+	 * @inheritDoc
+	 */
+	public function get_display_name(): string {
+		return 'Example API';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_endpoint(): string {
+		return 'https://example.com/api/v1';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_request_headers(): array {
+		return [];
+	}
+}

--- a/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
@@ -45,12 +45,6 @@ class ExampleApiGetRecordQuery extends HttpQueryContext {
 		],
 	];
 
-	public function __construct() {}
-
-	public function get_image_url(): null {
-		return null;
-	}
-
 	public function get_query_name(): string {
 		return 'Get event';
 	}

--- a/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
@@ -35,12 +35,6 @@ class ExampleApiGetTableQuery extends HttpQueryContext {
 		],
 	];
 
-	public function __construct() {}
-
-	public function get_image_url(): null {
-		return null;
-	}
-
 	public function get_query_name(): string {
 		return 'List events';
 	}


### PR DESCRIPTION
Fix for https://github.com/Automattic/remote-data-blocks/pull/75 to provide a placeholder data source for the example API since our settings page / interfaces require it.