### PR TITLE
Extend ExampleApiDataSource from CodedHttpDatasource

### DIFF
--- a/inc/ExampleApi/Queries/ExampleApiDataSource.php
+++ b/inc/ExampleApi/Queries/ExampleApiDataSource.php
@@ -2,13 +2,13 @@
 
 namespace RemoteDataBlocks\ExampleApi\Queries;
 
-use RemoteDataBlocks\Config\Datasource\DatasourceInterface;
+use RemoteDataBlocks\Config\Datasource\CodedHttpDatasource;
 
 /**
  * This is a placeholder datasource used only to represent the data source in the
  * settings UI. The actual data loading is implemented by ExampleApiQueryRunner.
  */
-class ExampleApiDataSource implements DatasourceInterface {
+class ExampleApiDataSource extends CodedHttpDatasource {
 	/**
 	 * @inheritDoc
 	 */
@@ -21,5 +21,22 @@ class ExampleApiDataSource implements DatasourceInterface {
 	 */
 	public function get_image_url(): null {
 		return null;
+	}
+
+	public function get_object_representations(): array {
+		return [
+			'example-api' => (object) [
+				'slug'    => 'example-api',
+				'service' => 'example-api',
+			],
+		];
+	}
+
+	public function get_endpoint(): string {
+		return '';
+	}
+
+	public function get_request_headers(): array {
+		return [];
 	}
 }

--- a/src/data-sources/constants.ts
+++ b/src/data-sources/constants.ts
@@ -1,4 +1,9 @@
-export const SUPPORTED_SERVICES = [ 'airtable', 'shopify', 'google-sheets' ] as const;
+export const SUPPORTED_SERVICES = [
+	'airtable',
+	'shopify',
+	'google-sheets',
+	'example-api',
+] as const;
 export const OPTIONS_PAGE_SLUG = 'remote-data-blocks-settings';
 export const REST_BASE = '/remote-data-blocks/v1';
 export const REST_BASE_DATA_SOURCES = `${ REST_BASE }/data-sources`;


### PR DESCRIPTION
This fixes the plugin settings page crashing with error -

```
Fatal error: Uncaught Error: RemoteDataBlocks\Config\QueryContext\HttpQueryContext::__construct(): Argument #1 ($datasource) must be of type RemoteDataBlocks\Config\Datasource\HttpDatasource, RemoteDataBlocks\ExampleApi\Queries\ExampleApiDataSource given, called in /var/www/html/wp-content/plugins/remote-data-blocks/inc/ExampleApi/ExampleApi.php on line 34
in /var/www/html/wp-content/plugins/remote-data-blocks/inc/Config/QueryContext/HttpQueryContext.php on line 64
```

Extending the `ExampleApiDataSource` from `CodedHttpDatasource` fixes the type issue thrown when the `ExampleApiDataSource` instance is passed to query classes, for Example API block. This also has the upside of showing the Example Data Source in the setting page.