### PR TITLE
Add validation, sanitization classes

### DIFF
--- a/inc/Sanitization/Sanitizer.php
+++ b/inc/Sanitization/Sanitizer.php
@@ -19,7 +19,7 @@ class Sanitizer implements SanitizerInterface {
 	 * @inheritDoc
 	 */
 	public function sanitize( array $data ): array {
-		if ( ! isset( $this->schema['type'] ) || $this->schema['type'] !== 'object' || ! isset( $this->schema['properties'] ) ) {
+		if ( ! isset( $this->schema['type'] ) || 'object' !== $this->schema['type'] || ! isset( $this->schema['properties'] ) ) {
 			return [];
 		}
 

--- a/inc/Sanitization/Sanitizer.php
+++ b/inc/Sanitization/Sanitizer.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace RemoteDataBlocks\Sanitization;
+
+/**
+ * Sanitizer class.
+ */
+class Sanitizer implements SanitizerInterface {
+	private array $schema;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function __construct( array $schema ) {
+		$this->schema = $schema;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function sanitize( array $data ): array {
+		if ( ! isset( $this->schema['type'] ) || $this->schema['type'] !== 'object' || ! isset( $this->schema['properties'] ) ) {
+			return [];
+		}
+
+		return $this->sanitize_config( $data, $this->schema['properties'] );
+	}
+
+	/**
+	 * Sanitize the config, recursively if necessary, according to the schema.
+	 *
+	 * @param array $config The config to sanitize.
+	 * @param array $schema The schema to use for sanitization.
+	 * @return array The sanitized config.
+	 */
+	private function sanitize_config( array $config, array $schema ): array {
+		$sanitized = [];
+
+		foreach ( $schema as $key => $field_schema ) {
+			if ( ! isset( $config[ $key ] ) ) {
+				continue;
+			}
+
+			$value = $config[ $key ];
+
+			if ( isset( $field_schema['sanitize'] ) ) {
+				$sanitized[ $key ] = call_user_func( $field_schema['sanitize'], $value );
+				continue;
+			}
+
+			switch ( $field_schema['type'] ) {
+				case 'string':
+					$sanitized[ $key ] = sanitize_text_field( $value );
+					break;
+				case 'integer':
+					$sanitized[ $key ] = intval( $value );
+					break;
+				case 'boolean':
+					$sanitized[ $key ] = (bool) $value;
+					break;
+				case 'array':
+					if ( is_array( $value ) ) {
+						if ( isset( $field_schema['items'] ) ) {
+							$sanitized[ $key ] = array_map(function ( $item ) use ( $field_schema ) {
+								return $this->sanitize_config( $item, $field_schema['items'] );
+							}, $value);
+						} else {
+							$sanitized[ $key ] = array_map( 'sanitize_text_field', $value );
+						}
+					}
+					break;
+				case 'object':
+					if ( is_array( $value ) && isset( $field_schema['properties'] ) ) {
+						$sanitized[ $key ] = $this->sanitize_config( $value, $field_schema['properties'] );
+					}
+					break;
+			}
+		}
+
+		return $sanitized;
+	}
+}

--- a/inc/Sanitization/SanitizerInterface.php
+++ b/inc/Sanitization/SanitizerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace RemoteDataBlocks\Sanitization;
+
+/**
+ * Interface for providing data sanitization.
+ *
+ * @see Sanitizer for an implementation
+ */
+interface SanitizerInterface {
+	/**
+	 * Constructor.
+	 * 
+	 * @param array $schema
+	 */
+	public function __construct( array $schema );
+
+	/**
+	 * Sanitize data according to a schema.
+	 *
+	 * @param array $data
+	 *
+	 * @return array The sanitized data.
+	 */
+	public function sanitize( array $data ): array;
+}

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -79,8 +79,6 @@ class Validator implements ValidatorInterface {
 				return is_object( $value ) || ( is_array( $value ) && ! array_is_list( $value ) );
 			case 'string':
 				return is_string( $value );
-			case 'number':
-				return is_numeric( $value );
 			case 'integer':
 				return is_int( $value );
 			case 'boolean':

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -26,20 +26,24 @@ class Validator implements ValidatorInterface {
 
 	private function validate_schema( array $schema, $data ): bool|WP_Error {
 		if ( isset( $schema['type'] ) && ! $this->check_type( $data, $schema['type'] ) ) {
-			return new WP_Error( 'invalid_type', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['type'], gettype( $data ) ) );
+			// translators: %1$s is the expected PHP data type, %2$s is the actual PHP data type.
+			return new WP_Error( 'invalid_type', sprintf( __('Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['type'], gettype( $data ) ) );
 		}
 
 		if ( isset( $schema['pattern'] ) && is_string( $data ) && ! preg_match( $schema['pattern'], $data ) ) {
+			// translators: %1$s is the expected regex pattern, %2$s is the actual value.
 			return new WP_Error( 'invalid_format', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['pattern'], $data ) );
 		}
 
 		if ( isset( $schema['enum'] ) && ! in_array( $data, $schema['enum'] ) ) {
+			// translators: %1$s is the expected value, %2$s is the actual value.
 			return new WP_Error( 'invalid_value', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), implode( ', ', $schema['enum'] ), $data ) );
 		}
 
 		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
 			foreach ( $schema['properties'] as $field => $field_schema ) {
 				if ( ! isset( $data[ $field ] ) ) {
+					// translators: %1$s is the missing field name.
 					return new WP_Error( 'missing_field', sprintf( __( 'Missing field %1$s.', 'remote-data-blocks' ), $field ) );
 				}
 				
@@ -52,7 +56,8 @@ class Validator implements ValidatorInterface {
 
 		if ( isset( $schema['items'] ) ) {
 			if ( ! is_array( $data ) ) {
-				return new WP_Error( 'invalid_array', __( 'Expected array', 'remote-data-blocks' ) );
+				// translators: %1$s is the expected PHP data type, %2$s is the actual PHP data type.
+				return new WP_Error( 'invalid_array', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), 'array', gettype( $data ) ) );
 			}
 
 			foreach ( $data as $item ) {

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace RemoteDataBlocks\Validation;
+
+use WP_Error;
+
+/**
+ * Validator class.
+ */
+class Validator implements ValidatorInterface {
+	private array $schema;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function __construct( array $schema ) {
+		$this->schema = $schema;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function validate( array $data ): bool|WP_Error {
+		return $this->validate_schema( $this->schema, $data );
+	}
+
+	private function validate_schema( array $schema, $data ): bool|WP_Error {
+		if ( isset( $schema['type'] ) && ! $this->check_type( $data, $schema['type'] ) ) {
+			return new WP_Error( 'invalid_type', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['type'], gettype( $data ) ) );
+		}
+
+		if ( isset( $schema['pattern'] ) && is_string( $data ) && ! preg_match( $schema['pattern'], $data ) ) {
+			return new WP_Error( 'invalid_format', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['pattern'], $data ) );
+		}
+
+		if ( isset( $schema['enum'] ) && ! in_array( $data, $schema['enum'] ) ) {
+			return new WP_Error( 'invalid_value', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), implode( ', ', $schema['enum'] ), $data ) );
+		}
+
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+			foreach ( $schema['properties'] as $field => $field_schema ) {
+				if ( ! isset( $data[ $field ] ) ) {
+					return new WP_Error( 'missing_field', sprintf( __( 'Missing field %1$s.', 'remote-data-blocks' ), $field ) );
+				}
+				
+				$result = $this->validate_schema( $field_schema, $data[ $field ] );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+			}
+		}
+
+		if ( isset( $schema['items'] ) ) {
+			if ( ! is_array( $data ) ) {
+				return new WP_Error( 'invalid_array', __( 'Expected array', 'remote-data-blocks' ) );
+			}
+
+			foreach ( $data as $item ) {
+				$result = $this->validate_schema( $schema['items'], $item );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	private function check_type( $value, string $expected_type ): bool {
+		switch ( $expected_type ) {
+			case 'array':
+				return is_array( $value );
+			case 'object':
+				return is_object( $value ) || ( is_array( $value ) && ! array_is_list( $value ) );
+			case 'string':
+				return is_string( $value );
+			case 'number':
+				return is_numeric( $value );
+			case 'integer':
+				return is_int( $value );
+			case 'boolean':
+				return is_bool( $value );
+			case 'null':
+				return is_null( $value );
+			default:
+				return false;
+		}
+	}
+}

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -27,7 +27,7 @@ class Validator implements ValidatorInterface {
 	private function validate_schema( array $schema, $data ): bool|WP_Error {
 		if ( isset( $schema['type'] ) && ! $this->check_type( $data, $schema['type'] ) ) {
 			// translators: %1$s is the expected PHP data type, %2$s is the actual PHP data type.
-			return new WP_Error( 'invalid_type', sprintf( __('Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['type'], gettype( $data ) ) );
+			return new WP_Error( 'invalid_type', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['type'], gettype( $data ) ) );
 		}
 
 		if ( isset( $schema['pattern'] ) && is_string( $data ) && ! preg_match( $schema['pattern'], $data ) ) {

--- a/inc/Validation/ValidatorInterface.php
+++ b/inc/Validation/ValidatorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace RemoteDataBlocks\Validation;
+
+use WP_Error;
+
+/**
+ * Interface for providing data validation.
+ *
+ * @see Validator for an implementation
+ */
+interface ValidatorInterface {
+	/**
+	 * Constructor.
+	 * 
+	 * @param array $schema
+	 */
+	public function __construct( array $schema );
+
+	/**
+	 * Validate data against a schema.
+	 *
+	 * @param array $data
+	 *
+	 * @return true|\WP_Error WP_Error for invalid data, true otherwise
+	 */
+	public function validate( array $data ): bool|WP_Error;
+}

--- a/tests/inc/Sanitization/SanitizerTest.php
+++ b/tests/inc/Sanitization/SanitizerTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace RemoteDataBlocks\Tests\Sanitization;
+
+use PHPUnit\Framework\TestCase;
+use RemoteDataBlocks\Sanitization\Sanitizer;
+
+class SanitizerTest extends TestCase {
+	public function test_sanitize_string() {
+		$schema = [
+			'type'       => 'object',
+			'properties' => [
+				'name' => [ 'type' => 'string' ],
+			],
+		];
+		$data   = [ 'name' => ' John Doe ' ];
+		
+		$sanitizer = new Sanitizer( $schema );
+		$result    = $sanitizer->sanitize( $data );
+		
+		$this->assertSame( 'John Doe', $result['name'] );
+	}
+
+	public function test_sanitize_integer() {
+		$schema = [
+			'type'       => 'object',
+			'properties' => [
+				'age' => [ 'type' => 'integer' ],
+			],
+		];
+		$data   = [ 'age' => '25' ];
+		
+		$sanitizer = new Sanitizer( $schema );
+		$result    = $sanitizer->sanitize( $data );
+		
+		$this->assertSame( 25, $result['age'] );
+	}
+
+	public function test_sanitize_boolean() {
+		$schema = [
+			'type'       => 'object',
+			'properties' => [
+				'is_active' => [ 'type' => 'boolean' ],
+			],
+		];
+		$data   = [ 'is_active' => 1 ];
+		
+		$sanitizer = new Sanitizer( $schema );
+		$result    = $sanitizer->sanitize( $data );
+		
+		$this->assertSame( true, $result['is_active'] );
+	}
+
+	public function test_sanitize_array() {
+		$schema = [
+			'type'       => 'object',
+			'properties' => [
+				'tags' => [ 'type' => 'array' ],
+			],
+		];
+		$data   = [ 'tags' => [ 'php', ' javascript ', 'python ' ] ];
+		
+		$sanitizer = new Sanitizer( $schema );
+		$result    = $sanitizer->sanitize( $data );
+		
+		$this->assertSame( [ 'php', 'javascript', 'python' ], $result['tags'] );
+	}
+
+	public function test_sanitize_nested_array() {
+		$schema = [ 
+			'type'       => 'object',
+			'properties' => [
+				'users' => [
+					'type'  => 'array',
+					'items' => [
+						'name' => [ 'type' => 'string' ],
+						'age'  => [ 'type' => 'integer' ],
+					],
+				],
+			],
+		];
+		$data   = [
+			'users' => [
+				[
+					'name' => ' Alice ',
+					'age'  => '30',
+				],
+				[
+					'name' => ' Bob ',
+					'age'  => '25',
+				],
+			],
+		];
+		
+		$sanitizer = new Sanitizer( $schema );
+		$result    = $sanitizer->sanitize( $data );
+		
+		$expected = [
+			'users' => [
+				[
+					'name' => 'Alice',
+					'age'  => 30,
+				],
+				[
+					'name' => 'Bob',
+					'age'  => 25,
+				],
+			],
+		];
+		$this->assertSame( $expected, $result );
+	}
+
+	public function test_sanitize_object() {
+		$schema = [
+			'type'       => 'object',
+			'properties' => [
+				'user' => [
+					'type'       => 'object',
+					'properties' => [
+						'name' => [ 'type' => 'string' ],
+						'age'  => [ 'type' => 'integer' ],
+					],
+				],
+			],
+		];
+		$data   = [
+			'user' => [
+				'name' => ' John Doe ',
+				'age'  => '30',
+			],
+		];
+		
+		$sanitizer = new Sanitizer( $schema );
+		$result    = $sanitizer->sanitize( $data );
+		
+		$expected = [
+			'user' => [
+				'name' => 'John Doe',
+				'age'  => 30,
+			],
+		];
+		$this->assertSame( $expected, $result );
+	}
+
+	public function test_sanitize_with_custom_sanitizer() {
+		$schema = [
+			'type'       => 'object',
+			'properties' => [
+				'email' => [
+					'type'     => 'string',
+					'sanitize' => function ( $value ) {
+						return strtolower( trim( $value ) );
+					},
+				],
+			],
+		];
+		$data   = [ 'email' => ' User@Example.com ' ];
+		
+		$sanitizer = new Sanitizer( $schema );
+		$result    = $sanitizer->sanitize( $data );
+		
+		$this->assertSame( 'user@example.com', $result['email'] );
+	}
+
+	public function test_sanitize_ignores_undefined_fields() {
+		$schema = [
+			'type'       => 'object',
+			'properties' => [
+				'name' => [ 'type' => 'string' ],
+			],
+		];
+		$data   = [
+			'name' => 'John Doe',
+			'age'  => 30,
+		];
+		
+		$sanitizer = new Sanitizer( $schema );
+		$result    = $sanitizer->sanitize( $data );
+		
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayNotHasKey( 'age', $result );
+	}
+
+	public function test_sanitize_complex_nested_structure() {
+		$schema = [
+			'type'       => 'object',
+			'properties' => [
+				'company' => [
+					'type'       => 'object',
+					'properties' => [
+						'name'      => [ 'type' => 'string' ],
+						'employees' => [
+							'type'  => 'array',
+							'items' => [
+								'name'     => [ 'type' => 'string' ],
+								'position' => [ 'type' => 'string' ],
+								'skills'   => [ 'type' => 'array' ],
+							],
+						],
+					],
+				],
+			],
+		];
+		$data   = [
+			'company' => [
+				'name'      => ' Acme Corp ',
+				'employees' => [
+					[
+						'name'     => ' Alice Smith ',
+						'position' => ' Developer ',
+						'skills'   => [ ' PHP ', 'JavaScript', ' Python ' ],
+					],
+					[
+						'name'     => ' Bob Johnson ',
+						'position' => ' Designer ',
+						'skills'   => [ ' UI/UX ', 'Photoshop', ' Illustrator ' ],
+					],
+				],
+			],
+		];
+		
+		$sanitizer = new Sanitizer( $schema );
+		$result    = $sanitizer->sanitize( $data );
+		
+		$expected = [
+			'company' => [
+				'name'      => 'Acme Corp',
+				'employees' => [
+					[
+						'name'     => 'Alice Smith',
+						'position' => 'Developer',
+						'skills'   => [ 'PHP', 'JavaScript', 'Python' ],
+					],
+					[
+						'name'     => 'Bob Johnson',
+						'position' => 'Designer',
+						'skills'   => [ 'UI/UX', 'Photoshop', 'Illustrator' ],
+					],
+				],
+			],
+		];
+		$this->assertSame( $expected, $result );
+	}
+}

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace RemoteDataBlocks\Tests\Validation;
+
+use PHPUnit\Framework\TestCase;
+use RemoteDataBlocks\Integrations\Airtable\AirtableDatasource;
+use RemoteDataBlocks\Integrations\Google\Sheets\GoogleSheetsDatasource;
+use RemoteDataBlocks\Integrations\Shopify\ShopifyDatasource;
+use RemoteDataBlocks\Validation\Validator;
+use WP_Error;
+
+class ValidatorTest extends TestCase {
+	const AIRTABLE_SCHEMA = [
+		'type'       => 'object',
+		'properties' => [
+			'access_token' => [ 'type' => 'string' ],
+			'base'         => [
+				'type'       => 'object',
+				'properties' => [
+					'id'   => [ 'type' => 'string' ],
+					'name' => [ 'type' => 'string' ],
+				],
+			],
+			'tables'       => [
+				'type'       => 'object',
+				'properties' => [
+					'id'   => [ 'type' => 'string' ],
+					'name' => [ 'type' => 'string' ],
+				],
+			],
+		],
+	];
+
+	const SHOPIFY_SCHEMA = [
+		'type'       => 'object',
+		'properties' => [
+			'access_token' => [ 'type' => 'string' ],
+			'store_name'   => [ 'type' => 'string' ],
+		],
+	];
+
+	const GOOGLE_SHEETS_SCHEMA = [
+		'type'       => 'object',
+		'properties' => [       
+			'credentials' => [
+				'type'       => 'object',
+				'properties' => [
+					'type'                        => [ 'type' => 'string' ],
+					'project_id'                  => [ 'type' => 'string' ],
+					'private_key_id'              => [ 'type' => 'string' ],
+					'private_key'                 => [ 'type' => 'string' ],
+					'client_email'                => [
+						'type'     => 'string',
+						'callback' => 'is_email',
+						'sanitize' => 'sanitize_email',
+					],
+					'client_id'                   => [ 'type' => 'string' ],
+					'auth_uri'                    => [
+						'type'     => 'string',
+						'sanitize' => 'sanitize_url',
+					],
+					'token_uri'                   => [
+						'type'     => 'string',
+						'sanitize' => 'sanitize_url',
+					],
+					'auth_provider_x509_cert_url' => [
+						'type'     => 'string',
+						'sanitize' => 'sanitize_url',
+					],
+					'client_x509_cert_url'        => [
+						'type'     => 'string',
+						'sanitize' => 'sanitize_url',
+					],
+					'universe_domain'             => [ 'type' => 'string' ],
+				],
+			],
+			'spreadsheet' => [
+				'type'       => 'object',
+				'properties' => [
+					'id'   => [ 'type' => 'string' ],
+					'name' => [ 'type' => 'string' ],
+				],
+			],
+			'sheet'       => [
+				'type'       => 'object',
+				'properties' => [
+					'id'   => [ 'type' => 'integer' ],
+					'name' => [ 'type' => 'string' ],
+				],
+			],
+		],
+	];
+
+	public function test_validate_airtable_source_with_valid_input() {
+		$valid_source = [
+			'uuid'         => '123e4567-e89b-12d3-a456-426614174000',
+			'access_token' => 'valid_token',
+			'service'      => 'airtable',
+			'base'         => [
+				'id'   => 'base_id',
+				'name' => 'Base Name',
+			],
+			'tables'       => [
+				'id'   => 'table_id',
+				'name' => 'Table Name',
+			],
+			'slug'         => 'valid-slug',
+		];
+
+		$validator = new Validator( self::AIRTABLE_SCHEMA );
+		$this->assertTrue( $validator->validate( $valid_source ) );
+	}
+
+	public function test_validate_airtable_source_with_invalid_input() {
+		$invalid_source = [
+			'uuid'    => '123e4567-e89b-12d3-a456-426614174000',
+			'service' => 'airtable',
+			'slug'    => 'valid-slug',
+		];
+
+		$validator = new Validator( self::AIRTABLE_SCHEMA );
+		$this->assertInstanceOf( WP_Error::class, $validator->validate( $invalid_source ) );
+	}
+
+	public function test_validate_shopify_source_with_valid_input() {
+		$valid_source = [
+			'uuid'         => '123e4567-e89b-12d3-a456-426614174000',
+			'access_token' => 'valid_token',
+			'service'      => 'shopify',
+			'store_name'   => 'mystore.myshopify.com',
+			'slug'         => 'valid-slug',
+		];
+	
+		$validator = new Validator( self::SHOPIFY_SCHEMA );
+		$this->assertTrue( $validator->validate( $valid_source ) );
+	}
+
+	public function test_validate_shopify_source_with_invalid_input() {
+		$invalid_source = [
+			'uuid'    => '123e4567-e89b-12d3-a456-426614174000',
+			'service' => 'shopify',
+			'slug'    => 'valid-slug',
+		];
+
+		$validator = new Validator( self::SHOPIFY_SCHEMA );
+		$this->assertInstanceOf( WP_Error::class, $validator->validate( $invalid_source ) );
+	}
+	
+	public function test_validate_google_sheets_source_with_valid_input() {
+		$valid_credentials = [
+			'type'                        => 'service_account',
+			'project_id'                  => 'test-project',
+			'private_key_id'              => '1234567890abcdef',
+			'private_key'                 => '-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC7/jHh2Wo0zkA5\n-----END PRIVATE KEY-----\n',
+			'client_email'                => 'test@test-project.iam.gserviceaccount.com',
+			'client_id'                   => '123456789012345678901',
+			'auth_uri'                    => 'https://accounts.google.com/o/oauth2/auth',
+			'token_uri'                   => 'https://oauth2.googleapis.com/token',
+			'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
+			'client_x509_cert_url'        => 'https://www.googleapis.com/robot/v1/metadata/x509/test%40test-project.iam.gserviceaccount.com',
+			'universe_domain'             => 'googleapis.com',
+		];
+
+		$valid_source = [
+			'uuid'        => '123e4567-e89b-12d3-a456-426614174000',
+			'service'     => 'google-sheets',
+			'credentials' => $valid_credentials,
+			'spreadsheet' => [
+				'id'   => 'spreadsheet_id',
+				'name' => 'Spreadsheet Name',
+			],
+			'sheet'       => [
+				'id'   => 0,
+				'name' => 'Sheet Name',
+			],
+			'slug'        => 'valid-slug',
+		];
+
+		$validator = new Validator( self::GOOGLE_SHEETS_SCHEMA );
+		$this->assertTrue( $validator->validate( $valid_source ) );
+	}
+
+	public function test_validate_google_sheets_source_with_invalid_input() {
+		$invalid_source = [
+			'uuid'        => '123e4567-e89b-12d3-a456-426614174000',
+			'service'     => 'google-sheets',
+			'credentials' => [
+				'type' => 'service_account',
+			],
+			'slug'        => 'valid-slug',
+		];
+
+		$validator = new Validator( self::GOOGLE_SHEETS_SCHEMA );
+		$result    = $validator->validate( $invalid_source );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_field', $result->get_error_code() );
+	}
+}

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -196,4 +196,113 @@ class ValidatorTest extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'missing_field', $result->get_error_code() );
 	}
+
+
+	public function test_validate_nested_array_with_valid_input() {
+		$valid_nested_source = [
+			'uuid'     => '123e4567-e89b-12d3-a456-426614174000',
+			'service'  => 'valid-nested-service',
+			'whatever' => [
+				'level1'        => [
+					'level2'       => [
+						'key1' => 'value1',
+						'key2' => 42,
+					],
+					'simple_array' => [ 'item1', 'item2', 'item3' ],
+				],
+				'boolean_field' => true,
+			],
+			'slug'     => 'valid-nested-slug',
+		];
+
+		$schema = [
+			'type'       => 'object',
+			'properties' => [   
+				'uuid'     => [ 'type' => 'string' ],
+				'service'  => [ 'type' => 'string' ],
+				'whatever' => [
+					'type'       => 'object',
+					'properties' => [
+						'level1'        => [
+							'type'       => 'object',
+							'properties' => [
+								'level2'       => [
+									'type'       => 'object',
+									'properties' => [
+										'key1' => [ 'type' => 'string' ],
+										'key2' => [ 'type' => 'integer' ],
+									],
+								],
+								'simple_array' => [
+									'type'  => 'array',
+									'items' => [ 'type' => 'string' ],
+								],
+							],
+						],
+						'boolean_field' => [ 'type' => 'boolean' ],
+					],
+				],
+				'slug'     => [ 'type' => 'string' ],
+			],
+		];
+
+		$validator = new Validator( $schema );
+		$this->assertTrue( $validator->validate( $valid_nested_source ) );
+	}
+
+	public function test_validate_nested_array_with_invalid_input() {
+		$invalid_nested_source = [
+			'uuid'     => '123e4567-e89b-12d3-a456-426614174000',
+			'service'  => 'invalid-nested-service',
+			'whatever' => [
+				'level1'        => [
+					'level2'      => [
+						'key1' => 'value1',
+						'key2' => 'not_an_integer', // This should be an integer
+					],
+					'array_field' => 'not_an_array', // This should be an array
+				],
+				'boolean_field' => 'not_a_boolean', // This should be a boolean
+			],
+			'slug'     => 'valid-nested-slug',
+		];
+
+		$schema = [
+			'type'       => 'object',
+			'properties' => [
+				'uuid'     => [ 'type' => 'string' ],
+				'service'  => [ 'type' => 'string' ],
+				'whatever' => [
+					'type'       => 'object',
+					'properties' => [
+						'level1'        => [
+							'type'       => 'object',
+							'properties' => [
+								'level2'       => [
+									'type'       => 'object',
+									'properties' => [
+										'key1' => [ 'type' => 'string' ],
+										'key2' => [ 'type' => 'integer' ],
+									],
+								],
+								'simple_array' => [
+									'type'  => 'array',
+									'items' => [ 'type' => 'string' ],
+								],
+							],
+						],
+						'boolean_field' => [ 'type' => 'boolean' ],
+					],
+				],
+				'slug'     => [ 'type' => 'string' ],
+			],
+		];
+
+		$validator = new Validator( $schema );
+		$result    = $validator->validate( $invalid_nested_source );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_type', $result->get_error_code() );
+		$this->assertSame( 'Expected integer, got string.', $result->get_error_message() );
+	}
 }

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -197,7 +197,6 @@ class ValidatorTest extends TestCase {
 		$this->assertSame( 'missing_field', $result->get_error_code() );
 	}
 
-
 	public function test_validate_nested_array_with_valid_input() {
 		$valid_nested_source = [
 			'uuid'     => '123e4567-e89b-12d3-a456-426614174000',

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -210,6 +210,7 @@ class ValidatorTest extends TestCase {
 					'simple_array' => [ 'item1', 'item2', 'item3' ],
 				],
 				'boolean_field' => true,
+				'enum_field'    => 'option2',
 			],
 			'slug'     => 'valid-nested-slug',
 		];
@@ -239,6 +240,10 @@ class ValidatorTest extends TestCase {
 							],
 						],
 						'boolean_field' => [ 'type' => 'boolean' ],
+						'enum_field'    => [
+							'type' => 'string',
+							'enum' => [ 'option1', 'option2', 'option3' ],
+						],
 					],
 				],
 				'slug'     => [ 'type' => 'string' ],

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -25,6 +25,7 @@ function sanitize_title( string $title ): string {
 }
 
 function sanitize_text_field( string $text ): string {
+	// phpcs:ignore WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter
 	$text = strip_tags( $text );
 	$text = trim( $text );
 	$text = stripslashes( $text );

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -25,7 +25,22 @@ function sanitize_title( string $title ): string {
 }
 
 function sanitize_text_field( string $text ): string {
-	return $text;
+	$text = strip_tags( $text );
+	$text = trim( $text );
+	$text = stripslashes( $text );
+	return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+}
+
+function sanitize_email( string $email ): string {
+	$email = trim( $email );
+	$email = strtolower( $email );
+	return filter_var( $email, FILTER_SANITIZE_EMAIL );
+}
+
+function sanitize_url( string $url ): string {
+	$url = trim( $url );
+	$url = filter_var( $url, FILTER_SANITIZE_URL );
+	return preg_replace( '/[^-a-zA-Z0-9:_.\/@?&=#%]/', '', $url );
 }
 
 function __( string $text ): string {
@@ -106,6 +121,10 @@ function wp_generate_uuid4() {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_mt_rand
 		mt_rand( 0, 0xffff )
 	);
+}
+
+function is_email( $email ) {
+	return filter_var( $email, FILTER_VALIDATE_EMAIL ) !== false;
 }
 
 function wp_is_uuid( $uuid, $version = null ) {


### PR DESCRIPTION
This change adds:

- `Validator`
- `Sanitizer`

Traditionally, with WordPress, one does both of those at the edge via the core REST api. I explored moving our code to there, but, because we offer the code path, I think we do have to offer validation/sanitization deeper in the execution.

I then explored reusing`rest_validate_value_from_schema` / `rest_sanitize_value_from_schema` for that. That does feel possible, but, it started to drift from simplicity when I wanted to allow custom validation or santization callbacks.

So I ended up back here, with a similar api as core, but fully decoupled from http i/o.