### PR TITLE
Automatically add block arg to user-registered patterns

### DIFF
--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -78,11 +78,6 @@ class BlockRegistration {
 
 			// Register a default pattern that simply displays the available data.
 			BlockPatterns::register_default_block_pattern( $block_name, $config['title'], $config['queries']['__DISPLAY__'] );
-
-			// Register any user-provided patterns.
-			foreach ( $config['patterns'] as $pattern_name => $pattern_options ) {
-				register_block_pattern( $pattern_name, $pattern_options );
-			}
 		}
 
 		foreach ( array_unique( $scripts_to_localize ) as $script_handle ) {

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -7,8 +7,12 @@ defined( 'ABSPATH' ) || exit();
 use RemoteDataBlocks\Config\QueryContext\QueryContextInterface;
 use RemoteDataBlocks\Logging\LoggerManager;
 use Psr\Log\LoggerInterface;
+use RemoteDataBlocks\Editor\BlockPatterns\BlockPatterns;
 
 use function get_page_by_path;
+use function parse_blocks;
+use function register_block_pattern;
+use function serialize_blocks;
 use function wp_insert_post;
 
 class ConfigRegistry {
@@ -32,7 +36,6 @@ class ConfigRegistry {
 			'description' => '',
 			'name'        => $block_name,
 			'loop'        => $options['loop'] ?? false,
-			'patterns'    => [],
 			'queries'     => [
 				'__DISPLAY__' => $display_query,
 			],
@@ -70,7 +73,11 @@ class ConfigRegistry {
 			return;
 		}
 
-		$config['patterns'][ $pattern_name ] = array_merge(
+		// Add the block arg to any bindings present in the pattern.
+		$parsed_blocks   = parse_blocks( $pattern_content );
+		$parsed_blocks   = BlockPatterns::add_block_arg_to_bindings( $block_name, $parsed_blocks );
+		$pattern_content = serialize_blocks( $parsed_blocks );
+		$pattern_options = array_merge(
 			[
 				'blockTypes' => [ $block_name ],
 				'categories' => [ 'Remote Data' ],
@@ -81,7 +88,9 @@ class ConfigRegistry {
 			],
 			$pattern_options
 		);
-		ConfigStore::set_configuration( $block_name, $config );
+
+		// Register the pattern.
+		register_block_pattern( $pattern_name, $pattern_options );
 	}
 
 	public static function register_page( string $block_title, string $page_slug ): void {

--- a/inc/Editor/BlockPatterns/BlockPatterns.php
+++ b/inc/Editor/BlockPatterns/BlockPatterns.php
@@ -5,8 +5,10 @@ namespace RemoteDataBlocks\Editor\BlockPatterns;
 defined( 'ABSPATH' ) || exit();
 
 use RemoteDataBlocks\Config\QueryContext\QueryContextInterface;
+use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 
 use function register_block_pattern;
+use function wp_json_encode;
 
 class BlockPatterns {
 	private static $templates = [];
@@ -35,7 +37,7 @@ class BlockPatterns {
 			}
 
 			$attributes['metadata']['bindings'][ $attribute ] = [
-				'source' => 'remote-data/binding',
+				'source' => BlockBindings::$binding_source,
 				'args'   => [
 					'block' => $block_name,
 					'field' => $binding[0],
@@ -148,5 +150,35 @@ class BlockPatterns {
 				'source'     => 'plugin',
 			]
 		);
+	}
+
+	/**
+	 * Bindings are difficult to hardcode, especially if you want to reuse them
+	 * across multiple remote data blocks. Ensure that the block arg is present in
+	 * the binding and matches the expected value. The block arg is important,
+	 * because it is used to determine "compatibility" between blocks and bindings.
+	 *
+	 * @param string $block_name     The block name.
+	 * @param array  $parsed_blocks  The parsed blocks.
+	 * @return array The parsed blocks with the block arg added to the bindings.
+	 */
+	public static function add_block_arg_to_bindings( string $block_name, array $parsed_blocks ): array {
+		return array_map( function ( $parsed_block ) use ( $block_name ) {
+			$attributes = $parsed_block['attrs'];
+
+			if ( isset( $attributes['metadata']['bindings'] ) ) {
+				foreach ( $attributes['metadata']['bindings'] as $target => $binding ) {
+					if ( BlockBindings::$binding_source === $binding['source'] ) {
+						$parsed_block['attrs']['metadata']['bindings'][ $target ]['args']['block'] = $block_name;
+					}
+				}
+			}
+
+			if ( isset( $parsed_block['innerBlocks'] ) ) {
+				$parsed_block['innerBlocks'] = self::add_block_arg_to_bindings( $block_name, $parsed_block['innerBlocks'] );
+			}
+
+			return $parsed_block;
+		}, $parsed_blocks );
 	}
 }

--- a/src/blocks/remote-data-container/components/item-list/item-list.tsx
+++ b/src/blocks/remote-data-container/components/item-list/item-list.tsx
@@ -18,7 +18,11 @@ interface ItemListProps {
 
 export function ItemList( props: ItemListProps ) {
 	const { getPatternsByBlockTypes } = usePatterns( props.blockName, '' );
-	const [ pattern ] = getPatternsByBlockTypes( props.blockName );
+
+	// Find the pattern that the plugin has registered that is guaranteed to work.
+	const pattern = getPatternsByBlockTypes( props.blockName ).find(
+		( { name } ) => `${ props.blockName }/pattern` === name
+	);
 
 	if ( props.loading || ! pattern ) {
 		return <Spinner />;

--- a/tests/inc/Editor/BlockPatternsTest.php
+++ b/tests/inc/Editor/BlockPatternsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace RemoteDataBlocks\Tests\Editor\BlockPatterns;
+
+use PHPUnit\Framework\TestCase;
+use RemoteDataBlocks\Editor\BlockPatterns\BlockPatterns;
+
+class BlockPatternsTest extends TestCase {
+	public function testAddBlockArgToBindings(): void {
+		$block_name    = 'test-block';
+		$parsed_blocks = [
+			[
+				'blockName' => 'core/paragraph',
+				'attrs'     => [
+					'metadata' => [
+						'bindings' => [
+							'content' => [
+								'source' => 'not-ours',
+								'args'   => [
+									'field' => 'content',
+								],
+							],
+						],
+					],
+				],
+			],
+			[
+				'blockName' => 'core/paragraph',
+				'attrs'     => [
+					'metadata' => [
+						'bindings' => [
+							'content' => [
+								'source' => 'remote-data/binding',
+								'args'   => [
+									'field' => 'content',
+								],
+							],
+						],
+					],
+				],
+			],
+			[
+				'blockName' => 'core/paragraph',
+				'attrs'     => [
+					'content' => 'Goodbye, world!',
+				],
+			],
+		];
+
+		$parsed_blockss = BlockPatterns::add_block_arg_to_bindings( $block_name, $parsed_blocks );
+
+		// The second block should be updated with the block arg.
+		$this->assertSame(
+			[
+				'blockName' => 'core/paragraph',
+				'attrs'     => [
+					'metadata' => [
+						'bindings' => [
+							'content' => [
+								'source' => 'remote-data/binding',
+								'args'   => [
+									'field' => 'content',
+									'block' => 'test-block',
+								],
+							],
+						],
+					],
+				],
+			],
+			$parsed_blockss[1]
+		);
+
+		// The first and third blocks should be unchanged.
+		$this->assertSame( $parsed_blocks[0], $parsed_blockss[0] );
+		$this->assertSame( $parsed_blocks[2], $parsed_blockss[2] );
+	}
+}

--- a/tests/inc/Functions/FunctionsTest.php
+++ b/tests/inc/Functions/FunctionsTest.php
@@ -49,17 +49,6 @@ class FunctionsTest extends TestCase {
 		$this->assertTrue( $config['loop'] );
 	}
 
-	public function testRegisterBlockPattern() {
-		$query_context = new HttpQueryContext( new MockDatasource() );
-		register_remote_data_block( 'Block with Pattern', $query_context );
-		register_remote_data_block_pattern( 'Block with Pattern', 'Test Pattern', '<!-- wp:paragraph -->Test<!-- /wp:paragraph -->' );
-
-		$block_name = 'remote-data-blocks/block-with-pattern';
-		$config     = ConfigStore::get_configuration( $block_name );
-		$this->assertArrayHasKey( 'patterns', $config );
-		$this->assertArrayHasKey( 'Test Pattern', $config['patterns'] );
-	}
-
 	public function testRegisterQuery() {
 		$query_context = new HttpQueryContext( new MockDatasource() );
 		register_remote_data_block( 'Query Block', $query_context );


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/Automattic/remote-data-blocks/pull/53 (h/t @mhsdef). We now detect pattern compatibility by inspecting the block arg of the block binding. Rather than ask users to bake this arg into their supplied patterns (which is probably error-prone), we can inject it for them when they call `register_remote_data_block_pattern`.

This PR also removes the unused `patterns` key of the registered block config.