### PR TITLE
Update WP Playground blueprint landing page

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -9,7 +9,7 @@
   "features": {
     "networking": true
   },
-  "landingPage": "/wp-admin/",
+  "landingPage": "/wp-admin/admin.php?page=remote-data-blocks-settings",
   "login": true,
   "phpExtensionBundles": [ "light" ],
   "preferredVersions": {
@@ -21,7 +21,7 @@
       "step": "setSiteOptions",
       "options": {
         "blogname": "Remote Data Blocks",
-        "blogdescription": "A WordPress playground to explore the Remote Data Blocks plugin"
+        "blogdescription": "Explore the Remote Data Blocks plugin in a WordPress Playground"
       }
     },
     {


### PR DESCRIPTION
This seems to me, at least for now, like the most intuitive place for discovering some RDB functionality without documentation.

I'm thinking of linking the Try Now at https://remotedatablocks.com if you agree.

Not great, not perfect, yet, but pretty neat for short notice.

## How To Test

Click:
https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/remote-data-blocks/59337045f80c5794091fc65652508503d2a4a1e0/blueprint.json
