### PR TITLE
Move our PHP to declare(strict_types = 1)

### DIFF
--- a/bin/wp-env/decoupled/mu-plugins/home-url-filter.php
+++ b/bin/wp-env/decoupled/mu-plugins/home-url-filter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types = 1);
+
 add_filter('home_url', function ( $url, $path ) {
 	if ( have_posts() && is_singular() ) {
 		return site_url( $path );

--- a/bin/wp-env/decoupled/mu-plugins/home-url-filter.php
+++ b/bin/wp-env/decoupled/mu-plugins/home-url-filter.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 add_filter('home_url', function ( $url, $path ) {
 	if ( have_posts() && is_singular() ) {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     },
     "files": [
       "inc/Integrations/constants.php",
-      "inc/Validation/functions.php",
       "functions.php"
     ]
   },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,12 @@
   "autoload": {
     "psr-4": {
       "RemoteDataBlocks\\": "inc/"
-    }
+    },
+    "files": [
+      "inc/Integrations/constants.php",
+      "inc/Validation/functions.php",
+      "functions.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {
@@ -32,7 +37,8 @@
   "require-dev": {
     "automattic/vipwpcs": "^3.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "phpunit/phpunit": "^10"
+    "phpunit/phpunit": "^10",
+    "slevomat/coding-standard": "^8.15"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c861583aca763f81bf8154b4300c674",
+    "content-hash": "dd062e3fce42d497f2a6e13bd2b39ba2",
     "packages": [
         {
             "name": "galbar/jsonpath",
@@ -1529,6 +1529,53 @@
             "time": "2024-05-20T13:34:27+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "249f15fb843bf240cf058372dad29e100cee6c17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/249f15fb843bf240cf058372dad29e100cee6c17",
+                "reference": "249f15fb843bf240cf058372dad29e100cee6c17",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.31.0"
+            },
+            "time": "2024-09-22T11:32:18+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "10.1.16",
             "source": {
@@ -2923,6 +2970,71 @@
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
             "time": "2024-06-26T20:08:34+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "7d1d957421618a3803b593ec31ace470177d7817"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/7d1d957421618a3803b593ec31ace470177d7817",
+                "reference": "7d1d957421618a3803b593ec31ace470177d7817",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.23.1",
+                "squizlabs/php_codesniffer": "^3.9.0"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.10.60",
+                "phpstan/phpstan-deprecation-rules": "1.1.4",
+                "phpstan/phpstan-phpunit": "1.3.16",
+                "phpstan/phpstan-strict-rules": "1.5.2",
+                "phpunit/phpunit": "8.5.21|9.6.8|10.5.11"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.15.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-03-09T15:20:58+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/example/airtable/elden-ring-map/inc/queries/class-airtable-elden-ring-list-locations-query.php
+++ b/example/airtable/elden-ring-map/inc/queries/class-airtable-elden-ring-list-locations-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Airtable\EldenRingMap;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/example/airtable/elden-ring-map/inc/queries/class-airtable-elden-ring-list-locations-query.php
+++ b/example/airtable/elden-ring-map/inc/queries/class-airtable-elden-ring-list-locations-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Airtable\EldenRingMap;
 

--- a/example/airtable/elden-ring-map/inc/queries/class-airtable-elden-ring-list-maps-query.php
+++ b/example/airtable/elden-ring-map/inc/queries/class-airtable-elden-ring-list-maps-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Airtable\EldenRingMap;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/example/airtable/elden-ring-map/inc/queries/class-airtable-elden-ring-list-maps-query.php
+++ b/example/airtable/elden-ring-map/inc/queries/class-airtable-elden-ring-list-maps-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Airtable\EldenRingMap;
 

--- a/example/airtable/elden-ring-map/register.php
+++ b/example/airtable/elden-ring-map/register.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Airtable\EldenRingMap;
 
 use RemoteDataBlocks\Integrations\Airtable\AirtableDatasource;

--- a/example/airtable/elden-ring-map/register.php
+++ b/example/airtable/elden-ring-map/register.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Airtable\EldenRingMap;
 

--- a/example/airtable/events/inc/queries/class-airtable-get-event-query.php
+++ b/example/airtable/events/inc/queries/class-airtable-get-event-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Airtable\Events;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/example/airtable/events/inc/queries/class-airtable-get-event-query.php
+++ b/example/airtable/events/inc/queries/class-airtable-get-event-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Airtable\Events;
 

--- a/example/airtable/events/inc/queries/class-airtable-list-events-query.php
+++ b/example/airtable/events/inc/queries/class-airtable-list-events-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Airtable\Events;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/example/airtable/events/inc/queries/class-airtable-list-events-query.php
+++ b/example/airtable/events/inc/queries/class-airtable-list-events-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Airtable\Events;
 

--- a/example/airtable/events/register.php
+++ b/example/airtable/events/register.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Airtable\Events;
 
 use RemoteDataBlocks\Integrations\Airtable\AirtableDatasource;

--- a/example/airtable/events/register.php
+++ b/example/airtable/events/register.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Airtable\Events;
 

--- a/example/github/remote-data-blocks/inc/queries/class-github-get-file-as-html-query.php
+++ b/example/github/remote-data-blocks/inc/queries/class-github-get-file-as-html-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\GitHub;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/example/github/remote-data-blocks/inc/queries/class-github-get-file-as-html-query.php
+++ b/example/github/remote-data-blocks/inc/queries/class-github-get-file-as-html-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\GitHub;
 

--- a/example/github/remote-data-blocks/inc/queries/class-github-list-files-query.php
+++ b/example/github/remote-data-blocks/inc/queries/class-github-list-files-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\GitHub;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/example/github/remote-data-blocks/inc/queries/class-github-list-files-query.php
+++ b/example/github/remote-data-blocks/inc/queries/class-github-list-files-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\GitHub;
 

--- a/example/github/remote-data-blocks/register.php
+++ b/example/github/remote-data-blocks/register.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\GitHub;
 
 use RemoteDataBlocks\Integrations\GitHub\GitHubDatasource;

--- a/example/github/remote-data-blocks/register.php
+++ b/example/github/remote-data-blocks/register.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\GitHub;
 

--- a/example/google-sheets/westeros-houses/inc/queries/class-get-westeros-houses-query.php
+++ b/example/google-sheets/westeros-houses/inc/queries/class-get-westeros-houses-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\GoogleSheets\WesterosHouses;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/example/google-sheets/westeros-houses/inc/queries/class-get-westeros-houses-query.php
+++ b/example/google-sheets/westeros-houses/inc/queries/class-get-westeros-houses-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\GoogleSheets\WesterosHouses;
 

--- a/example/google-sheets/westeros-houses/inc/queries/class-list-westeros-houses-query.php
+++ b/example/google-sheets/westeros-houses/inc/queries/class-list-westeros-houses-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\GoogleSheets\WesterosHouses;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/example/google-sheets/westeros-houses/inc/queries/class-list-westeros-houses-query.php
+++ b/example/google-sheets/westeros-houses/inc/queries/class-list-westeros-houses-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\GoogleSheets\WesterosHouses;
 

--- a/example/google-sheets/westeros-houses/register.php
+++ b/example/google-sheets/westeros-houses/register.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\GoogleSheets\WesterosHouses;
 
 use RemoteDataBlocks\Integrations\Google\Sheets\GoogleSheetsDatasource;

--- a/example/google-sheets/westeros-houses/register.php
+++ b/example/google-sheets/westeros-houses/register.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\GoogleSheets\WesterosHouses;
 

--- a/example/remote-data-blocks-example-code.php
+++ b/example/remote-data-blocks-example-code.php
@@ -1,7 +1,4 @@
 <?php
-
-declare(strict_types = 1);
-
 /**
  * Plugin Name: Remote Data Blocks Examples
  * Plugin URI: https://github.com/Automattic/remote-data-blocks/blob/trunk/example
@@ -15,6 +12,8 @@ declare(strict_types = 1);
  *
  * @package remote-data-blocks
  */
+
+declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example;
 

--- a/example/remote-data-blocks-example-code.php
+++ b/example/remote-data-blocks-example-code.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types = 1);
+
 /**
  * Plugin Name: Remote Data Blocks Examples
  * Plugin URI: https://github.com/Automattic/remote-data-blocks/blob/trunk/example
@@ -12,8 +13,6 @@
  *
  * @package remote-data-blocks
  */
-
-declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example;
 

--- a/example/remote-data-blocks-example-code.php
+++ b/example/remote-data-blocks-example-code.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types = 1);
+
 /**
  * Plugin Name: Remote Data Blocks Examples
  * Plugin URI: https://github.com/Automattic/remote-data-blocks/blob/trunk/example

--- a/example/rest-api/art-institute/inc/queries/class-art-institute-datasource.php
+++ b/example/rest-api/art-institute/inc/queries/class-art-institute-datasource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\ArtInstituteOfChicago;
 

--- a/example/rest-api/art-institute/inc/queries/class-art-institute-datasource.php
+++ b/example/rest-api/art-institute/inc/queries/class-art-institute-datasource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\ArtInstituteOfChicago;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/example/rest-api/art-institute/inc/queries/class-art-institute-get-query.php
+++ b/example/rest-api/art-institute/inc/queries/class-art-institute-get-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\ArtInstituteOfChicago;
 

--- a/example/rest-api/art-institute/inc/queries/class-art-institute-get-query.php
+++ b/example/rest-api/art-institute/inc/queries/class-art-institute-get-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\ArtInstituteOfChicago;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/example/rest-api/art-institute/inc/queries/class-art-institute-search-query.php
+++ b/example/rest-api/art-institute/inc/queries/class-art-institute-search-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\ArtInstituteOfChicago;
 

--- a/example/rest-api/art-institute/inc/queries/class-art-institute-search-query.php
+++ b/example/rest-api/art-institute/inc/queries/class-art-institute-search-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\ArtInstituteOfChicago;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/example/rest-api/art-institute/register.php
+++ b/example/rest-api/art-institute/register.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\ArtInstituteOfChicago;
 
 require_once __DIR__ . '/inc/queries/class-art-institute-datasource.php';

--- a/example/rest-api/art-institute/register.php
+++ b/example/rest-api/art-institute/register.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\ArtInstituteOfChicago;
 

--- a/example/rest-api/zip-code/inc/queries/class-get-zip-code-query.php
+++ b/example/rest-api/zip-code/inc/queries/class-get-zip-code-query.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\ZipCode;
 

--- a/example/rest-api/zip-code/inc/queries/class-get-zip-code-query.php
+++ b/example/rest-api/zip-code/inc/queries/class-get-zip-code-query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\ZipCode;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/example/rest-api/zip-code/inc/queries/class-zip-code-datasource.php
+++ b/example/rest-api/zip-code/inc/queries/class-zip-code-datasource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\ZipCode;
 

--- a/example/rest-api/zip-code/inc/queries/class-zip-code-datasource.php
+++ b/example/rest-api/zip-code/inc/queries/class-zip-code-datasource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\ZipCode;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/example/rest-api/zip-code/register.php
+++ b/example/rest-api/zip-code/register.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\ZipCode;
 

--- a/example/rest-api/zip-code/register.php
+++ b/example/rest-api/zip-code/register.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\ZipCode;
 
 require_once __DIR__ . '/inc/queries/class-zip-code-datasource.php';

--- a/example/shopify/inc/interactivity-store/interactivity-store.php
+++ b/example/shopify/inc/interactivity-store/interactivity-store.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Shopify;
 
 defined( 'ABSPATH' ) || exit();

--- a/example/shopify/inc/interactivity-store/interactivity-store.php
+++ b/example/shopify/inc/interactivity-store/interactivity-store.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Shopify;
 

--- a/example/shopify/inc/queries/class-shopify-add-to-cart-mutation.php
+++ b/example/shopify/inc/queries/class-shopify-add-to-cart-mutation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Shopify;
 
 use RemoteDataBlocks\Config\QueryContext\GraphqlQueryContext;

--- a/example/shopify/inc/queries/class-shopify-add-to-cart-mutation.php
+++ b/example/shopify/inc/queries/class-shopify-add-to-cart-mutation.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Shopify;
 

--- a/example/shopify/inc/queries/class-shopify-create-cart-mutation.php
+++ b/example/shopify/inc/queries/class-shopify-create-cart-mutation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Shopify;
 
 use RemoteDataBlocks\Config\QueryContext\GraphqlQueryContext;

--- a/example/shopify/inc/queries/class-shopify-create-cart-mutation.php
+++ b/example/shopify/inc/queries/class-shopify-create-cart-mutation.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Shopify;
 

--- a/example/shopify/inc/queries/class-shopify-remove-from-cart-mutation.php
+++ b/example/shopify/inc/queries/class-shopify-remove-from-cart-mutation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Shopify;
 
 use RemoteDataBlocks\Config\QueryContext\GraphqlQueryContext;

--- a/example/shopify/inc/queries/class-shopify-remove-from-cart-mutation.php
+++ b/example/shopify/inc/queries/class-shopify-remove-from-cart-mutation.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Shopify;
 

--- a/example/shopify/register.php
+++ b/example/shopify/register.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Shopify;
 

--- a/example/shopify/register.php
+++ b/example/shopify/register.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Shopify;
 
 use RemoteDataBlocks\Editor\BlockManagement\ConfigRegistry;

--- a/example/shopify/src/blocks/shopify-cart-button/render.php
+++ b/example/shopify/src/blocks/shopify-cart-button/render.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 use RemoteDataBlocks\Example\Shopify\InteractivityStore;
 

--- a/example/shopify/src/blocks/shopify-cart-button/render.php
+++ b/example/shopify/src/blocks/shopify-cart-button/render.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 use RemoteDataBlocks\Example\Shopify\InteractivityStore;
 
 $interactive_context = InteractivityStore::get_cart_button_interactive_context( $block );

--- a/example/shopify/src/blocks/shopify-cart/render.php
+++ b/example/shopify/src/blocks/shopify-cart/render.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 use RemoteDataBlocks\Example\Shopify\InteractivityStore;
 

--- a/example/shopify/src/blocks/shopify-cart/render.php
+++ b/example/shopify/src/blocks/shopify-cart/render.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 use RemoteDataBlocks\Example\Shopify\InteractivityStore;
 
 $public_store_name = InteractivityStore::get_store_name();

--- a/example/theme/functions.php
+++ b/example/theme/functions.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Example\Theme;
 

--- a/example/theme/functions.php
+++ b/example/theme/functions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Example\Theme;
 
 use function add_action;

--- a/functions.php
+++ b/functions.php
@@ -1,12 +1,14 @@
 <?php
-
-declare(strict_types = 1);
-
 /**
- * Access functions for class methods in the global namespace.
+ * Remote Data Blocks API
+ *
+ * This file contains functions, in the global namespace, for registering and
+ * interacting with Remote Data Blocks.
  *
  * @package remote-data-blocks
  */
+
+declare(strict_types = 1);
 
 use RemoteDataBlocks\Config\QueryContext\QueryContextInterface;
 use RemoteDataBlocks\Editor\BlockManagement\ConfigRegistry;

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types = 1);
+
 /**
  * Access functions for class methods in the global namespace.
  *

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types = 1);
+
 /**
  * Remote Data Blocks API
  *
@@ -7,8 +8,6 @@
  *
  * @package remote-data-blocks
  */
-
-declare(strict_types = 1);
 
 use RemoteDataBlocks\Config\QueryContext\QueryContextInterface;
 use RemoteDataBlocks\Editor\BlockManagement\ConfigRegistry;

--- a/inc/Config/ArraySerializableInterface.php
+++ b/inc/Config/ArraySerializableInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config;
 

--- a/inc/Config/ArraySerializableInterface.php
+++ b/inc/Config/ArraySerializableInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Config;
 
 interface ArraySerializableInterface {

--- a/inc/Config/Datasource/DatasourceInterface.php
+++ b/inc/Config/Datasource/DatasourceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 /**
  * DatasourceInterface
  *

--- a/inc/Config/Datasource/DatasourceInterface.php
+++ b/inc/Config/Datasource/DatasourceInterface.php
@@ -2,22 +2,20 @@
 
 declare(strict_types = 1);
 
-/**
- * DatasourceInterface
- *
- * @package remote-data-blocks
- * @since 0.1.0
- */
-
 namespace RemoteDataBlocks\Config\Datasource;
 
 /**
+ * DatasourceInterface
+ *
  * Interface used to define a Remote Data Blocks Datasource. It defines the
  * properties of a datasource that will be shared by queries against that
  * datasource.
  *
  * If you are a WPVIP customer, datasources are automatically provided by VIP.
  * Only implement this interface if you have additional custom datasources.
+ * 
+ * @package remote-data-blocks
+ * @since 0.1.0
  */
 interface DatasourceInterface {
 	public const BASE_SCHEMA = [

--- a/inc/Config/Datasource/DatasourceInterface.php
+++ b/inc/Config/Datasource/DatasourceInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config\Datasource;
 

--- a/inc/Config/Datasource/HttpDatasource.php
+++ b/inc/Config/Datasource/HttpDatasource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Config\Datasource;
 
 use RemoteDataBlocks\Config\ArraySerializableInterface;

--- a/inc/Config/Datasource/HttpDatasource.php
+++ b/inc/Config/Datasource/HttpDatasource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config\Datasource;
 

--- a/inc/Config/Datasource/HttpDatasourceInterface.php
+++ b/inc/Config/Datasource/HttpDatasourceInterface.php
@@ -2,16 +2,11 @@
 
 declare(strict_types = 1);
 
-/**
- * HttpDatasourceInterface
- *
- * @package remote-data-blocks
- * @since 0.1.0
- */
-
 namespace RemoteDataBlocks\Config\Datasource;
 
 /**
+ * HttpDatasourceInterface
+ *
  * Interface used to define a Remote Data Blocks Datasource for an HTTP API. It
  * defines the properties of an API that will be shared by queries against that
  * API.
@@ -25,6 +20,9 @@ namespace RemoteDataBlocks\Config\Datasource;
  *
  * If you are a WPVIP customer, datasources are automatically provided by VIP.
  * Only implement this interface if you have custom datasources not provided by VIP.
+ * 
+ * @package remote-data-blocks
+ * @since 0.1.0
  */
 interface HttpDatasourceInterface {
 	/**

--- a/inc/Config/Datasource/HttpDatasourceInterface.php
+++ b/inc/Config/Datasource/HttpDatasourceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 /**
  * HttpDatasourceInterface
  *

--- a/inc/Config/Datasource/HttpDatasourceInterface.php
+++ b/inc/Config/Datasource/HttpDatasourceInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config\Datasource;
 

--- a/inc/Config/QueryContext/GraphqlQueryContext.php
+++ b/inc/Config/QueryContext/GraphqlQueryContext.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config\QueryContext;
 

--- a/inc/Config/QueryContext/GraphqlQueryContext.php
+++ b/inc/Config/QueryContext/GraphqlQueryContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 /**
  * GraphqlQueryContext class
  *

--- a/inc/Config/QueryContext/GraphqlQueryContext.php
+++ b/inc/Config/QueryContext/GraphqlQueryContext.php
@@ -2,20 +2,18 @@
 
 declare(strict_types = 1);
 
-/**
- * GraphqlQueryContext class
- *
- * @package remote-data-blocks
- * @since 0.1.0
- */
-
 namespace RemoteDataBlocks\Config\QueryContext;
 
 defined( 'ABSPATH' ) || exit();
 
 /**
+ * GraphqlQueryContext class
+ *
  * Base class used to define a Remote Data Query. This class defines a
  * composable query that allows it to be composed with another query or a block.
+ *
+ * @package remote-data-blocks
+ * @since 0.1.0
  */
 abstract class GraphqlQueryContext extends HttpQueryContext {
 

--- a/inc/Config/QueryContext/HttpQueryContext.php
+++ b/inc/Config/QueryContext/HttpQueryContext.php
@@ -2,13 +2,6 @@
 
 declare(strict_types = 1);
 
-/**
- * HttpQueryContext class
- *
- * @package remote-data-blocks
- * @since 0.1.0
- */
-
 namespace RemoteDataBlocks\Config\QueryContext;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;
@@ -18,8 +11,13 @@ use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
 defined( 'ABSPATH' ) || exit();
 
 /**
+ * HttpQueryContext class
+ *
  * Base class used to define a Remote Data Blocks Query. This class defines a
  * composable query that allows it to be composed with another query or a block.
+ * 
+ * @package remote-data-blocks
+ * @since 0.1.0
  */
 class HttpQueryContext implements QueryContextInterface, HttpQueryContextInterface {
 	const VERSION = '0.1.0';

--- a/inc/Config/QueryContext/HttpQueryContext.php
+++ b/inc/Config/QueryContext/HttpQueryContext.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config\QueryContext;
 

--- a/inc/Config/QueryContext/HttpQueryContext.php
+++ b/inc/Config/QueryContext/HttpQueryContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 /**
  * HttpQueryContext class
  *

--- a/inc/Config/QueryContext/HttpQueryContextInterface.php
+++ b/inc/Config/QueryContext/HttpQueryContextInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config\QueryContext;
 

--- a/inc/Config/QueryContext/HttpQueryContextInterface.php
+++ b/inc/Config/QueryContext/HttpQueryContextInterface.php
@@ -2,15 +2,14 @@
 
 declare(strict_types = 1);
 
+namespace RemoteDataBlocks\Config\QueryContext;
+
 /**
  * HttpQueryContextInterface interface
  *
  * @package remote-data-blocks
  * @since 0.1.0
  */
-
-namespace RemoteDataBlocks\Config\QueryContext;
-
 interface HttpQueryContextInterface {
 	public function get_endpoint( array $input_variables ): string;
 	public function get_request_method(): string;

--- a/inc/Config/QueryContext/HttpQueryContextInterface.php
+++ b/inc/Config/QueryContext/HttpQueryContextInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 /**
  * HttpQueryContextInterface interface
  *

--- a/inc/Config/QueryContext/QueryContextInterface.php
+++ b/inc/Config/QueryContext/QueryContextInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config\QueryContext;
 

--- a/inc/Config/QueryContext/QueryContextInterface.php
+++ b/inc/Config/QueryContext/QueryContextInterface.php
@@ -2,17 +2,16 @@
 
 declare(strict_types = 1);
 
-/**
- * HttpQueryContextInterface interface
- *
- * @package remote-data-blocks
- * @since 0.1.0
- */
-
 namespace RemoteDataBlocks\Config\QueryContext;
 
 use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
 
+/**
+ * QueryContextInterface interface
+ *
+ * @package remote-data-blocks
+ * @since 0.1.0
+ */
 interface QueryContextInterface {
 	public function get_image_url(): string|null;
 	public function get_query_name(): string;

--- a/inc/Config/QueryContext/QueryContextInterface.php
+++ b/inc/Config/QueryContext/QueryContextInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 /**
  * HttpQueryContextInterface interface
  *

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config\QueryRunner;
 

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 /**
  * QueryRunner class
  *

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -198,13 +198,13 @@ class QueryRunner implements QueryRunnerInterface {
 				return $field_value_single;
 
 			case 'price':
-				return sprintf( '$%s', number_format( $field_value_single, 2 ) );
+				return sprintf( '$%s', number_format( (float) $field_value_single, 2 ) );
 
 			case 'string':
 				return wp_strip_all_tags( $field_value_single );
 		}
 
-		return $field_value_single;
+		return (string) $field_value_single;
 	}
 
 	/**

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -2,13 +2,6 @@
 
 declare(strict_types = 1);
 
-/**
- * QueryRunner class
- *
- * @package remote-data-blocks
- * @since 0.1.0
- */
-
 namespace RemoteDataBlocks\Config\QueryRunner;
 
 use Exception;
@@ -22,7 +15,12 @@ use WP_Error;
 defined( 'ABSPATH' ) || exit();
 
 /**
- * Class that executes a query using HttpQueryContext.
+ * QueryRunner class
+ *
+ * Class that executes queries, leveraging provided QueryContext.
+ *
+ * @package remote-data-blocks
+ * @since 0.1.0
  */
 class QueryRunner implements QueryRunnerInterface {
 

--- a/inc/Config/QueryRunner/QueryRunnerInterface.php
+++ b/inc/Config/QueryRunner/QueryRunnerInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config\QueryRunner;
 

--- a/inc/Config/QueryRunner/QueryRunnerInterface.php
+++ b/inc/Config/QueryRunner/QueryRunnerInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Config\QueryRunner;
 
 interface QueryRunnerInterface {

--- a/inc/Config/UiDisplayableInterface.php
+++ b/inc/Config/UiDisplayableInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Config;
 

--- a/inc/Config/UiDisplayableInterface.php
+++ b/inc/Config/UiDisplayableInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Config;
 
 interface UiDisplayableInterface {

--- a/inc/Editor/AdminNotices/AdminNotices.php
+++ b/inc/Editor/AdminNotices/AdminNotices.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Editor\AdminNotices;
 
 use Psr\Log\LogLevel;

--- a/inc/Editor/AdminNotices/AdminNotices.php
+++ b/inc/Editor/AdminNotices/AdminNotices.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Editor\AdminNotices;
 

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Editor\BlockManagement;
 

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Editor\BlockManagement;
 
 defined( 'ABSPATH' ) || exit();
@@ -7,7 +9,6 @@ defined( 'ABSPATH' ) || exit();
 use RemoteDataBlocks\Editor\BlockPatterns\BlockPatterns;
 use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 use RemoteDataBlocks\REST\RemoteDataController;
-use function register_block_pattern;
 use function register_block_type;
 
 class BlockRegistration {

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Editor\BlockManagement;
 
 defined( 'ABSPATH' ) || exit();

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Editor\BlockManagement;
 

--- a/inc/Editor/BlockManagement/ConfigStore.php
+++ b/inc/Editor/BlockManagement/ConfigStore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Editor\BlockManagement;
 
 defined( 'ABSPATH' ) || exit();

--- a/inc/Editor/BlockManagement/ConfigStore.php
+++ b/inc/Editor/BlockManagement/ConfigStore.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Editor\BlockManagement;
 

--- a/inc/Editor/BlockPatterns/BlockPatterns.php
+++ b/inc/Editor/BlockPatterns/BlockPatterns.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Editor\BlockPatterns;
 
 defined( 'ABSPATH' ) || exit();

--- a/inc/Editor/BlockPatterns/BlockPatterns.php
+++ b/inc/Editor/BlockPatterns/BlockPatterns.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Editor\BlockPatterns;
 

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Editor\DataBinding;
 

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Editor\DataBinding;
 
 defined( 'ABSPATH' ) || exit();

--- a/inc/Editor/DataBinding/FieldShortcode.php
+++ b/inc/Editor/DataBinding/FieldShortcode.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Editor\DataBinding;
 

--- a/inc/Editor/DataBinding/FieldShortcode.php
+++ b/inc/Editor/DataBinding/FieldShortcode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Editor\DataBinding;
 
 defined( 'ABSPATH' ) || exit();

--- a/inc/Editor/DataBinding/QueryOverrides.php
+++ b/inc/Editor/DataBinding/QueryOverrides.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Editor\DataBinding;
 
 use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;

--- a/inc/Editor/DataBinding/QueryOverrides.php
+++ b/inc/Editor/DataBinding/QueryOverrides.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Editor\DataBinding;
 

--- a/inc/Editor/PatternEditor/PatternEditor.php
+++ b/inc/Editor/PatternEditor/PatternEditor.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Editor\PatternEditor;
 

--- a/inc/Editor/PatternEditor/PatternEditor.php
+++ b/inc/Editor/PatternEditor/PatternEditor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Editor\PatternEditor;
 
 defined( 'ABSPATH' ) || exit();

--- a/inc/ExampleApi/Data/ExampleApiData.php
+++ b/inc/ExampleApi/Data/ExampleApiData.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\ExampleApi\Data;
 

--- a/inc/ExampleApi/Data/ExampleApiData.php
+++ b/inc/ExampleApi/Data/ExampleApiData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\ExampleApi\Data;
 
 use WP_Error;

--- a/inc/ExampleApi/ExampleApi.php
+++ b/inc/ExampleApi/ExampleApi.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\ExampleApi;
 

--- a/inc/ExampleApi/ExampleApi.php
+++ b/inc/ExampleApi/ExampleApi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\ExampleApi;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/inc/ExampleApi/Queries/ExampleApiDataSource.php
+++ b/inc/ExampleApi/Queries/ExampleApiDataSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\ExampleApi\Queries;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/inc/ExampleApi/Queries/ExampleApiDataSource.php
+++ b/inc/ExampleApi/Queries/ExampleApiDataSource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\ExampleApi\Queries;
 

--- a/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\ExampleApi\Queries;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\ExampleApi\Queries;
 

--- a/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\ExampleApi\Queries;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;

--- a/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\ExampleApi\Queries;
 

--- a/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
+++ b/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 /**
  * ExampleApiQueryRunner class
  *

--- a/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
+++ b/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\ExampleApi\Queries;
 

--- a/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
+++ b/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
@@ -2,12 +2,6 @@
 
 declare(strict_types = 1);
 
-/**
- * ExampleApiQueryRunner class
- *
- * @package remote-data-blocks
- */
-
 namespace RemoteDataBlocks\ExampleApi\Queries;
 
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
@@ -17,6 +11,8 @@ use WP_Error;
 defined( 'ABSPATH' ) || exit();
 
 /**
+ * ExampleApiQueryRunner class
+ *
  * Execute the query by making an internal REST API request. This allows the
  * example API to work when running locally (inside a container). Otherwise,
  * there would be a mismatch between the public address (e.g., localhost:888) and
@@ -24,6 +20,9 @@ defined( 'ABSPATH' ) || exit();
  *
  * A nice side effect is that we avoid using Guzzle/cURL for this example, which
  * makes it runnable in environments like WP Now.
+ *
+ * @package remote-data-blocks
+ * @since 0.1.0
  */
 class ExampleApiQueryRunner extends QueryRunner {
 	protected function get_raw_response_data( array $input_variables ): array|WP_Error {

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\HttpClient;
 
 use Exception;

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\HttpClient;
 

--- a/inc/Integrations/Airtable/AirtableDatasource.php
+++ b/inc/Integrations/Airtable/AirtableDatasource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\Airtable;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/inc/Integrations/Airtable/AirtableDatasource.php
+++ b/inc/Integrations/Airtable/AirtableDatasource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\Airtable;
 

--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\Airtable;
 
 use RemoteDataBlocks\Logging\LoggerManager;

--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\Airtable;
 

--- a/inc/Integrations/GenericHttp/GenericHttpDatasource.php
+++ b/inc/Integrations/GenericHttp/GenericHttpDatasource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\GenericHttp;
 

--- a/inc/Integrations/GenericHttp/GenericHttpDatasource.php
+++ b/inc/Integrations/GenericHttp/GenericHttpDatasource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\GenericHttp;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;
@@ -44,6 +46,7 @@ class GenericHttpDatasource extends HttpDatasource {
 			],
 			'url'                    => [
 				'type'     => 'string',
+				'callback' => '\RemoteDataBlocks\Validation\is_url',
 				'sanitize' => 'sanitize_url',
 			],
 		],

--- a/inc/Integrations/GitHub/GitHubDatasource.php
+++ b/inc/Integrations/GitHub/GitHubDatasource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\GitHub;
 

--- a/inc/Integrations/GitHub/GitHubDatasource.php
+++ b/inc/Integrations/GitHub/GitHubDatasource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\GitHub;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/inc/Integrations/Google/Auth/GoogleAuth.php
+++ b/inc/Integrations/Google/Auth/GoogleAuth.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\Google\Auth;
 
 use WP_Error;

--- a/inc/Integrations/Google/Auth/GoogleAuth.php
+++ b/inc/Integrations/Google/Auth/GoogleAuth.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\Google\Auth;
 

--- a/inc/Integrations/Google/Auth/GoogleServiceAccountKey.php
+++ b/inc/Integrations/Google/Auth/GoogleServiceAccountKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\Google\Auth;
 
 use WP_Error;

--- a/inc/Integrations/Google/Auth/GoogleServiceAccountKey.php
+++ b/inc/Integrations/Google/Auth/GoogleServiceAccountKey.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\Google\Auth;
 

--- a/inc/Integrations/Google/Sheets/GoogleSheetsDatasource.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsDatasource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\Google\Sheets;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/inc/Integrations/Google/Sheets/GoogleSheetsDatasource.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsDatasource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\Google\Sheets;
 

--- a/inc/Integrations/Shopify/Queries/ShopifyGetProductQuery.php
+++ b/inc/Integrations/Shopify/Queries/ShopifyGetProductQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\Shopify\Queries;
 
 use RemoteDataBlocks\Config\QueryContext\GraphqlQueryContext;

--- a/inc/Integrations/Shopify/Queries/ShopifyGetProductQuery.php
+++ b/inc/Integrations/Shopify/Queries/ShopifyGetProductQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\Shopify\Queries;
 

--- a/inc/Integrations/Shopify/Queries/ShopifySearchProductsQuery.php
+++ b/inc/Integrations/Shopify/Queries/ShopifySearchProductsQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\Shopify\Queries;
 
 use RemoteDataBlocks\Config\QueryContext\GraphqlQueryContext;

--- a/inc/Integrations/Shopify/Queries/ShopifySearchProductsQuery.php
+++ b/inc/Integrations/Shopify/Queries/ShopifySearchProductsQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\Shopify\Queries;
 

--- a/inc/Integrations/Shopify/ShopifyDatasource.php
+++ b/inc/Integrations/Shopify/ShopifyDatasource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\Shopify;
 

--- a/inc/Integrations/Shopify/ShopifyDatasource.php
+++ b/inc/Integrations/Shopify/ShopifyDatasource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\Shopify;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\Shopify;
 

--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\Shopify;
 
 use RemoteDataBlocks\Integrations\Shopify\Queries\ShopifyGetProductQuery;

--- a/inc/Integrations/VipBlockDataApi/VipBlockDataApi.php
+++ b/inc/Integrations/VipBlockDataApi/VipBlockDataApi.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Integrations\VipBlockDataApi;
 

--- a/inc/Integrations/VipBlockDataApi/VipBlockDataApi.php
+++ b/inc/Integrations/VipBlockDataApi/VipBlockDataApi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Integrations\VipBlockDataApi;
 
 use RemoteDataBlocks\Editor\DataBinding\BlockBindings;

--- a/inc/Integrations/constants.php
+++ b/inc/Integrations/constants.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks;
 
 define( 'REMOTE_DATA_BLOCKS_AIRTABLE_SERVICE', 'airtable' );

--- a/inc/Integrations/constants.php
+++ b/inc/Integrations/constants.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks;
 

--- a/inc/Logging/Logger.php
+++ b/inc/Logging/Logger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Logging;
 
 use Psr\Log\AbstractLogger;

--- a/inc/Logging/Logger.php
+++ b/inc/Logging/Logger.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Logging;
 

--- a/inc/Logging/LoggerManager.php
+++ b/inc/Logging/LoggerManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Logging;
 
 use Psr\Log\LoggerInterface;

--- a/inc/Logging/LoggerManager.php
+++ b/inc/Logging/LoggerManager.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Logging;
 

--- a/inc/PluginSettings/PluginSettings.php
+++ b/inc/PluginSettings/PluginSettings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\PluginSettings;
 
 use RemoteDataBlocks\REST\DatasourceController;

--- a/inc/PluginSettings/PluginSettings.php
+++ b/inc/PluginSettings/PluginSettings.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\PluginSettings;
 

--- a/inc/REST/AuthController.php
+++ b/inc/REST/AuthController.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\REST;
 

--- a/inc/REST/AuthController.php
+++ b/inc/REST/AuthController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\REST;
 
 use WP_REST_Controller;

--- a/inc/REST/DatasourceController.php
+++ b/inc/REST/DatasourceController.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\REST;
 

--- a/inc/REST/DatasourceController.php
+++ b/inc/REST/DatasourceController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\REST;
 
 use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;

--- a/inc/REST/RemoteDataController.php
+++ b/inc/REST/RemoteDataController.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\REST;
 

--- a/inc/REST/RemoteDataController.php
+++ b/inc/REST/RemoteDataController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\REST;
 
 defined( 'ABSPATH' ) || exit();

--- a/inc/Sanitization/Sanitizer.php
+++ b/inc/Sanitization/Sanitizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Sanitization;
 
 /**

--- a/inc/Sanitization/Sanitizer.php
+++ b/inc/Sanitization/Sanitizer.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Sanitization;
 

--- a/inc/Sanitization/SanitizerInterface.php
+++ b/inc/Sanitization/SanitizerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Sanitization;
 
 /**

--- a/inc/Sanitization/SanitizerInterface.php
+++ b/inc/Sanitization/SanitizerInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Sanitization;
 

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Validation;
 

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Validation;
 
 use WP_Error;
@@ -31,28 +33,28 @@ class Validator implements ValidatorInterface {
 
 		if ( isset( $schema['type'] ) && ! $this->check_type( $data, $schema['type'] ) ) {
 			// translators: %1$s is the expected PHP data type, %2$s is the actual PHP data type.
-			return new WP_Error( 'invalid_type', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['type'], gettype( $data ) ) );
+			return new WP_Error( 'invalid_type', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['type'], gettype( $data ) ), [ 'status' => 400 ] );
 		}
 
 		if ( isset( $schema['pattern'] ) && is_string( $data ) && ! preg_match( $schema['pattern'], $data ) ) {
 			// translators: %1$s is the expected regex pattern, %2$s is the actual value.
-			return new WP_Error( 'invalid_format', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['pattern'], $data ) );
+			return new WP_Error( 'invalid_format', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['pattern'], $data ), [ 'status' => 400 ] );
 		}
 
 		if ( isset( $schema['enum'] ) && ! in_array( $data, $schema['enum'] ) ) {
 			// translators: %1$s is the expected value, %2$s is the actual value.
-			return new WP_Error( 'invalid_value', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), implode( ', ', $schema['enum'] ), $data ) );
+			return new WP_Error( 'invalid_value', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), implode( ', ', $schema['enum'] ), $data ), [ 'status' => 400 ] );
 		}
 
 		if ( isset( $schema['const'] ) && $data !== $schema['const'] ) {
 			// translators: %1$s is the expected value, %2$s is the actual value.
-			return new WP_Error( 'invalid_value', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['const'], $data ) );
+			return new WP_Error( 'invalid_value', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), $schema['const'], $data ), [ 'status' => 400 ] );
 		}
 
 		if ( isset( $schema['callback'] ) && is_callable( $schema['callback'] ) ) {
 			if ( false === call_user_func( $schema['callback'], $data ) ) {
 				// translators: %1$s is the callback name, %2$s is the value given to the callback.
-				return new WP_Error( 'invalid_value', sprintf( __( 'Validate callback %1$s failed with value %2$s.', 'remote-data-blocks' ), $schema['callback'], $data ) );
+				return new WP_Error( 'invalid_value', sprintf( __( 'Validate callback %1$s failed with value %2$s.', 'remote-data-blocks' ), $schema['callback'], $data ), [ 'status' => 400 ] );
 			}
 		}
 
@@ -64,7 +66,7 @@ class Validator implements ValidatorInterface {
 
 				if ( ! isset( $data[ $field ] ) ) {
 					// translators: %1$s is the missing field name.
-					return new WP_Error( 'missing_field', sprintf( __( 'Missing field %1$s.', 'remote-data-blocks' ), $field ) );
+					return new WP_Error( 'missing_field', sprintf( __( 'Missing field %1$s.', 'remote-data-blocks' ), $field ), [ 'status' => 400 ] );
 				}
 				
 				$result = $this->validate_schema( $field_schema, $data[ $field ] );
@@ -77,7 +79,7 @@ class Validator implements ValidatorInterface {
 		if ( isset( $schema['items'] ) ) {
 			if ( ! is_array( $data ) ) {
 				// translators: %1$s is the expected PHP data type, %2$s is the actual PHP data type.
-				return new WP_Error( 'invalid_array', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), 'array', gettype( $data ) ) );
+				return new WP_Error( 'invalid_array', sprintf( __( 'Expected %1$s, got %2$s.', 'remote-data-blocks' ), 'array', gettype( $data ) ), [ 'status' => 400 ] );
 			}
 
 			foreach ( $data as $item ) {

--- a/inc/Validation/ValidatorInterface.php
+++ b/inc/Validation/ValidatorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Validation;
 
 use WP_Error;

--- a/inc/Validation/ValidatorInterface.php
+++ b/inc/Validation/ValidatorInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Validation;
 

--- a/inc/WpdbStorage/DataEncryption.php
+++ b/inc/WpdbStorage/DataEncryption.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types = 1);
+
 /**
  * Class RemoteDataBlocks\Storage\DataEncryption
  *

--- a/inc/WpdbStorage/DataEncryption.php
+++ b/inc/WpdbStorage/DataEncryption.php
@@ -2,21 +2,19 @@
 
 declare(strict_types = 1);
 
+namespace RemoteDataBlocks\WpdbStorage;
+
 /**
  * Class RemoteDataBlocks\Storage\DataEncryption
+ *
+ * Class responsible for encrypting and decrypting data. We use this to store sensitive data in the database.
  *
  * Adapted from Google Site Kit plugin.
  *
  * Original License   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @see https://github.com/google/site-kit-wp/blob/e99bed8bfc08869427021bbd47bc57b2c866cc20/includes/Core/Storage/Data_Encryption.php
  * @see https://felix-arntz.me/blog/storing-confidential-data-in-wordpress/
- */
-
-namespace RemoteDataBlocks\WpdbStorage;
-
-/**
- * Class responsible for encrypting and decrypting data. We use this to store sensitive data in the database.
- *
+ * 
  * @access private
  * @ignore
  */

--- a/inc/WpdbStorage/DataEncryption.php
+++ b/inc/WpdbStorage/DataEncryption.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\WpdbStorage;
 

--- a/inc/WpdbStorage/DatasourceCrud.php
+++ b/inc/WpdbStorage/DatasourceCrud.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\WpdbStorage;
 
 use RemoteDataBlocks\Config\ArraySerializableInterface;

--- a/inc/WpdbStorage/DatasourceCrud.php
+++ b/inc/WpdbStorage/DatasourceCrud.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\WpdbStorage;
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -85,6 +85,13 @@
 		<exclude-pattern>/tests/*</exclude-pattern>
 	</rule>
 
+	<!-- Exclude PSR12.Files.FileHeader.IncorrectOrder for specific files -->
+	<rule ref="PSR12.Files.FileHeader.IncorrectOrder">
+		<exclude-pattern>remote-data-blocks.php</exclude-pattern>
+		<exclude-pattern>functions.php</exclude-pattern>
+		<exclude-pattern>example/remote-data-blocks-example-code.php</exclude-pattern>
+	</rule>
+
 	<!-- These functions are new via the Interactivity API and are auto-escaped -->
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
@@ -103,6 +110,11 @@
 		</properties>
 	</rule>
 
-    <rule ref="SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php" />
-
+	<!-- Slevomat Coding Standard -->
+	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+		<properties>
+			<property name="declareOnFirstLine" value="true"/>
+		</properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -103,4 +103,6 @@
 		</properties>
 	</rule>
 
+    <rule ref="SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php" />
+
 </ruleset>

--- a/remote-data-blocks.php
+++ b/remote-data-blocks.php
@@ -13,6 +13,8 @@
  * @package remote-data-blocks
  */
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks;
 
 defined( 'ABSPATH' ) || exit();
@@ -23,14 +25,8 @@ define( 'REMOTE_DATA_BLOCKS__PLUGIN_VERSION', '0.1.0' );
 
 define( 'REMOTE_DATA_BLOCKS__REST_NAMESPACE', 'remote-data-blocks/v1' );
 
-// Datasource services
-require_once __DIR__ . '/inc/integrations/constants.php';
-
 // Autoloader
 require_once __DIR__ . '/vendor/autoload.php';
-
-// Access functions
-require_once __DIR__ . '/functions.php';
 
 // Other editor modifications
 Editor\AdminNotices\AdminNotices::init();

--- a/remote-data-blocks.php
+++ b/remote-data-blocks.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types = 1);
+
 /**
  * Plugin Name: Remote Data Blocks
  * Plugin URI: https://remotedatablocks.com
@@ -12,8 +13,6 @@
  *
  * @package remote-data-blocks
  */
-
-declare(strict_types = 1);
 
 namespace RemoteDataBlocks;
 

--- a/tests/inc/Config/QueryContextTest.php
+++ b/tests/inc/Config/QueryContextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Config;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/inc/Config/QueryContextTest.php
+++ b/tests/inc/Config/QueryContextTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Config;
 

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Config;
 
 use GuzzleHttp\Psr7\Response;

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Config;
 

--- a/tests/inc/Editor/BlockPatternsTest.php
+++ b/tests/inc/Editor/BlockPatternsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Editor\BlockPatterns;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/inc/Editor/BlockPatternsTest.php
+++ b/tests/inc/Editor/BlockPatternsTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Editor\BlockPatterns;
 

--- a/tests/inc/Functions/FunctionsTest.php
+++ b/tests/inc/Functions/FunctionsTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Editor\BlockManagement;
 

--- a/tests/inc/Functions/FunctionsTest.php
+++ b/tests/inc/Functions/FunctionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Editor\BlockManagement;
 
 use Psr\Log\LogLevel;

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\HttpClient;
 

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\HttpClient;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/inc/Integrations/Airtable/AirtableDatasourceTest.php
+++ b/tests/inc/Integrations/Airtable/AirtableDatasourceTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Integrations\Airtable;
 

--- a/tests/inc/Integrations/Airtable/AirtableDatasourceTest.php
+++ b/tests/inc/Integrations/Airtable/AirtableDatasourceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Integrations\Airtable;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
+++ b/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Integrations\VipBlockDataApi;
 

--- a/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
+++ b/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Integrations\VipBlockDataApi;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/inc/Mocks/MockDatasource.php
+++ b/tests/inc/Mocks/MockDatasource.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Mocks;
 
 use RemoteDataBlocks\Config\Datasource\HttpDatasource;

--- a/tests/inc/Mocks/MockDatasource.php
+++ b/tests/inc/Mocks/MockDatasource.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Mocks;
 

--- a/tests/inc/Mocks/MockLogger.php
+++ b/tests/inc/Mocks/MockLogger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Mocks;
 
 use Psr\Log\LoggerInterface;

--- a/tests/inc/Mocks/MockLogger.php
+++ b/tests/inc/Mocks/MockLogger.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Mocks;
 

--- a/tests/inc/Mocks/MockQueryRunner.php
+++ b/tests/inc/Mocks/MockQueryRunner.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Mocks;
 
 use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;

--- a/tests/inc/Mocks/MockQueryRunner.php
+++ b/tests/inc/Mocks/MockQueryRunner.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Mocks;
 

--- a/tests/inc/Mocks/MockValidator.php
+++ b/tests/inc/Mocks/MockValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Mocks;
 
 use RemoteDataBlocks\Validation\ValidatorInterface;

--- a/tests/inc/Mocks/MockValidator.php
+++ b/tests/inc/Mocks/MockValidator.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Mocks;
 

--- a/tests/inc/Sanitization/SanitizerTest.php
+++ b/tests/inc/Sanitization/SanitizerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Sanitization;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/inc/Sanitization/SanitizerTest.php
+++ b/tests/inc/Sanitization/SanitizerTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Sanitization;
 

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\Validation;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\Validation;
 

--- a/tests/inc/WpdbStorage/DataEncryptionTest.php
+++ b/tests/inc/WpdbStorage/DataEncryptionTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\WpdbStorage;
 

--- a/tests/inc/WpdbStorage/DataEncryptionTest.php
+++ b/tests/inc/WpdbStorage/DataEncryptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\WpdbStorage;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/inc/WpdbStorage/DatasourceCrudTest.php
+++ b/tests/inc/WpdbStorage/DatasourceCrudTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace RemoteDataBlocks\Tests\WpdbStorage;
 

--- a/tests/inc/WpdbStorage/DatasourceCrudTest.php
+++ b/tests/inc/WpdbStorage/DatasourceCrudTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace RemoteDataBlocks\Tests\WpdbStorage;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/inc/bootstrap.php
+++ b/tests/inc/bootstrap.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 define( 'ABSPATH', __FILE__ );
 define( 'REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY', __DIR__ . '/../../' );

--- a/tests/inc/bootstrap.php
+++ b/tests/inc/bootstrap.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types = 1);
+
 define( 'ABSPATH', __FILE__ );
 define( 'REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY', __DIR__ . '/../../' );
 define( 'REMOTE_DATA_BLOCKS__UNIT_TEST', true );

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 function apply_filters( string $_filter, mixed $thing ): mixed {
 	return $thing;

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 function apply_filters( string $_filter, mixed $thing ): mixed {
 	return $thing;
 }


### PR DESCRIPTION
**tl;dr:** this makes type hinting work like you actually think it does.

In PHP, `declare(strict_types=1);` is a declaration that enables strict typing for a specific PHP file. This declaration affects how type checking is performed for function arguments and return values within that file. 

Without strict typing (default behavior):

1. PHP performs type juggling (automatic type conversion) when passing arguments to functions or returning values.
2. Allows for more flexible coding but can lead to unexpected results or hidden bugs.
3. Type hints are treated as suggestions rather than strict requirements.

With strict typing, we gain:

1. Better type safety: Strict typing provides stronger type checking, reducing the risk of type-related errors. With strict typing, type mismatches result in a `TypeError`, while without it, PHP attempts to convert types silently.
2. Code clarity: Strict typing requires function signatures more explicit about expected types.

