### PR TITLE
Update `withBlockBinding` filter strategy to override core

### DIFF
--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -24,7 +24,7 @@ class BlockBindings {
 	 */
 	public static function register_block_bindings(): void {
 		register_block_bindings_source( self::$binding_source, [
-			'label'              => __( 'Remote Field Binding', 'remote-data-blocks' ),
+			'label'              => __( 'Remote Data Blocks', 'remote-data-blocks' ),
 			'get_value_callback' => [ __CLASS__, 'get_value' ],
 			'uses_context'       => [ self::$context_name ],
 		] );

--- a/src/blocks/remote-data-container/filters/with-block-binding.tsx
+++ b/src/blocks/remote-data-container/filters/with-block-binding.tsx
@@ -1,5 +1,5 @@
 import { InspectorControls } from '@wordpress/block-editor';
-import { BlockEditProps } from '@wordpress/blocks';
+import { BlockConfiguration, BlockEditProps } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -134,3 +134,15 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 		);
 	};
 }, 'withBlockBinding' );
+
+/**
+ * Shim for the block binding HOC to be used with the `blocks.registerBlockType` filter.
+ */
+export function withBlockBindingShim(
+	settings: BlockConfiguration< RemoteDataInnerBlockAttributes >
+): BlockConfiguration< RemoteDataInnerBlockAttributes > {
+	return {
+		...settings,
+		edit: withBlockBinding( settings.edit ?? ( () => null ) ),
+	};
+}

--- a/src/blocks/remote-data-container/index.ts
+++ b/src/blocks/remote-data-container/index.ts
@@ -4,7 +4,7 @@ import { registerFormatType } from '@wordpress/rich-text';
 
 import { formatTypeSettings } from '@/blocks/remote-data-container/components/field-shortcode/field-shortcode';
 import { Edit } from '@/blocks/remote-data-container/edit';
-import { withBlockBinding } from '@/blocks/remote-data-container/filters/with-block-binding';
+import { withBlockBindingShim } from '@/blocks/remote-data-container/filters/with-block-binding';
 import { Save } from '@/blocks/remote-data-container/save';
 import { getBlocksConfig } from '@/utils/localized-block-data';
 import './style.scss';
@@ -26,5 +26,18 @@ Object.values( getBlocksConfig() ).forEach( blockConfig => {
 // Register the field shortcode format type.
 registerFormatType( 'remote-data-blocks/field-shortcode', formatTypeSettings );
 
-// Filter the BlockEdit component to inject our block binding logic.
-addFilter( 'editor.BlockEdit', 'remote-data-blocks/with-block-binding', withBlockBinding );
+/**
+ * Use a filter to wrap the block edit component with our block binding HOC.
+ * We are intentionally using the `blocks.registerBlockType` filter instead of
+ * `editor.BlockEdit` so that we can make sure our HOC is applied after any
+ * other HOCs from Core -- specifically this one, which injects the binding label
+ * as the attribute value:
+ *
+ * https://github.com/WordPress/gutenberg/blob/f56dbeb9257c19acf6fbd8b45d87ae8a841624da/packages/block-editor/src/hooks/use-bindings-attributes.js#L159
+ */
+addFilter(
+	'blocks.registerBlockType',
+	'remote-data-blocks/with-block-binding',
+	withBlockBindingShim,
+	5 // Ensure this runs before core filters
+);


### PR DESCRIPTION
Recent changes to Gutenberg in `trunk` broke our method of rendering remote data in the block editor. Core is preparing a public API that will allow custom block bindings to more easily do what we are doing manually. In its current state, however, it does not allow non-core code to participate and instead falls back to the binding label ("Remote Field Binding", in our case).

By adjusting our filter strategy, we can override this core behavior in a way that works for current and future releases.

- Move from `editor.BlockEdit` to `blocks.registerBlockType`.
- Use a higher filter priority (lower number) than Core.

This PR also updates the binding label for consistency (visible in sidebar block settings).