### PR TITLE
Allow "inner blocks" block pattern registration option

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -98,7 +98,7 @@ function register_your_block_pattern() {
     $block_name    = 'Your Custom Block';
     $block_pattern = file_get_contents( **DIR** . '/your-pattern.html' );
 
-    register_remote_data_block_pattern( $block_name, 'your-namespace/your-pattern', $block_pattern );
+    register_remote_data_block_pattern( $block_name, 'Pattern Title', $block_pattern );
 }
 add_action( 'init', 'YourNamespace\\register_your_block_pattern' );
 ```

--- a/example/airtable/elden-ring-map/register.php
+++ b/example/airtable/elden-ring-map/register.php
@@ -26,7 +26,7 @@ function register_airtable_elden_ring_map_block() {
 	register_remote_data_list_query( $block_name, $list_maps_query );
 
 	$block_pattern = file_get_contents( __DIR__ . '/inc/patterns/map-pattern.html' );
-	register_remote_data_block_pattern( $block_name, 'Elden Ring Map', $block_pattern );
+	register_remote_data_block_pattern( $block_name, 'Elden Ring Map', $block_pattern, [ 'role' => 'inner_blocks' ] );
 
 	$elden_ring_map_block_path = __DIR__ . '/build/blocks/elden-ring-map';
 	wp_register_style( 'leaflet-style', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', [], '1.9.4' );

--- a/example/airtable/elden-ring-map/register.php
+++ b/example/airtable/elden-ring-map/register.php
@@ -26,7 +26,7 @@ function register_airtable_elden_ring_map_block() {
 	register_remote_data_list_query( $block_name, $list_maps_query );
 
 	$block_pattern = file_get_contents( __DIR__ . '/inc/patterns/map-pattern.html' );
-	register_remote_data_block_pattern( $block_name, 'remote-data-blocks/elden-ring-map/pattern', $block_pattern );
+	register_remote_data_block_pattern( $block_name, 'Elden Ring Map', $block_pattern );
 
 	$elden_ring_map_block_path = __DIR__ . '/build/blocks/elden-ring-map';
 	wp_register_style( 'leaflet-style', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', [], '1.9.4' );

--- a/example/github/remote-data-blocks/register.php
+++ b/example/github/remote-data-blocks/register.php
@@ -24,11 +24,12 @@ function register_github_file_as_html_block() {
 
 	$block_pattern1 = file_get_contents( __DIR__ . '/inc/patterns/file-picker.html' );
 	$block_pattern2 = file_get_contents( __DIR__ . '/inc/patterns/file-render.html' );
-	register_remote_data_block_pattern( $block_name, 'remote-data-blocks/github-file-picker', $block_pattern1, [
-		'title'    => 'GitHub File Picker',
-		'inserter' => false,
+	register_remote_data_block_pattern( $block_name, 'GitHub File Picker', $block_pattern1, [
+		'properties' => [
+			'inserter' => false,
+		],
 	] );
-	register_remote_data_block_pattern( $block_name, 'remote-data-blocks/github-file-render', $block_pattern2, [ 'title' => 'GitHub File Render' ] );
+	register_remote_data_block_pattern( $block_name, 'GitHub File Render', $block_pattern2 );
 
 	$logger = LoggerManager::instance();
 	$logger->info( sprintf( 'Registered %s block (branch: %s)', $block_name, $branch ) );

--- a/example/shopify/register.php
+++ b/example/shopify/register.php
@@ -37,7 +37,7 @@ function register_shopify_block() {
 	ConfigRegistry::register_query( $block_name, new ShopifyRemoveFromCartMutation( $shopify_datasource ) );
 
 	$block_pattern = file_get_contents( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/inc/integrations/shopify/Patterns/product-teaser.html' );
-	register_remote_data_block_pattern( $block_name, 'remote-data-blocks/shopify-product-teaser', $block_pattern, [ 'title' => 'Shopify Product Teaser' ] );
+	register_remote_data_block_pattern( $block_name, 'Shopify Product Teaser', $block_pattern );
 
 	register_block_type( __DIR__ . '/build/blocks/shopify-cart' );
 	register_block_type( __DIR__ . '/build/blocks/shopify-cart-button' );

--- a/functions.php
+++ b/functions.php
@@ -59,12 +59,12 @@ function register_remote_data_search_query( string $block_name, QueryContextInte
  * Register a block pattern that can used with a remote data block.
  *
  * @param string $block_name       The block name.
- * @param string $pattern_name     The pattern name.
+ * @param string $pattern_title    The pattern title.
  * @param string $pattern_html     The pattern HTML.
  * @param array  $pattern_options  The pattern options.
  */
-function register_remote_data_block_pattern( string $block_name, string $pattern_name, string $pattern_html, array $pattern_options = [] ): void {
-	ConfigRegistry::register_block_pattern( $block_name, $pattern_name, $pattern_html, $pattern_options );
+function register_remote_data_block_pattern( string $block_name, string $pattern_title, string $pattern_html, array $pattern_options = [] ): void {
+	ConfigRegistry::register_block_pattern( $block_name, $pattern_title, $pattern_html, $pattern_options );
 }
 
 /**

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -51,11 +51,13 @@ class BlockRegistration {
 				];
 			}
 
+			// Create the localized data that will be used by our block editor script.
 			$remote_data_blocks_config[ $block_name ] = [
 				'availableBindings' => $available_bindings,
 				'loop'              => $config['loop'],
 				'name'              => $block_name,
 				'overrides'         => $overrides,
+				'patterns'          => $config['patterns'],
 				'selectors'         => $config['selectors'],
 				'settings'          => [
 					'category' => self::$block_category['slug'],
@@ -79,7 +81,8 @@ class BlockRegistration {
 			$scripts_to_localize[] = $block_type->editor_script_handles[0];
 
 			// Register a default pattern that simply displays the available data.
-			BlockPatterns::register_default_block_pattern( $block_name, $config['title'], $config['queries']['__DISPLAY__'] );
+			$default_pattern_name = BlockPatterns::register_default_block_pattern( $block_name, $config['title'], $config['queries']['__DISPLAY__'] );
+			$remote_data_blocks_config[ $block_name ]['patterns']['default'] = $default_pattern_name;
 		}
 
 		foreach ( array_unique( $scripts_to_localize ) as $script_handle ) {

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -36,6 +36,7 @@ class ConfigRegistry {
 			'description' => '',
 			'name'        => $block_name,
 			'loop'        => $options['loop'] ?? false,
+			'patterns'    => [],
 			'queries'     => [
 				'__DISPLAY__' => $display_query,
 			],

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -66,7 +66,7 @@ class ConfigRegistry {
 		self::register_block( $block_title, $display_query, [ 'loop' => true ] );
 	}
 
-	public static function register_block_pattern( string $block_title, string $pattern_name, string $pattern_content, array $pattern_options = [] ): void {
+	public static function register_block_pattern( string $block_title, string $pattern_title, string $pattern_content, array $pattern_options = [] ): void {
 		$block_name = ConfigStore::get_block_name( $block_title );
 		$config     = ConfigStore::get_configuration( $block_name );
 
@@ -78,20 +78,23 @@ class ConfigRegistry {
 		$parsed_blocks   = parse_blocks( $pattern_content );
 		$parsed_blocks   = BlockPatterns::add_block_arg_to_bindings( $block_name, $parsed_blocks );
 		$pattern_content = serialize_blocks( $parsed_blocks );
-		$pattern_options = array_merge(
+		$pattern_name    = 'remote-data-blocks/' . sanitize_title( $pattern_title );
+
+		// Create the pattern properties, allowing overrides via pattern options.
+		$pattern_properties = array_merge(
 			[
 				'blockTypes' => [ $block_name ],
 				'categories' => [ 'Remote Data' ],
 				'content'    => $pattern_content,
 				'inserter'   => true,
 				'source'     => 'plugin',
-				'title'      => $pattern_name,
+				'title'      => $pattern_title,
 			],
-			$pattern_options
+			$pattern_options['properties'] ?? []
 		);
 
 		// Register the pattern.
-		register_block_pattern( $pattern_name, $pattern_options );
+		register_block_pattern( $pattern_name, $pattern_properties );
 	}
 
 	public static function register_page( string $block_title, string $page_slug ): void {

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -95,6 +95,13 @@ class ConfigRegistry {
 
 		// Register the pattern.
 		register_block_pattern( $pattern_name, $pattern_properties );
+
+		// If the pattern role is specified and recognized, add it to the block configuration.
+		$recognized_roles = [ 'inner_blocks' ];
+		if ( isset( $pattern_options['role'] ) && in_array( $pattern_options['role'], $recognized_roles, true ) ) {
+			$config['patterns'][ $pattern_options['role'] ] = $pattern_name;
+			ConfigStore::set_configuration( $block_name, $config );
+		}
 	}
 
 	public static function register_page( string $block_title, string $page_slug ): void {

--- a/inc/Editor/BlockPatterns/templates/empty.html
+++ b/inc/Editor/BlockPatterns/templates/empty.html
@@ -1,0 +1,3 @@
+<!-- wp:paragraph -->
+<p>The query used by this Remote Data Block has no output variables, so there is no data available for display.</p>
+<!-- /wp:paragraph -->

--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -29,7 +29,7 @@ class ShopifyIntegration {
 
 		register_remote_data_block( $block_name, $shopify_get_product_query );
 		register_remote_data_search_query( $block_name, $shopify_search_products_query );
-		register_remote_data_block_pattern( $block_name, 'remote-data-blocks/shopify-product-teaser', $block_pattern, [ 'title' => 'Shopify Product Teaser' ] );
+		register_remote_data_block_pattern( $block_name, 'Shopify Product Teaser', $block_pattern );
 
 		LoggerManager::instance()->info( 'Registered Shopify block', [ 'block_name' => $block_name ] );
 	}

--- a/src/blocks/remote-data-container/components/item-list/item-list.tsx
+++ b/src/blocks/remote-data-container/components/item-list/item-list.tsx
@@ -17,12 +17,7 @@ interface ItemListProps {
 }
 
 export function ItemList( props: ItemListProps ) {
-	const { getPatternsByBlockTypes } = usePatterns( props.blockName, '' );
-
-	// Find the pattern that the plugin has registered that is guaranteed to work.
-	const pattern = getPatternsByBlockTypes( props.blockName ).find(
-		( { name } ) => `${ props.blockName }/pattern` === name
-	);
+	const { defaultPattern: pattern } = usePatterns( props.blockName );
 
 	if ( props.loading || ! pattern ) {
 		return <Spinner />;

--- a/src/blocks/remote-data-container/edit.tsx
+++ b/src/blocks/remote-data-container/edit.tsx
@@ -32,8 +32,8 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 		getInnerBlocks,
 		getSupportedPatterns,
 		insertPatternBlocks,
-		removeInnerBlocks,
-		setShowPatternSelection,
+		markReadyForInsertion,
+		resetReadyForInsertion,
 		showPatternSelection,
 	} = usePatterns( props.name, rootClientId );
 	const { execute } = useRemoteData( props.name, DISPLAY_QUERY_KEY );
@@ -61,7 +61,7 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 		}
 
 		if ( insertBlocks ) {
-			setShowPatternSelection( true );
+			markReadyForInsertion();
 		}
 	}
 
@@ -75,8 +75,7 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 
 	function resetRemoteData() {
 		props.setAttributes( { remoteData: undefined } );
-		removeInnerBlocks();
-		setShowPatternSelection( false );
+		resetReadyForInsertion();
 	}
 
 	useEffect( () => {
@@ -101,7 +100,7 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 				<div { ...blockProps }>
 					<PatternSelection
 						insertPatternBlocks={ insertPatternBlocks }
-						onCancel={ () => setShowPatternSelection( false ) }
+						onCancel={ resetReadyForInsertion }
 						supportedPatterns={ supportedPatterns }
 					/>
 				</div>

--- a/src/blocks/remote-data-container/hooks/use-patterns.ts
+++ b/src/blocks/remote-data-container/hooks/use-patterns.ts
@@ -51,8 +51,10 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string )
 		},
 		getPatternsByBlockTypes,
 		getSupportedPatterns: ( result?: Record< string, string > ): BlockPattern[] => {
-			const supportedPatterns = __experimentalGetAllowedPatterns( rootClientId ).filter( pattern =>
-				pattern.blocks.some( block => hasBlockBinding( block, remoteDataBlockName ) )
+			const supportedPatterns = __experimentalGetAllowedPatterns( rootClientId ).filter(
+				pattern =>
+					pattern.blockTypes?.includes( remoteDataBlockName ) ||
+					pattern.blocks.some( block => hasBlockBinding( block, remoteDataBlockName ) )
 			);
 
 			// If no result is provided, return the supported patterns as is.

--- a/tests/src/blocks/remote-data-container/filters/with-block-bindings.test.tsx
+++ b/tests/src/blocks/remote-data-container/filters/with-block-bindings.test.tsx
@@ -34,6 +34,7 @@ describe( 'withBlockBinding', () => {
 				loop: false,
 				name: 'test/block',
 				overrides: {},
+				patterns: { default: 'test/block/pattern' },
 				selectors: [],
 				settings: {
 					category: 'widget',

--- a/types/localized-block-data.d.ts
+++ b/types/localized-block-data.d.ts
@@ -19,6 +19,9 @@ interface BlockConfig {
 	loop: boolean;
 	name: string;
 	overrides: Record< string, InputVariableOverrides >;
+	patterns: {
+		default: string;
+	};
 	selectors: {
 		image_url?: string;
 		inputs: InputVariable[];

--- a/types/localized-block-data.d.ts
+++ b/types/localized-block-data.d.ts
@@ -21,6 +21,7 @@ interface BlockConfig {
 	overrides: Record< string, InputVariableOverrides >;
 	patterns: {
 		default: string;
+		inner_blocks?: string;
 	};
 	selectors: {
 		image_url?: string;

--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -28,6 +28,7 @@ declare module '@wordpress/block-editor' {
 	// Incomplete type for our use case.
 	interface BlockPattern {
 		blocks: BlockInstance< RemoteDataInnerBlockAttributes >[];
+		blockTypes?: string[];
 		id?: number;
 		name: string;
 		source: string;


### PR DESCRIPTION
This provides a fix for the missing map pattern raised by @jblz after https://github.com/Automattic/remote-data-blocks/pull/89, but goes further to address the use case of bypassing the pattern selection flow with a designated pattern.

The fix for restoring the pattern to the pattern selection modal is fairly narrow:

- [Include blockTypes in supportedPatterns logic](https://github.com/Automattic/remote-data-blocks/commit/895fb4ccb70c15b2297febe0ab1586bb291c3c01)

Beyond that, this PR does three things:

- We are already registering a "default" pattern that displays the data in a simple format. This allows us to be sure that there is always a pattern available (e.g., when we need to display items in a list for selection). Formalizing this a bit in the localized block config allows us to identify the default pattern without a kluge-y assumption (based on the format of the pattern name).
  - [Update BlockPatterns to always register a default pattern and return pattern name](https://github.com/Automattic/remote-data-blocks/commit/6405850f5f0636ba38dd61730e29460f4ede2783)
  - [Provide default pattern in localized remote data block config](https://github.com/Automattic/remote-data-blocks/commit/0cde3538b2d28e89f48a6b5196b9c2f083a5bfc4)
- Looking at example usage of `register_remote_data_block_pattern`, it's clear that pattern title should be a first-class argument. Updating the function signature makes the ergonomics better.
  - [Update register_remote_data_block_pattern signature to reflect usage](https://github.com/Automattic/remote-data-blocks/commit/58c8bddd4d30dbc269b161018df95db7496aba42)
- Finally, we can recognize a `role` option passed to `register_remote_data_block_pattern` that allows us to designate patterns for a specific use case. A `role` of `inner_blocks` means that the pattern should always be used as the inner blocks of a remote data block, thereby bypassing the pattern selection flow. (Please suggest better names! I avoided `default` here since "default pattern" already means something else.)
  - [Recognize role=inner_blocks pattern option](https://github.com/Automattic/remote-data-blocks/commit/e0ee8fcafc69c42b5b210d3d9a853a2c0ae826bb)
  - [Use config-provided patterns in usePatterns](https://github.com/Automattic/remote-data-blocks/commit/80e36bf27eeca6d7b9dd3ae7a9101c6da3dad2ee)