### PR TITLE
Properly read request body in WPRemoteRequestHandler

### DIFF
--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -45,7 +45,6 @@ class HttpClient {
 	 * @var array<string, mixed>
 	 */
 	private array $default_options = [
-		'timeout' => 3,
 		'headers' => [
 			'User-Agent' => 'WordPress Remote Data Blocks/1.0',
 		],

--- a/inc/HttpClient/WPRemoteRequestHandler.php
+++ b/inc/HttpClient/WPRemoteRequestHandler.php
@@ -31,7 +31,7 @@ class WPRemoteRequestHandler {
 			// Convert Guzzle request to arguments for wp_remote_request.
 			$url  = (string) $request->getUri();
 			$args = [
-				'body'        => $request->getBody()->getContents(),
+				'body'        => (string) $request->getBody(), // Stream has been read, let __toString() rewind and read it.
 				'headers'     => [],
 				'httpversion' => $options['httpversion'] ?? self::DEFAULT_HTTP_VERSION,
 				'method'      => $request->getMethod(),

--- a/inc/HttpClient/WPRemoteRequestHandler.php
+++ b/inc/HttpClient/WPRemoteRequestHandler.php
@@ -66,7 +66,8 @@ class WPRemoteRequestHandler {
 				new Response(
 					$response_code,
 					$response_headers,
-					$response_body
+					$response_body,
+					$args['httpversion'],
 				)
 			);
 		} catch ( Exception $e ) {

--- a/inc/HttpClient/WPRemoteRequestHandler.php
+++ b/inc/HttpClient/WPRemoteRequestHandler.php
@@ -3,7 +3,7 @@
 namespace RemoteDataBlocks\HttpClient;
 
 use Exception;
-use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;
@@ -62,7 +62,7 @@ class WPRemoteRequestHandler {
 			}
 
 			// Create a Guzzle-compatible promise response.
-			return Create::promiseFor(
+			return new FulfilledPromise(
 				new Response(
 					$response_code,
 					$response_headers,


### PR DESCRIPTION
Fixing a bug that led to empty request bodies ... which inexplicably led to request timeouts from Shopify's API.

Guzzle's implementation of `PSR7/Request` is not my favorite today. In middleware, `$request->getBody()->getContents()` will always return an empty string, because Guzzle has already `seek`ed through the stream and it doesn't `rewind`. Luckily, the `__toString()` implementation does `rewind`, so we can just cast to string instead. This is the only fix of real import here:

- [Properly read request body](https://github.com/Automattic/remote-data-blocks/commit/208e022a12373557dbd2f7965a8435b082f6b074)

Some minor tweaks:

- [Use FulfilledPromise instead of Create](https://github.com/Automattic/remote-data-blocks/commit/0a69eb2b0ba107330d792d12b19bcb585a9442b3) ... just cleaner
- [Add HTTP version to Response](https://github.com/Automattic/remote-data-blocks/commit/94d4e0019064c6a95a096c8b57f4af8caef51790) ... for completeness
- [Allow WPRemoteRequestHandler to set timeout](https://github.com/Automattic/remote-data-blocks/commit/6fb4c308dea9723edccca49e698889b3b404d43e) ... there were two competing "defaults"