### PR TITLE
Fix pre_update_option hook argument type

### DIFF
--- a/inc/PluginSettings/PluginSettings.php
+++ b/inc/PluginSettings/PluginSettings.php
@@ -4,6 +4,7 @@ namespace RemoteDataBlocks\PluginSettings;
 
 use RemoteDataBlocks\REST\DatasourceController;
 use RemoteDataBlocks\REST\AuthController;
+use RemoteDataBlocks\WpdbStorage\DatasourceCrud;
 use function wp_get_environment_type;
 use function wp_is_development_mode;
 
@@ -13,8 +14,8 @@ class PluginSettings {
 	public static function init(): void {
 		add_action( 'admin_menu', [ __CLASS__, 'add_options_page' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_settings_assets' ] );
-		add_action( 'pre_update_option_remote_data_blocks_config', [ __CLASS__, 'pre_update_option_remote_data_blocks_config' ], 10, 3 );
-		add_action( 'option_remote_data_blocks_config', [ __CLASS__, 'decrypt_option' ], 10, 3 );
+		add_action( 'pre_update_option_' . DatasourceCrud::CONFIG_OPTION_NAME, [ __CLASS__, 'encrypt_option' ], 10, 2 );
+		add_action( 'option_' . DatasourceCrud::CONFIG_OPTION_NAME, [ __CLASS__, 'decrypt_option' ], 10, 1 );
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_routes' ] );
 	}
 
@@ -138,7 +139,7 @@ class PluginSettings {
 		return 'development' === wp_get_environment_type() && wp_is_development_mode( 'plugin' );
 	}
 
-	public static function pre_update_option_remote_data_blocks_config( array $new_value, array $old_value ): string|array|bool {
+	public static function encrypt_option( array $new_value, string|array|bool $old_value ): string|array|bool {
 		$encryptor = new \RemoteDataBlocks\WpdbStorage\DataEncryption();
 
 		try {


### PR DESCRIPTION
Fixes a fatal error that occurs when a user attempts to configure a datasource for the first time. The `pre_update_option` hook fires even on initial save and the `$old_value` is `false` and not an array. With strict types enabled, this results in a fatal.

This also leverages the constant that defines the option name for consistency and renames the method for clarity.