### PR TITLE
Add playground and WP CLI npm scripts

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,3 +7,11 @@ Installing the [Query Monitor plugin](https://wordpress.org/plugins/query-monito
 ## Debugging
 
 The [local development environment](local-development.md) includes Xdebug for debugging PHP code and a Node.js debugging port for debugging block editor scripts.
+
+## Resetting config
+
+If you need to reset the Remote Data Blocks configuration in your local development environment, you can use WP-CLI to delete the configuration option. This will permananently delete all configuration values, including access tokens and API keys.
+
+```sh
+npm run wp-cli option delete remote_data_blocks_config
+```

--- a/package.json
+++ b/package.json
@@ -39,12 +39,15 @@
     "start:decoupled": "./bin/start decoupled",
     "start:monolith": "./bin/start monolith",
     "start:monolith-xdebug": "./bin/start monolith-xdebug",
+    "start:playground": "npx @wp-now/wp-now start --php=8.2",
+    "start:playground:reset": "npm run start:playground -- --reset",
     "stop": "./bin/stop",
     "test": "npm run test:php && npm run test:js",
     "test:php": "composer test",
     "test:php:coverage": "composer test-coverage",
     "test:js": "vitest --watch=false",
-    "test:js:coverage": "vitest --coverage --watch=false"
+    "test:js:coverage": "vitest --coverage --watch=false",
+    "wp-cli": "wp-env run cli -- wp"
   },
   "devDependencies": {
     "@automattic/eslint-plugin-wpvip": "0.13.0",


### PR DESCRIPTION
- Add npm script to run WP-CLI commands and document method to clear config
- Add npm scripts to run playground / `wp-now` locally