### PR TITLE
Add DatasourceCrud::get_by_slug

### DIFF
--- a/inc/Config/Datasource/HttpDatasource.php
+++ b/inc/Config/Datasource/HttpDatasource.php
@@ -8,6 +8,7 @@ use RemoteDataBlocks\Sanitization\Sanitizer;
 use RemoteDataBlocks\Sanitization\SanitizerInterface;
 use RemoteDataBlocks\Validation\Validator;
 use RemoteDataBlocks\Validation\ValidatorInterface;
+use RemoteDataBlocks\WpdbStorage\DatasourceCrud;
 use WP_Error;
 
 /**
@@ -53,6 +54,16 @@ abstract class HttpDatasource implements DatasourceInterface, HttpDatasourceInte
 		}
 
 		return $schema;
+	}
+
+	public static function from_slug( string $slug ): DatasourceInterface|WP_Error {
+		$config = DatasourceCrud::get_by_slug( $slug );
+
+		if ( ! $config ) {
+			return new WP_Error( 'data_source_not_found', __( 'Data source not found.', 'remote-data-blocks' ), [ 'status' => 404 ] );
+		}
+
+		return static::from_array( $config );
 	}
 
 	/**

--- a/inc/WpdbStorage/DatasourceCrud.php
+++ b/inc/WpdbStorage/DatasourceCrud.php
@@ -124,6 +124,28 @@ class DatasourceCrud {
 		return true;
 	}
 
+	/**
+	 * Get a data source by its slug.
+	 * 
+	 * The easiest way to think of the slug relative to data sources is it
+	 * provides a developer-friendly "contract" for the data source. The developer
+	 * can define the slug pre-emptively in their code and then customers can add it
+	 * when configuring specific data sources later.
+	 * 
+	 * This function naively returns the first data source it finds. In theory, that
+	 * should be the only one as we check for slug conflicts at present. In the future,
+	 * it's be good to holistically improve how those interactions work
+	 */
+	public static function get_by_slug( string $slug ): array|false {
+		$data_sources = self::get_data_sources();
+		foreach ( $data_sources as $source ) {
+			if ( $source['slug'] === $slug ) {
+				return $source;
+			}
+		}
+		return false;
+	}
+
 	private static function save_datasource( ArraySerializableInterface $datasource, array $datasource_configs ): bool {
 		$config = $datasource->to_array();
 		

--- a/tests/inc/WpdbStorage/DatasourceCrudTest.php
+++ b/tests/inc/WpdbStorage/DatasourceCrudTest.php
@@ -186,4 +186,31 @@ class DatasourceCrudTest extends TestCase {
 		$deleted_source = DatasourceCrud::get_item_by_uuid( DatasourceCrud::get_data_sources(), $source->to_array()['uuid'] );
 		$this->assertFalse( $deleted_source );
 	}
+
+	public function test_get_by_slug_with_existing_slug() {
+		DatasourceCrud::register_new_data_source([
+			'service'                => REMOTE_DATA_BLOCKS_AIRTABLE_SERVICE,
+			'service_schema_version' => 1,
+			'uuid'                   => wp_generate_uuid4(),
+			'access_token'           => 'token1',
+			'base'                   => [
+				'id'   => 'base_id1',
+				'name' => 'Base Name 1',
+			],
+			'tables'                 => [],
+			'display_name'           => 'Crud Test',
+			'slug'                   => 'existing-slug',
+		]);
+
+		$source = DatasourceCrud::get_by_slug( 'existing-slug' );
+		$this->assertIsArray( $source );
+		$this->assertSame( 'existing-slug', $source['slug'] );
+		$this->assertSame( 'token1', $source['access_token'] );
+		$this->assertSame( 'base_id1', $source['base']['id'] );
+	}
+
+	public function test_get_by_slug_with_non_existent_slug() {
+		$non_existent = DatasourceCrud::get_by_slug( 'non-existent-slug' );
+		$this->assertFalse( $non_existent );
+	}
 }


### PR DESCRIPTION
We've determined we want to support this in some form and, for release next week, this--leaning on `slug`s--is the clearest, simplest path.