### PR TITLE
de-duplicate data sources

### DIFF
--- a/inc/REST/DatasourceController.php
+++ b/inc/REST/DatasourceController.php
@@ -4,6 +4,7 @@ namespace RemoteDataBlocks\REST;
 
 use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;
 use RemoteDataBlocks\WpdbStorage\DatasourceCrud;
+use RemoteDataBlocks\Utils\ArrayUtils;
 use WP_REST_Controller;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -110,15 +111,30 @@ class DatasourceController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Retrieves a collection of items.
+	 * Retrieves a collection of unique data sources.
+	 *
+	 * This method compiles a comprehensive list of data sources by:
+	 * 1. Merging data sources from registered blocks and those configured in the settings page UI.
+	 * 2. Removing duplicates based on the 'slug' key.
+	 *
+	 * TEMPORARY: The deduplication process is necessary because:
+	 * - Some remote data blocks may use data sources configured in the settings page UI.
+	 * - Not all UI-configured data sources are registered as blocks and vice versa.
+	 * 
+	 * The deduplication is temporary fix and won't be required when we moved towards a single data sources store.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$code_configured_data_sources = ConfigStore::get_datasources_displayable();
 		$ui_configured_data_sources   = DatasourceCrud::get_data_sources_list();
-		return rest_ensure_response( array_merge( $code_configured_data_sources, $ui_configured_data_sources ) );
+		$data_sources_from_registered_blocks = ConfigStore::get_datasources_displayable();
+		$merged_data_sources = array_merge(
+			$ui_configured_data_sources,
+			$data_sources_from_registered_blocks,
+		);
+		$unique_data_sources = ArrayUtils::merge_duplicates_by_key( $merged_data_sources, 'slug' );
+		return rest_ensure_response( $unique_data_sources );
 	}
 
 	/**

--- a/inc/REST/DatasourceController.php
+++ b/inc/REST/DatasourceController.php
@@ -127,13 +127,13 @@ class DatasourceController extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$ui_configured_data_sources   = DatasourceCrud::get_data_sources_list();
+		$ui_configured_data_sources          = DatasourceCrud::get_data_sources_list();
 		$data_sources_from_registered_blocks = ConfigStore::get_datasources_displayable();
-		$merged_data_sources = array_merge(
+		$merged_data_sources                 = array_merge(
 			$ui_configured_data_sources,
 			$data_sources_from_registered_blocks,
 		);
-		$unique_data_sources = ArrayUtils::merge_duplicates_by_key( $merged_data_sources, 'slug' );
+		$unique_data_sources                 = ArrayUtils::merge_duplicates_by_key( $merged_data_sources, 'slug' );
 		return rest_ensure_response( $unique_data_sources );
 	}
 

--- a/inc/Utils/ArrayUtils.php
+++ b/inc/Utils/ArrayUtils.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Utils;
+
+class ArrayUtils {
+	/**
+	 * Merges duplicate values from an array of arrays based on the specified key.
+	 * In case of duplicate values for same key in the inner array,
+	 * the value from the first occurence has priority.
+	 *
+	 * @param array  $array The array of arrays to merge duplicates from.
+	 * @param string $key   The key to merge duplicates based on.
+	 * @return array The array with duplicates merged.
+	 */
+	public static function merge_duplicates_by_key( array $array, string $key ): array {
+		$seen   = [];
+		$result = [];
+
+		foreach ( $array as $item ) {
+			if ( ! isset( $item[ $key ] ) ) {
+				continue;
+			}
+			$key_value = $item[ $key ];
+			if ( ! isset( $seen[ $key_value ] ) ) {
+				$seen[ $key_value ] = true;
+				$result[]           = $item;
+			} else {
+				// Merge the item with the existing item in the result array.
+				$result[ $key_value ] = array_merge( $item, $result[ $key_value ] );
+			}
+		}
+
+		return $result;
+	}
+}

--- a/tests/inc/Utils/ArrayUtilsTest.php
+++ b/tests/inc/Utils/ArrayUtilsTest.php
@@ -8,24 +8,45 @@ use RemoteDataBlocks\Utils\ArrayUtils;
 class ArrayUtilsTest extends TestCase {
 	public function test_merge_duplicates_by_key() {
 		$array = [
-			[ 'id' => 1, 'name' => 'John' ],
-			[ 'id' => 2, 'name' => 'Jane' ],
-			[ 'id' => 1, 'name' => 'John' ],
+			[
+				'id'   => 1,
+				'name' => 'John',
+			],
+			[
+				'id'   => 2,
+				'name' => 'Jane',
+			],
+			[
+				'id'   => 1,
+				'name' => 'John',
+			],
 		];
 
 		$result = ArrayUtils::merge_duplicates_by_key( $array, 'id' );
 
 		$this->assertCount( 2, $result );
 		$this->assertSame( [
-			[ 'id' => 1, 'name' => 'John' ],
-			[ 'id' => 2, 'name' => 'Jane' ],
+			[
+				'id'   => 1,
+				'name' => 'John',
+			],
+			[
+				'id'   => 2,
+				'name' => 'Jane',
+			],
 		], $result );
 	}
 
 	public function test_merge_duplicates_by_key_with_no_duplicates() {
 		$array = [
-			[ 'id' => 1, 'name' => 'John' ],
-			[ 'id' => 2, 'name' => 'Jane' ],
+			[
+				'id'   => 1,
+				'name' => 'John',
+			],
+			[
+				'id'   => 2,
+				'name' => 'Jane',
+			],
 		];
 
 		$result = ArrayUtils::merge_duplicates_by_key( $array, 'id' );
@@ -36,17 +57,37 @@ class ArrayUtilsTest extends TestCase {
 
 	public function test_merge_duplicates_by_key_with_duplicate_inner_array_values() {
 		$array = [
-			[ 'id' => 1, 'name' => 'John', 'age' => 20 ],
-			[ 'id' => 2, 'name' => 'Jane', 'age' => 25 ],
-			[ 'id' => 1, 'name' => 'William', 'age' => 20 ],
+			[
+				'id'   => 1,
+				'name' => 'John',
+				'age'  => 20,
+			],
+			[
+				'id'   => 2,
+				'name' => 'Jane',
+				'age'  => 25,
+			],
+			[
+				'id'   => 1,
+				'name' => 'William',
+				'age'  => 20,
+			],
 		];
 
 		$result = ArrayUtils::merge_duplicates_by_key( $array, 'id' );
 
 		$this->assertCount( 2, $result );
 		$this->assertSame( [
-			[ 'id' => 1, 'name' => 'John', 'age' => 20 ],
-			[ 'id' => 2, 'name' => 'Jane', 'age' => 25 ],
+			[
+				'id'   => 1,
+				'name' => 'John',
+				'age'  => 20,
+			],
+			[
+				'id'   => 2,
+				'name' => 'Jane',
+				'age'  => 25,
+			],
 		], $result );
 	}
 }

--- a/tests/inc/Utils/ArrayUtilsTest.php
+++ b/tests/inc/Utils/ArrayUtilsTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use RemoteDataBlocks\Utils\ArrayUtils;
+
+class ArrayUtilsTest extends TestCase {
+	public function test_merge_duplicates_by_key() {
+		$array = [
+			[ 'id' => 1, 'name' => 'John' ],
+			[ 'id' => 2, 'name' => 'Jane' ],
+			[ 'id' => 1, 'name' => 'John' ],
+		];
+
+		$result = ArrayUtils::merge_duplicates_by_key( $array, 'id' );
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( [
+			[ 'id' => 1, 'name' => 'John' ],
+			[ 'id' => 2, 'name' => 'Jane' ],
+		], $result );
+	}
+
+	public function test_merge_duplicates_by_key_with_no_duplicates() {
+		$array = [
+			[ 'id' => 1, 'name' => 'John' ],
+			[ 'id' => 2, 'name' => 'Jane' ],
+		];
+
+		$result = ArrayUtils::merge_duplicates_by_key( $array, 'id' );
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( $array, $result );
+	}
+
+	public function test_merge_duplicates_by_key_with_duplicate_inner_array_values() {
+		$array = [
+			[ 'id' => 1, 'name' => 'John', 'age' => 20 ],
+			[ 'id' => 2, 'name' => 'Jane', 'age' => 25 ],
+			[ 'id' => 1, 'name' => 'William', 'age' => 20 ],
+		];
+
+		$result = ArrayUtils::merge_duplicates_by_key( $array, 'id' );
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( [
+			[ 'id' => 1, 'name' => 'John', 'age' => 20 ],
+			[ 'id' => 2, 'name' => 'Jane', 'age' => 25 ],
+		], $result );
+	}
+}


### PR DESCRIPTION
# Description

The data sources de-duplication temporary fix pulled from #118.

The deduplication process is necessary because:
- Some remote data blocks may use data sources configured in the settings page UI.
- Not all UI-configured data sources are registered as blocks and vice versa.

The deduplication is a temporary fix and won't be required when we moved towards a single data sources store.
