### PR TITLE
Update "extending" docs with additional detail, hooks, and links

### DIFF
--- a/docs/extending/block-patterns.md
+++ b/docs/extending/block-patterns.md
@@ -1,0 +1,28 @@
+# Block patterns
+
+Patterns allow you to represent your remote data if different ways. By default, the plugin registers a unstyled block pattern that you can use out of the box. You can create additional patterns in the WordPress Dashboard or programmatically using the `register_remote_data_block_pattern` function.
+
+Example:
+
+```html
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+	<!-- wp:heading {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"field":"title"}}}}} -->
+	<h2 class="wp-block-heading"></h2>
+	<!-- /wp:heading -->
+	<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"field":"description"}}}}} -->
+	<p></p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->
+```
+
+```php
+function register_your_block_pattern() {
+    $block_name    = 'Your Custom Block';
+    $block_pattern = file_get_contents( '/path/to/your-pattern.html' );
+
+    register_remote_data_block_pattern( $block_name, 'Pattern Title', $block_pattern );
+}
+add_action( 'init', 'YourNamespace\\register_your_block_pattern', 10, 0 );
+```

--- a/docs/extending/block-registration.md
+++ b/docs/extending/block-registration.md
@@ -1,0 +1,14 @@
+# Block registration
+
+Use the `register_remote_data_block` function to register your block and associate it with your query and data source.
+
+```php
+function register_your_custom_block() {
+    $block_name       = 'Your Custom Block';
+    $your_data_source = new YourCustomDataSource();
+    $your_query       = new YourCustomQuery( $your_data_source );
+
+    register_remote_data_block( $block_name, $your_query );
+}
+add_action( 'init', 'YourNamespace\\register_your_custom_block', 10, 0 );
+```

--- a/docs/extending/hooks.md
+++ b/docs/extending/hooks.md
@@ -1,0 +1,84 @@
+# Hooks
+
+## Actions
+
+### wpcomvip_log
+
+If you want to send debugging information to another source besides [Query Monitor](../troubleshooting.md#query-monitor), use the `wpcomvip_log` action.
+
+```php
+function custom_log( string $namespace, string $level, string $message, array $context ): void {
+    // Send the log to a custom destination.
+}
+add_action( 'wpcomvip_log', 'custom_log', 10, 4 );
+```
+
+## Filters
+
+### wpcomvip_log_to_query_monitor
+
+Filter whether to log a message to Query Monitor (default: `true`).
+
+```php
+add_filter( 'wpcomvip_log_to_query_monitor', '__return_false' );
+```
+
+### remote_data_blocks_register_example_block
+
+Filter whether to register the included example API block ("Conference Event") (default: `true`).
+
+```php
+add_filter( 'remote_data_blocks_register_example_block', '__return false' );
+```
+
+### remote_data_blocks_allowed_url_schemes
+
+Filter the allowed URL schemes for this request. By default, only HTTPS is allowed, but it might be useful to relax this restriction in local environments.
+
+```php
+function custom_allowed_url_schemes( array $allowed_url_schemes, HttpQueryContext $query_context ): array {
+	// Modify the allowed URL schemes.
+	return $allowed_url_schemes;
+}
+add_filter( 'remote_data_blocks_allowed_url_schemes', 'custom_allowed_url_schemes', 10, 2 );
+```
+
+### remote_data_blocks_request_details
+
+Filter the request details (method, options, url) before the HTTP request is dispatched.
+
+```php
+function custom_request_details( array $request_details, HttpQueryContext $query_context, array $input_variables ): array {
+	// Modify the request details.
+	return $request_details;
+}
+add_filter( 'remote_data_blocks_request_details', 'custom_request_details', 10, 3 );
+```
+
+### remote_data_blocks_query_response_metadata
+
+Filter the query response metadata, which are available as bindings for field shortcodes. In most cases, it is better to provide a custom query class and override the `get_response_metadata` method but this filter is available in case that is not possible.
+
+```php
+function custom_query_response_metadata( array $metadata, HttpQueryContext $query_context, array $input_variables ): array {
+	// Modify the response metadata.
+	return $metadata;
+}
+add_filter( 'remote_data_blocks_query_response_metadata', 'custom_query_response_metadata', 10, 3 );
+```
+
+### remote_data_blocks_bypass_cache
+
+Filter to bypass the cache for a specific request (default: `false`).
+
+```php
+add_filter( 'remote_data_blocks_bypass_cache', '__return_true' );
+```
+
+### remote_data_blocks_http_client_retry_delay
+
+### remote_data_blocks_http_client_retry_on_exception
+
+### remote_data_blocks_http_client_retry_decider
+
+Filter the HTTP retry logic when an HTTP request fails.


### PR DESCRIPTION
Update "extending" docs with additional detail, hooks, and links:

- Break out detailed info into new pages (block registration, block patterns)
- Add documentation for actions and filters
- Add additional detail and rationale for extending use cases