### PR TITLE
Improve logger with better stack trace, source context

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,6 +6,9 @@ This plugin provides a [local development environment](local-development.md) wit
 
 When the [Query Monitor plugin](https://wordpress.org/plugins/query-monitor/) is installed and activated, Remote Data Blocks will output debugging information to the Query Monitor "Logs" panel, including error details, stack traces, query execution details, and cache hit/miss status.
 
+> [!TIP]
+> By default, the block editor is rendered in "Fullscreen mode" which hides the Admin Bar and Query Monitor. Open the three-dot menu in the top-right corner and toggle off "Fullscreen mode", or press `⇧⌥⌘F`.
+
 The provided local development environment includes Query Monitor by default. You can also install it in non-local environments, but be aware that it may expose sensitive information in production environments.
 
 ## Debugging

--- a/inc/Logging/Logger.php
+++ b/inc/Logging/Logger.php
@@ -5,6 +5,7 @@ namespace RemoteDataBlocks\Logging;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
 use Stringable;
+use function add_filter;
 use function apply_filters;
 use function do_action;
 
@@ -15,6 +16,11 @@ defined( 'ABSPATH' ) || exit();
  * Composer package and used by other WordPress VIP plugins.
  */
 class Logger extends AbstractLogger {
+	/**
+	 * Whether the factory has have been initialized. Done automatically on first use.
+	 */
+	private static bool $initialized = false;
+
 	/**
 	 * We use the factory pattern to provide access to namespaced instances.
 	 *
@@ -59,9 +65,8 @@ class Logger extends AbstractLogger {
 		$this->log_level = apply_filters( 'wpcomvip_log_level', $default_log_level );
 
 		// If an invalid log level is provided, revert to the default.
-		if ( ! isset( $this->log_levels[ $this->log_level ] ) ) {
+		if ( ! $this->validate_log_level( $this->log_level, 'wpcomvip_log_level filter' ) ) {
 			$this->log_level = $default_log_level;
-			$this->log( LogLevel::ERROR, 'Invalid log level provided to "wpcomvip_log_level" filter.', [ 'level' => $this->log_level ] );
 		}
 	}
 
@@ -71,11 +76,31 @@ class Logger extends AbstractLogger {
 	 * @param string $namespace Optional namespace for the logger.
 	 */
 	public static function create( string $namespace = 'default' ): self {
+		self::init();
+
 		if ( ! isset( self::$instances[ $namespace ] ) ) {
 			self::$instances[ $namespace ] = new self( $namespace );
 		}
 
 		return self::$instances[ $namespace ];
+	}
+
+	public static function init(): void {
+		if ( self::$initialized ) {
+			return;
+		}
+
+		self::$initialized = true;
+
+		// Filter logger classes out of the stack traces. Using a static closure
+		// keeps the filter from being added to the stack.
+		add_filter( 'qm/trace/ignore_class', static function ( array $classes ): array {
+			return array_merge( $classes, [
+				AbstractLogger::class => true,
+				Logger::class         => true,
+				LoggerManager::class  => true,
+			] );
+		}, 10, 1 );
 	}
 
 	/**
@@ -96,6 +121,9 @@ class Logger extends AbstractLogger {
 	 * PSR log implementation.
 	 */
 	public function log( mixed $level, Stringable|string $message, array $context = [] ): void {
+		$level   = strval( $level );
+		$message = strval( $message );
+
 		if ( ! $this->should_log( $level ) ) {
 			return;
 		}
@@ -109,19 +137,27 @@ class Logger extends AbstractLogger {
 		 * @param string $message   The log message.
 		 * @param array  $context   Additional context for the log message.
 		 */
-		do_action( 'wpcomvip_log', $this->namespace, strval( $level ), strval( $message ), $context );
+		do_action( 'wpcomvip_log', $this->namespace, $level, $message, $context );
+
+		// Prefix with a "source" name to help identify the source of the log message.
+		if ( isset( $context['source'] ) ) {
+			$message = sprintf( '[%s] %s', $context['source'], $message );
+			unset( $context['source'] );
+		}
 
 		$this->log_to_query_monitor( $level, $message, $context );
 	}
 
-	private function log_to_query_monitor( mixed $level, string $message, array $context = [] ): void {
+	private function log_to_query_monitor( string $level, string $message, array $context = [] ): void {
 		/**
 		 * Filter to determine if a message should be logged to Query Monitor.
 		 *
 		 * @param bool   $should_log_to_query_monitor Whether the message should be logged to Query Monitor.
 		 * @param string $level                       The log level.
+		 * @param string $message                     The log message.
+		 * @param array  $context                     Additional context for the log message.
 		 */
-		$should_log_to_query_monitor = apply_filters( 'wpcomvip_log_to_query_monitor', true, $level );
+		$should_log_to_query_monitor = apply_filters( 'wpcomvip_log_to_query_monitor', true, $level, $message, $context );
 
 		if ( ! $should_log_to_query_monitor ) {
 			return;
@@ -137,12 +173,26 @@ class Logger extends AbstractLogger {
 	/**
 	 * Determine if a message should be logged based on the log level.
 	 */
-	private function should_log( mixed $level ): bool {
-		if ( ! isset( $this->log_levels[ $level ] ) || ! is_string( $level ) ) {
-			$this->log( LogLevel::ERROR, 'Invalid log level provided to logger.', [ 'level' => $level ] );
+	private function should_log( string $level ): bool {
+		if ( ! $this->validate_log_level( $level, 'log method' ) ) {
 			return false;
 		}
 
 		return $this->is_log_level_higher( $level, $this->log_level );
+	}
+
+	/**
+	 * Validate that the provided log level is a valid PSR log level.
+	 *
+	 * @param string $level  The log level to validate.
+	 * @param string $caller A description of the code path that is validating the log level.
+	 */
+	private function validate_log_level( string $level, string $caller ): bool {
+		if ( ! isset( $this->log_levels[ $level ] ) ) {
+			$this->log( LogLevel::ERROR, sprintf( 'Invalid log level provided to %s, must match a Psr\\Log\\LogLevel class constant.', $caller ) );
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -4,7 +4,8 @@ function apply_filters( string $_filter, mixed $thing ): mixed {
 	return $thing;
 }
 
-function add_action( string $_filter, mixed ...$_args ): void {}
+function add_action( string $_action, mixed ...$_args ): void {}
+function add_filter( string $_filter, mixed ...$_args ): void {}
 
 $GLOBALS['__wordpress_done_actions'] = [];
 function do_action( string $action, mixed ...$args ): void {


### PR DESCRIPTION
- Ignore Logging classes in stack traces, which makes stack trace much more immediately useful even on its first line:

  <img width="424" alt="Screenshot 2024-10-08 at 17 52 09" src="https://github.com/user-attachments/assets/35941495-6560-4acb-9b2c-108c75a030a7">

- When present, use a `source` context property as a message prefix in brackets. This has not been implemented anywhere, but is available:

   <img width="622" alt="Screenshot 2024-10-08 at 17 53 34" src="https://github.com/user-attachments/assets/136840bf-5b0b-4ecd-bd0c-59e1f6a3c43a">
