### PR TITLE
Fix example theme styling

### DIFF
--- a/example/airtable/events/register.php
+++ b/example/airtable/events/register.php
@@ -18,7 +18,7 @@ function register_airtable_events_block() {
 	register_remote_data_block( $block_name, $airtable_get_event_query );
 	register_remote_data_list_query( $block_name, $airtable_list_events_query );
 	register_remote_data_loop_block( 'Conference Event List', $airtable_list_events_query );
-	register_remote_data_page( $block_name, 'airtable-event' );
+	register_remote_data_page( $block_name, 'conference-event' );
 }
 
 add_action( 'init', __NAMESPACE__ . '\\register_airtable_events_block' );

--- a/example/theme/theme.json
+++ b/example/theme/theme.json
@@ -3,7 +3,7 @@
   "version": 3,
   "settings": {
     "blocks": {
-      "remote-data-blocks/airtable-event": {
+      "remote-data-blocks/conference-event": {
         "custom": {
           "remote-data-blocks": {}
         }
@@ -13,7 +13,7 @@
   "styles": {
     "elements": {},
     "blocks": {
-      "remote-data-blocks/airtable-event": {
+      "remote-data-blocks/conference-event": {
         "color": {
           "background": "#e9c9f9",
           "text": "#290939"


### PR DESCRIPTION
When we renamed `airtable-event` => `conference-event`, we missed a few string updates in our example theme `theme.json`