### PR TITLE
Fix query input overrides

### DIFF
--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -42,25 +42,26 @@ class BlockRegistration {
 				return isset( $input_var['overrides'] );
 			} );
 
-			$input_vars_with_overrides = array_map( function ( $name, $input_var ) {
-				$input_var['overrides'] = array_map( function ( $override ) use ( $name ) {
-					$display = '';
-					switch ( $override['type'] ) {
-						case 'query_var':
-							$display = sprintf( '?%s={%s}', $override['target'], $name );
-							break;
-						case 'url':
-							$display = sprintf( '/%s/{%s}', $override['target'], $name );
-							break;
-					}
+			$formatted_overrides = [];
+			foreach ( $input_vars_with_overrides as $name => $input_var ) {
+				$formatted_overrides[ $name ] = array_merge( $input_var, [
+					'overrides' => array_map( function ( $override ) use ( $name ) {
+						$display = '';
+						switch ( $override['type'] ) {
+							case 'query_var':
+								$display = sprintf( '?%s={%s}', $override['target'], $name );
+								break;
+							case 'url':
+								$display = sprintf( '/%s/{%s}', $override['target'], $name );
+								break;
+						}
 
-					$override['display'] = $override['display'] ?? $display;
+						$override['display'] = $override['display'] ?? $display;
 
-					return $override;
-				}, $input_var['overrides'] );
-
-				return $input_var;
-			}, array_keys( $input_vars_with_overrides ), $input_vars_with_overrides );
+						return $override;
+					}, $input_var['overrides'] ),
+				] );
+			}
 
 			// Set available bindings from the display query output mappings.
 			$available_bindings = [];
@@ -76,7 +77,7 @@ class BlockRegistration {
 				'availableBindings' => $available_bindings,
 				'loop'              => $config['loop'],
 				'name'              => $block_name,
-				'overrides'         => $input_vars_with_overrides,
+				'overrides'         => $formatted_overrides,
 				'patterns'          => $config['patterns'],
 				'selectors'         => $config['selectors'],
 				'settings'          => [

--- a/src/blocks/remote-data-container/components/panels/overrides-panel.tsx
+++ b/src/blocks/remote-data-container/components/panels/overrides-panel.tsx
@@ -31,17 +31,17 @@ export function OverridesPanel( props: OverridesPanelProps ) {
 
 	function updateOverrides( inputVar: string, index: number ) {
 		const overrides = availableOverrides[ inputVar ]?.overrides[ index ];
+		const copyOfQueryInputOverrides = { ...remoteData.queryInputOverrides };
 
 		if ( ! overrides || index === -1 ) {
-			return;
+			delete copyOfQueryInputOverrides?.[ inputVar ];
+		} else {
+			Object.assign( copyOfQueryInputOverrides, { [ inputVar ]: overrides } );
 		}
 
 		updateRemoteData( {
 			...remoteData,
-			queryInputOverrides: {
-				...( remoteData.queryInputOverrides ?? {} ),
-				[ inputVar ]: overrides,
-			},
+			queryInputOverrides: copyOfQueryInputOverrides,
 		} );
 	}
 

--- a/src/blocks/remote-data-container/components/panels/overrides-panel.tsx
+++ b/src/blocks/remote-data-container/components/panels/overrides-panel.tsx
@@ -32,7 +32,7 @@ export function OverridesPanel( props: OverridesPanelProps ) {
 	function updateOverrides( inputVar: string, index: number ) {
 		const overrides = availableOverrides[ inputVar ]?.overrides[ index ];
 
-		if ( ! overrides ) {
+		if ( ! overrides || index === -1 ) {
 			return;
 		}
 
@@ -58,7 +58,7 @@ export function OverridesPanel( props: OverridesPanelProps ) {
 					key={ key }
 					label={ value.name }
 					options={ [
-						{ label: 'Choose an override', value: '' },
+						{ label: 'Choose an override', value: '-1' },
 						...value.overrides.map( ( override, index ) => ( {
 							label: override.display,
 							value: index.toString(),

--- a/src/blocks/remote-data-container/edit.tsx
+++ b/src/blocks/remote-data-container/edit.tsx
@@ -43,7 +43,10 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 		execute( input, true )
 			.then( remoteData => {
 				if ( remoteData ) {
-					updateRemoteData( remoteData, insertBlocks );
+					updateRemoteData(
+						{ queryInputOverrides: props.attributes.remoteData.queryInputOverrides, ...remoteData },
+						insertBlocks
+					);
 				}
 			} )
 			.catch( () => {} )


### PR DESCRIPTION
Fix query input overrides to prevent them from being removed when data is updated. Still need to allow the selection to be unselected, but this makes things work as expected.