### PR TITLE
Fix error on selecting remote data

### DIFF
--- a/src/blocks/remote-data-container/edit.tsx
+++ b/src/blocks/remote-data-container/edit.tsx
@@ -44,7 +44,10 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 			.then( remoteData => {
 				if ( remoteData ) {
 					updateRemoteData(
-						{ queryInputOverrides: props.attributes.remoteData.queryInputOverrides, ...remoteData },
+						{
+							queryInputOverrides: props.attributes.remoteData?.queryInputOverrides,
+							...remoteData,
+						},
 						insertBlocks
 					);
 				}


### PR DESCRIPTION
One character (plus whitespace) fix. On some renders, `remoteDataBlocks` attribute is `undefined`. This deserves further scrutiny, because It shouldn't be. If it can be undefined, we should update the types accordingly, but I suspect that we are not providing a default value somewhere.