### PR TITLE
remoteData attribute is, in fact, optional

### DIFF
--- a/src/blocks/remote-data-container/components/field-shortcode/select-field-popover.tsx
+++ b/src/blocks/remote-data-container/components/field-shortcode/select-field-popover.tsx
@@ -43,10 +43,10 @@ export function FieldShortcodeSelectFieldPopover( props: FieldShortcodeSelectFie
 				</CardHeader>
 				<CardBody>
 					<FieldShortcodeSelectField
-						blockName={ props.fieldSelection.remoteData.blockName }
+						blockName={ props.fieldSelection.remoteData?.blockName ?? 'Remote Data Block' }
 						fieldType={ props.fieldSelection.type ?? 'field' }
 						onSelectField={ props.onSelectField }
-						queryInput={ props.fieldSelection.remoteData.queryInput }
+						queryInput={ props.fieldSelection.remoteData?.queryInput ?? {} }
 						selectedField={ props.fieldSelection.selectedField }
 					/>
 				</CardBody>

--- a/src/utils/block-binding.ts
+++ b/src/utils/block-binding.ts
@@ -97,7 +97,7 @@ export function hasBlockBinding(
 	);
 }
 
-export function hasRemoteDataChanged( one: RemoteData, two: RemoteData ): boolean {
+export function hasRemoteDataChanged( one?: RemoteData, two?: RemoteData ): boolean {
 	if ( ! one || ! two ) {
 		return true;
 	}

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -25,7 +25,7 @@ interface RemoteData {
 }
 
 interface RemoteDataBlockAttributes {
-	remoteData: RemoteData;
+	remoteData?: RemoteData;
 }
 
 interface FieldSelection extends RemoteDataBlockAttributes {


### PR DESCRIPTION
After investigating #176 a bit more, it's clear that the attribute can be missing before the block is configured, so we should update the type and make necessary adjustments.