### PR TITLE
Improve use of WP Playground CORS proxy

### DIFF
--- a/blueprint.local.json
+++ b/blueprint.local.json
@@ -24,11 +24,17 @@
       }
     },
     {
+      "step": "defineWpConfigConsts",
+      "consts": {
+        "USE_PLAYGROUND_CORS_PROXY": false
+      }
+    },
+    {
       "step": "installPlugin",
       "options": {
         "activate": true
       },
-      "pluginData": {
+      "pluginZipFile": {
         "resource": "wordpress.org/plugins",
         "slug": "query-monitor"
       }

--- a/inc/HttpClient/WPRemoteRequestHandler.php
+++ b/inc/HttpClient/WPRemoteRequestHandler.php
@@ -32,8 +32,14 @@ class WPRemoteRequestHandler {
 			$url = (string) $request->getUri();
 
 			// If we are running on WordPress Playground, use the provided CORS proxy.
-			if ( defined( 'USE_PLAYGROUND_CORS_PROXY' ) && USE_PLAYGROUND_CORS_PROXY ) {
-				$url = 'https://playground.wordpress.net/cors-proxy.php?' . $url;
+			if ( defined( 'USE_PLAYGROUND_CORS_PROXY' ) && true === USE_PLAYGROUND_CORS_PROXY ) {
+				$new_uri = $request->getUri()
+					->withHost( 'playground.wordpress.net' )
+					->withScheme( 'https' )
+					->withPath( '/cors-proxy.php' )
+					->withQuery( $url );
+				$request = $request->withUri( $new_uri );
+				$url     = (string) $new_uri;
 			}
 
 			$args = [


### PR DESCRIPTION
This fixes a bug that dispatched requests to the CORS proxy with incorrect `Host` header, but most requests will still fail since the CORS proxy strips `Authorization` and `Cookie` headers. Working the Playground team to resolve.