### PR TITLE
Conditionally stop WordPress in trap

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -23,7 +23,12 @@ cleanup() {
     echo ""
     echo "✊ Caught SIG signal. Stopping..."
 
-    npm run -s dev:stop
+    printf "Stop WordPress? (y/n) "
+    read -r answer
+    if [ "$answer" != "${answer#[Yy]}" ]; then
+        npm run -s dev:stop
+    fi
+
     exit 0
 }
 


### PR DESCRIPTION
The SIGINT trap works well, but often you don't need / want to stop _both_ the dev server and the `wp-env` environment. Often, you just want to stop the dev server so you can restart it (i.e., after a type change that hot reloader does not pick up). This provides a y/n prompt to ask whether to stop WordPress.