### PR TITLE
Fix pattern bindings missing in WordPress 6.7

### DIFF
--- a/remote-data-blocks.php
+++ b/remote-data-blocks.php
@@ -8,7 +8,7 @@
  * Author URI: https://wpvip.com
  * Text Domain: remote-data-blocks
  * Version: 0.2.7
- * Requires at least: 6.6
+ * Requires at least: 6.7
  * Requires PHP: 8.1
  */
 

--- a/src/blocks/remote-data-container/index.ts
+++ b/src/blocks/remote-data-container/index.ts
@@ -1,4 +1,5 @@
-import { registerBlockType } from '@wordpress/blocks';
+// @ts-expect-error -- Temporary registerBlockBindingsSource type error workaround for WordPress 6.7
+import { registerBlockType, registerBlockBindingsSource } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 import { registerFormatType } from '@wordpress/rich-text';
 
@@ -45,3 +46,12 @@ addFilter(
 	withBlockBindingShim,
 	5 // Ensure this runs before core filters
 );
+
+registerBlockBindingsSource( {
+	name: 'remote-data/binding',
+	label: 'Remote Data Binding',
+	usesContext: [ 'remote-data-blocks/remoteData' ],
+	getValues( { select, clientId, context, bindings }: any ) {
+		return {};
+	},
+} );

--- a/src/blocks/remote-data-container/index.ts
+++ b/src/blocks/remote-data-container/index.ts
@@ -47,10 +47,12 @@ addFilter(
 	5 // Ensure this runs before core filters
 );
 
+// eslint-disable-next-line -- Temporary registerBlockBindingsSource type error workaround for WordPress 6.7
 registerBlockBindingsSource( {
 	name: 'remote-data/binding',
 	label: 'Remote Data Binding',
 	usesContext: [ 'remote-data-blocks/remoteData' ],
+	// eslint-disable-next-line -- Temporary registerBlockBindingsSource type error workaround for WordPress 6.7
 	getValues( { select, clientId, context, bindings }: any ) {
 		return {};
 	},


### PR DESCRIPTION
This PR fixes an issue where all block bindings in the editor pattern selection would show "Remote Data Blocks" as values instead of the correct contextual values:

**On WordPress 6.7**:

![Screenshot 2024-11-13 at 11 29 16 AM](https://github.com/user-attachments/assets/338157ea-012e-4894-b343-2d07c36c4205)

**On WordPress 6.6**:

![image](https://github.com/user-attachments/assets/a0c733e3-eed4-4b57-9b26-740f1ed4821b)

## Solution

This is a fix that requires WordPress 6.7. There are two main parts to the workaround:

1. When we call `registerBlockBindingsSource()` to register our block bindings client-side, this changes the way that [Gutenberg's internal `withBlockBindingSupport()` hook](https://github.com/WordPress/gutenberg/blob/2f5701f0f4ec3a44a45658e3909a9d64e9fd8d97/packages/block-editor/src/hooks/use-bindings-attributes.js#L163-L175) functions. Previously `source.getValues` was undefined (as we had no client-side registration), which caused the "Remote Data Blocks" label to be injected into attribute values. When we register our block binding and provide a function for `getValues()`, we don't actually provide values, but this allows the attribute value to be set to `null` as a result of `withBlockBindingSupport()`'s internal flow.

    This allows our block cloning code to [inject missing attributes via `getMismatchedAttributes()`](https://github.com/Automattic/remote-data-blocks/blob/8e300d7525a62a892c01f4a82b371d1552deb3dd/src/blocks/remote-data-container/hooks/usePatterns.ts#L24-L31) directly and bypasses the block binding logic in the same way it previously did in WordPress 6.6.

    A proper fix to this issue will allow our `registerBlockBindingsSource()`'s `getValues()` function to properly use context to return block binding values. However, this workaround works with our previous logic flow to inject values until we have a better fix in place.

3. Some type errors related to the new `registerBlockBindingsSource()` function were ignored. We had some issues adding the new function definition to types in `types/wordpress__blocks/index.d.ts`, and the new function types are not available from official sources. We should also fix this typing issue in a subsequent update.