### PR TITLE
Adjust data source slug input

### DIFF
--- a/src/data-sources/components/SlugInput.tsx
+++ b/src/data-sources/components/SlugInput.tsx
@@ -2,7 +2,7 @@ import { TextControl } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useDataSources } from '@/data-sources/hooks/useDataSources';
 import { sanitizeDataSourceSlug } from '@/data-sources/utils';
@@ -15,12 +15,14 @@ interface SlugInputProps {
 
 export const SlugInput: React.FC< SlugInputProps > = ( { slug, onChange, uuid } ) => {
 	const { slugConflicts, checkSlugConflict } = useDataSources( false );
+	const [ newSlug, setNewSlug ] = useState( slug );
 
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
 	const debouncedCheckSlugConflict = useDebounce( checkSlugConflict, 500 );
-	const onSlugChange = ( newSlug: string | undefined ): void => {
+	const onSlugUpdate = () => {
 		const sanitizedSlug = sanitizeDataSourceSlug( newSlug ?? '' );
-		if ( sanitizedSlug !== slug ) {
+		if ( sanitizedSlug !== newSlug ) {
+			setNewSlug( sanitizedSlug );
 			onChange( sanitizedSlug );
 			void debouncedCheckSlugConflict( sanitizedSlug, uuid ?? '' );
 		}
@@ -36,8 +38,9 @@ export const SlugInput: React.FC< SlugInputProps > = ( { slug, onChange, uuid } 
 	return (
 		<TextControl
 			label={ __( 'Slug', 'remote-data-blocks' ) }
-			value={ slug }
-			onChange={ onSlugChange }
+			value={ newSlug }
+			onChange={ setNewSlug }
+			onBlur={ onSlugUpdate }
 			help={ __(
 				slugConflictMessage || 'A unique identifier for this data source.',
 				'remote-data-blocks'

--- a/src/data-sources/components/SlugInput.tsx
+++ b/src/data-sources/components/SlugInput.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import React, { useState } from 'react';
 
 import { useDataSources } from '@/data-sources/hooks/useDataSources';
-import { sanitizeDataSourceSlug } from '@/data-sources/utils';
+import { slugify } from '@/data-sources/utils';
 
 interface SlugInputProps {
 	slug: string;
@@ -20,7 +20,7 @@ export const SlugInput: React.FC< SlugInputProps > = ( { slug, onChange, uuid } 
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
 	const debouncedCheckSlugConflict = useDebounce( checkSlugConflict, 500 );
 	const onSlugUpdate = () => {
-		const sanitizedSlug = sanitizeDataSourceSlug( newSlug ?? '' );
+		const sanitizedSlug = slugify( newSlug ?? '' );
 		if ( sanitizedSlug !== newSlug ) {
 			setNewSlug( sanitizedSlug );
 			onChange( sanitizedSlug );

--- a/src/data-sources/utils.tsx
+++ b/src/data-sources/utils.tsx
@@ -2,7 +2,14 @@ import CheckIcon from '@/settings/icons/CheckIcon';
 import ErrorIcon from '@/settings/icons/ErrorIcon';
 
 export const sanitizeDataSourceSlug = ( slug: string ) => {
-	return slug.replace( /[^a-z0-9-]/gi, '' ).toLowerCase();
+	return slug
+		.toString() // Ensure input is a string
+		.toLowerCase() // Convert to lowercase
+		.trim() // Trim leading and trailing spaces
+		.replace( /\s+/g, '-' ) // Replace spaces with hyphens
+		.replace( /[^a-z0-9-]/g, '' ) // Remove invalid characters
+		.replace( /--+/g, '-' ) // Replace multiple hyphens with a single hyphen
+		.replace( /^-+|-+$/g, '' ); // Trim leading and trailing hyphens
 };
 
 export function getConnectionMessage(

--- a/src/data-sources/utils.tsx
+++ b/src/data-sources/utils.tsx
@@ -1,8 +1,13 @@
 import CheckIcon from '@/settings/icons/CheckIcon';
 import ErrorIcon from '@/settings/icons/ErrorIcon';
 
-export const sanitizeDataSourceSlug = ( slug: string ) => {
-	return slug
+/**
+ * Tranforms a string into a valid data source slug.
+ *
+ * @param input The string to slugify.
+ */
+export const slugify = ( input: string ) => {
+	return input
 		.toString() // Ensure input is a string
 		.toLowerCase() // Convert to lowercase
 		.trim() // Trim leading and trailing spaces

--- a/src/data-sources/utils.tsx
+++ b/src/data-sources/utils.tsx
@@ -2,7 +2,7 @@ import CheckIcon from '@/settings/icons/CheckIcon';
 import ErrorIcon from '@/settings/icons/ErrorIcon';
 
 export const sanitizeDataSourceSlug = ( slug: string ) => {
-	return slug.replace( /[^a-z0-9-]/g, '' ).toLowerCase();
+	return slug.replace( /[^a-z0-9-]/gi, '' ).toLowerCase();
 };
 
 export function getConnectionMessage(


### PR DESCRIPTION
The data source slug can only contain lowercase alphanumeric characters and hyphens, so currently it isn't possible to enter anything else into the input field, including capital letters. 

We already use the method `toLowerCase` in the `sanitizeDataSourceSlug` function, so we can adjust the regex to be case insensitive to allow for capitals to be entered before sanitizing. 

This PR also moves the logic from the input's `onChange` to `onBlur`, so there is visual feedback showing capitals are being entered, but when leaving the field, it'll be adjusted to lower case: 

![slug](https://github.com/user-attachments/assets/4b5b447d-de9b-452f-9f2f-dfa591fc8c97)

In the future, we may want to consider adding some warning to let the user know these characters are invalid for this field. 