### PR TITLE
Fix naming and casing for existing Airtable field types

### DIFF
--- a/src/data-sources/airtable/AirtableSettings.tsx
+++ b/src/data-sources/airtable/AirtableSettings.tsx
@@ -291,10 +291,10 @@ export const AirtableSettings = ( {
 			if ( selectedTable ) {
 				selectedTable.fields.forEach( field => {
 					const simpleFieldTypes = [
-						'singlelineText',
+						'singleLineText',
 						'multilineText',
 						'email',
-						'phone',
+						'phoneNumber',
 						'url',
 						'number',
 					];


### PR DESCRIPTION
I noticed when testing that some table fields weren't available to select but they were visible in the help text: 

<img width="750" alt="Screenshot 2024-11-13 at 1 49 05 PM" src="https://github.com/user-attachments/assets/d808a36b-53ea-4489-8f97-fc5704e4dba6">

This was due to differences in the naming of the field types from Airtable. There are still ones that won't show since we haven't included all types yet. For now, I just wanted to update the ones not showing that we had intended to include. 

<img width="741" alt="Screenshot 2024-11-13 at 1 48 41 PM" src="https://github.com/user-attachments/assets/c5881f7f-4352-4d44-bdbf-f1c6b15be4c0">
