### PR TITLE
add optional generate field to input_schema

### DIFF
--- a/inc/Config/QueryContext/HttpQueryContext.php
+++ b/inc/Config/QueryContext/HttpQueryContext.php
@@ -37,6 +37,10 @@ class HttpQueryContext implements QueryContextInterface, HttpQueryContextInterfa
 							'type' => 'array',
 							'required' => false,
 						],
+						'generate' => [
+							'type' => 'function',
+							'required' => false,
+						],
 					],
 				],
 			],

--- a/inc/Config/QueryContext/HttpQueryContext.php
+++ b/inc/Config/QueryContext/HttpQueryContext.php
@@ -37,7 +37,7 @@ class HttpQueryContext implements QueryContextInterface, HttpQueryContextInterfa
 							'type' => 'array',
 							'required' => false,
 						],
-						'generate' => [
+						'transform' => [
 							'type' => 'function',
 							'required' => false,
 						],

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -153,29 +153,29 @@ class BlockBindings {
 	}
 
 	/**
-	 * Generate the query input for a block binding before executing the query if
-	 * a generate function is provided. This allows the query input to be generated
-	 * from combined input variables or transformed in some way before the query
-	 * is executed. This runs after the query input overrides have been applied.
+	 * Transform the query input for a block binding before executing the query if
+	 * a transform function is provided. This allows the query input to be
+	 * transformed in some way before the query is executed. This runs after the
+	 * query input overrides have been applied.
 	 */
-	private static function transform_query_input_with_generators(
+	private static function transform_query_input(
 		array $query_input,
 		object $query_config
 	): array {
-		$generated_query_input = [];
+		$transformed_query_input = [];
 
 		foreach ( $query_config->input_schema as $query_input_key => $query_input_schema ) {
 			if (
-				isset( $query_input_schema['generate'] ) &&
-				is_callable( $query_input_schema['generate'] )
+				isset( $query_input_schema['transform'] ) &&
+				is_callable( $query_input_schema['transform'] )
 			) {
-				$generated_query_input[ $query_input_key ] = $query_input_schema['generate'](
+				$transformed_query_input[ $query_input_key ] = $query_input_schema['transform'](
 					$query_input
 				);
 			}
 		}
 
-		return array_merge( $query_input, $generated_query_input );
+		return array_merge( $query_input, $transformed_query_input );
 	}
 
 	private static function get_query_input( array $block_context, object $query_config ): array {
@@ -184,7 +184,7 @@ class BlockBindings {
 		$overrides = $block_context['queryInputOverrides'] ?? [];
 
 		$query_input = self::apply_query_input_overrides( $query_input, $overrides, $block_name );
-		$query_input = self::transform_query_input_with_generators( $query_input, $query_config );
+		$query_input = self::transform_query_input( $query_input, $query_config );
 
 		return $query_input;
 	}

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -152,10 +152,45 @@ class BlockBindings {
 		return array_merge( $query_input, $overrides );
 	}
 
-	public static function execute_query( array $block_context, string $operation_name ): array|null {
+	/**
+	 * Generate the query input for a block binding before executing the query if
+	 * a generate function is provided. This allows the query input to be generated
+	 * from combined input variables or transformed in some way before the query
+	 * is executed. This runs after the query input overrides have been applied.
+	 */
+	private static function transform_query_input_with_generators(
+		array $query_input,
+		object $query_config
+	): array {
+		$generated_query_input = [];
+
+		foreach ( $query_config->input_schema as $query_input_key => $query_input_schema ) {
+			if (
+				isset( $query_input_schema['generate'] ) &&
+				is_callable( $query_input_schema['generate'] )
+			) {
+				$generated_query_input[ $query_input_key ] = $query_input_schema['generate'](
+					$query_input
+				);
+			}
+		}
+
+		return array_merge( $query_input, $generated_query_input );
+	}
+
+	private static function get_query_input( array $block_context, object $query_config ): array {
 		$block_name = $block_context['blockName'];
 		$query_input = $block_context['queryInput'];
 		$overrides = $block_context['queryInputOverrides'] ?? [];
+
+		$query_input = self::apply_query_input_overrides( $query_input, $overrides, $block_name );
+		$query_input = self::transform_query_input_with_generators( $query_input, $query_config );
+
+		return $query_input;
+	}
+
+	public static function execute_query( array $block_context, string $operation_name ): array|null {
+		$block_name = $block_context['blockName'];
 		$block_config = ConfigStore::get_configuration( $block_name );
 
 		if ( null === $block_config ) {
@@ -164,7 +199,7 @@ class BlockBindings {
 
 		try {
 			$query_config = $block_config['queries']['__DISPLAY__'];
-			$query_input = self::apply_query_input_overrides( $query_input, $overrides, $block_name );
+			$query_input = self::get_query_input( $block_context, $query_config );
 
 			$query_runner = $query_config->get_query_runner();
 			$query_results = $query_runner->execute( $query_input );

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -220,7 +220,7 @@ class BlockBindingsTest extends TestCase {
 			'test_input_field' => [
 				'name' => 'Test Input Field',
 				'type' => 'string',
-				'generate' => function ( array $data ): string {
+				'transform' => function ( array $data ): string {
 					return $data['test_input_field'] . ' transformed';
 				},
 			],
@@ -275,7 +275,7 @@ class BlockBindingsTest extends TestCase {
 			'test_input_field' => [
 				'name' => 'Test Input Field',
 				'type' => 'string',
-				'generate' => function ( array $data ): string {
+				'transform' => function ( array $data ): string {
 					return $data['test_input_field'] . ' ' . $data['another_input_field'];
 				},
 			],
@@ -345,7 +345,7 @@ class BlockBindingsTest extends TestCase {
 			'test_input_field' => [
 				'name' => 'Test Input Field',
 				'type' => 'string',
-				'generate' => function ( array $data ): string {
+				'transform' => function ( array $data ): string {
 					return $data['test_input_field'] . ' transformed';
 				},
 			],

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -11,9 +11,7 @@ function get_query_var( string $var, $default = '' ): mixed {
 	return MockWordPressFunctions::get_query_var( $var, $default );
 }
 
-/**
- * Start of the test namespace.
- */
+// phpcs:disable Universal.Namespaces.OneDeclarationPerFile.MultipleFound
 namespace RemoteDataBlocks\Tests\Editor\DataBinding;
 
 use PHPUnit\Framework\TestCase;
@@ -42,7 +40,7 @@ class BlockBindingsTest extends TestCase {
 				'name' => 'Output Field',
 				'type' => 'string',
 				'path' => '$.output_field',
-			]
+			],
 		],
 	];
 	private const MOCK_OUTPUT_FIELD_NAME = 'output_field';
@@ -53,16 +51,12 @@ class BlockBindingsTest extends TestCase {
 			[
 				'result' => [
 					self::MOCK_OUTPUT_FIELD_NAME => [
-						'value' => self::MOCK_OUTPUT_FIELD_VALUE
+						'value' => self::MOCK_OUTPUT_FIELD_VALUE,
 					],
-				]
-			]
-		]
+				],
+			],
+		],
 	];
-
-	protected function setUp(): void {
-		parent::setUp();
-	}
 
 	protected function tearDown(): void {
 		parent::tearDown();
@@ -77,8 +71,8 @@ class BlockBindingsTest extends TestCase {
 		/**
 		 * Mock the ConfigStore to return null.
 		 */
-		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
-		$mockConfigStore->shouldReceive( 'get_configuration' )
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_configuration' )
 			->once()
 			->with( self::MOCK_BLOCK_NAME )
 			->andReturn( null );
@@ -126,8 +120,8 @@ class BlockBindingsTest extends TestCase {
 		/**
 		 * Mock the ConfigStore to return the block configuration.
 		 */
-		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
-		$mockConfigStore->shouldReceive( 'get_configuration' )
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_configuration' )
 			->once()
 			->with( self::MOCK_BLOCK_NAME )
 			->andReturn( $mock_block_config );
@@ -187,8 +181,8 @@ class BlockBindingsTest extends TestCase {
 			],
 		];
 
-		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
-		$mockConfigStore->shouldReceive( 'get_configuration' )
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_configuration' )
 			->once()
 			->with( self::MOCK_BLOCK_NAME )
 			->andReturn( $mock_block_config );
@@ -242,8 +236,8 @@ class BlockBindingsTest extends TestCase {
 			],
 		];
 
-		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
-		$mockConfigStore->shouldReceive( 'get_configuration' )
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_configuration' )
 			->once()
 			->with( self::MOCK_BLOCK_NAME )
 			->andReturn( $mock_block_config );
@@ -301,8 +295,8 @@ class BlockBindingsTest extends TestCase {
 			],
 		];
 
-		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
-		$mockConfigStore->shouldReceive( 'get_configuration' )
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_configuration' )
 			->once()
 			->with( self::MOCK_BLOCK_NAME )
 			->andReturn( $mock_block_config );
@@ -367,8 +361,8 @@ class BlockBindingsTest extends TestCase {
 			],
 		];
 
-		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
-		$mockConfigStore->shouldReceive( 'get_configuration' )
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_configuration' )
 			->once()
 			->with( self::MOCK_BLOCK_NAME )
 			->andReturn( $mock_block_config );

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -1,0 +1,386 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Editor\DataBinding;
+
+use RemoteDataBlocks\Tests\Mocks\MockWordPressFunctions;
+
+/**
+ * Mock the global WordPress functions in implementation namespace.
+ */
+function get_query_var( string $var, $default = '' ): mixed {
+	return MockWordPressFunctions::get_query_var( $var, $default );
+}
+
+/**
+ * Start of the test namespace.
+ */
+namespace RemoteDataBlocks\Tests\Editor\DataBinding;
+
+use PHPUnit\Framework\TestCase;
+use Mockery;
+use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;
+use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
+use RemoteDataBlocks\Tests\Mocks\MockQueryRunner;
+use RemoteDataBlocks\Tests\Mocks\MockWordPressFunctions;
+use RemoteDataBlocks\Tests\Mocks\MockQueryContext;
+
+class BlockBindingsTest extends TestCase {
+	private const MOCK_BLOCK_NAME = 'test/block';
+	private const MOCK_OPERATION_NAME = 'test-operation';
+
+	private const MOCK_INPUT_SCHEMA = [
+		'test_input_field' => [
+			'name' => 'Test Input Field',
+			'type' => 'string',
+		],
+	];
+
+	private const MOCK_OUTPUT_SCHEMA = [
+		'is_collection' => false,
+		'mappings' => [
+			'output_field' => [
+				'name' => 'Output Field',
+				'type' => 'string',
+				'path' => '$.output_field',
+			]
+		],
+	];
+	private const MOCK_OUTPUT_FIELD_NAME = 'output_field';
+	private const MOCK_OUTPUT_FIELD_VALUE = 'Test Output Value';
+	private const MOCK_OUTPUT_QUERY_RESULTS = [
+		'is_collection' => false,
+		'results' => [
+			[
+				'result' => [
+					self::MOCK_OUTPUT_FIELD_NAME => [
+						'value' => self::MOCK_OUTPUT_FIELD_VALUE
+					],
+				]
+			]
+		]
+	];
+
+	protected function setUp(): void {
+		parent::setUp();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		Mockery::close();
+		MockWordPressFunctions::reset();
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_execute_query_with_no_config(): void {
+		/**
+		 * Mock the ConfigStore to return null.
+		 */
+		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
+		$mockConfigStore->shouldReceive( 'get_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( null );
+
+		$block_context = [
+			'blockName' => self::MOCK_BLOCK_NAME,
+			'queryInput' => [],
+		];
+
+		$query_results = BlockBindings::execute_query( $block_context, 'test-operation' );
+
+		/**
+		 * Assert that the query results are null as no configuration was found.
+		 */
+		$this->assertNull( $query_results );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_execute_query_returns_query_results(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( 'output_field', 'Test Output Value' );
+
+		$block_context = [
+			'blockName' => self::MOCK_BLOCK_NAME,
+			'queryInput' => [
+				'test_input_field' => 'test_value',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				'__DISPLAY__' => new MockQueryContext(
+					$mock_qr,
+					self::MOCK_INPUT_SCHEMA,
+					self::MOCK_OUTPUT_SCHEMA,
+				),
+			],
+		];
+
+		/**
+		 * Mock the ConfigStore to return the block configuration.
+		 */
+		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
+		$mockConfigStore->shouldReceive( 'get_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$query_results = BlockBindings::execute_query( $block_context, self::MOCK_OPERATION_NAME );
+		$this->assertSame( $query_results, self::MOCK_OUTPUT_QUERY_RESULTS );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_execute_query_with_overrides(): void {
+		/**
+		 * Set the query var to an override value.
+		 */
+		MockWordPressFunctions::set_query_var( 'test_input_field', 'override_value' );
+
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( self::MOCK_OUTPUT_FIELD_NAME, self::MOCK_OUTPUT_FIELD_VALUE );
+
+		$block_context = [
+			'blockName' => self::MOCK_BLOCK_NAME,
+			'queryInput' => [
+				'test_input_field' => 'test_value',
+			],
+			'queryInputOverrides' => [
+				'test_input_field' => [
+					'type' => 'url',
+					'display' => '/test_input_field/{test_input_field}',
+				],
+			],
+		];
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+				'overrides' => [
+					[
+						'target' => 'test_target',
+						'type' => 'url',
+					],
+				],
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				'__DISPLAY__' => new MockQueryContext(
+					$mock_qr,
+					$input_schema,
+					self::MOCK_OUTPUT_SCHEMA,
+				),
+			],
+		];
+
+		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
+		$mockConfigStore->shouldReceive( 'get_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$query_results = BlockBindings::execute_query( $block_context, self::MOCK_OPERATION_NAME );
+
+		$this->assertSame( $query_results, self::MOCK_OUTPUT_QUERY_RESULTS );
+
+		/**
+		 * Assert that the query runner received the correct input after overrides were applied.
+		 */
+		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
+			'test_input_field' => 'override_value',
+		] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_execute_query_with_query_input_transformations(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( 'output_field', 'Test Output Value' );
+
+		$block_context = [
+			'blockName' => self::MOCK_BLOCK_NAME,
+			'queryInput' => [
+				'test_input_field' => 'test_value',
+			],
+		];
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+				'generate' => function ( array $data ): string {
+					return $data['test_input_field'] . ' transformed';
+				},
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				'__DISPLAY__' => new MockQueryContext(
+					$mock_qr,
+					$input_schema,
+					self::MOCK_OUTPUT_SCHEMA,
+				),
+			],
+		];
+
+		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
+		$mockConfigStore->shouldReceive( 'get_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$query_results = BlockBindings::execute_query( $block_context, self::MOCK_OPERATION_NAME );
+		$this->assertSame( $query_results, self::MOCK_OUTPUT_QUERY_RESULTS );
+
+		/**
+		 * Assert that the query runner received the correct input after transformations were applied.
+		 */
+		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
+			'test_input_field' => 'test_value transformed',
+		] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_execute_query_with_query_input_transformed_with_multiple_inputs(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( 'output_field', 'Test Output Value' );
+
+		$block_context = [
+			'blockName' => self::MOCK_BLOCK_NAME,
+			'queryInput' => [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			],
+		];
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+				'generate' => function ( array $data ): string {
+					return $data['test_input_field'] . ' ' . $data['another_input_field'];
+				},
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				'__DISPLAY__' => new MockQueryContext(
+					$mock_qr,
+					$input_schema,
+					self::MOCK_OUTPUT_SCHEMA,
+				),
+			],
+		];
+
+		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
+		$mockConfigStore->shouldReceive( 'get_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$query_results = BlockBindings::execute_query( $block_context, self::MOCK_OPERATION_NAME );
+		$this->assertSame( $query_results, self::MOCK_OUTPUT_QUERY_RESULTS );
+
+		/**
+		 * Assert that the query runner received the correct input after transformations were applied.
+		 */
+		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
+			'test_input_field' => 'test_value another_value',
+			'another_input_field' => 'another_value',
+		] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_execute_query_with_query_input_transformations_and_overrides(): void {
+		/**
+		 * Set the query var to an override value.
+		 */
+		MockWordPressFunctions::set_query_var( 'test_input_field', 'override_value' );
+
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( 'output_field', 'Test Output Value' );
+
+		$block_context = [
+			'blockName' => self::MOCK_BLOCK_NAME,
+			'queryInput' => [
+				'test_input_field' => 'test_value',
+			],
+			'queryInputOverrides' => [
+				'test_input_field' => [
+					'type' => 'url',
+					'display' => '/test_input_field/{test_input_field}',
+				],
+			],
+		];
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+				'generate' => function ( array $data ): string {
+					return $data['test_input_field'] . ' transformed';
+				},
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				'__DISPLAY__' => new MockQueryContext(
+					$mock_qr,
+					$input_schema,
+					self::MOCK_OUTPUT_SCHEMA,
+				),
+			],
+		];
+
+		$mockConfigStore = Mockery::namedMock( ConfigStore::class );
+		$mockConfigStore->shouldReceive( 'get_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$query_results = BlockBindings::execute_query( $block_context, self::MOCK_OPERATION_NAME );
+		$this->assertSame( $query_results, self::MOCK_OUTPUT_QUERY_RESULTS );
+
+		/**
+		 * Assert that the query runner received the correct input after transformations and overrides were applied.
+		 */
+		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
+			'test_input_field' => 'override_value transformed',
+		] );
+	}
+}

--- a/tests/inc/Mocks/MockQueryContext.php
+++ b/tests/inc/Mocks/MockQueryContext.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Tests\Mocks;
+
+use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
+use RemoteDataBlocks\Tests\Mocks\MockDataSource;
+use RemoteDataBlocks\Tests\Mocks\MockValidator;
+use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
+
+class MockQueryContext extends HttpQueryContext {
+	public function __construct(
+		private QueryRunnerInterface $mock_qr,
+		public array $input_schema = [],
+		public array $output_schema = []
+	) {
+		parent::__construct(
+			MockDataSource::from_array( MockDataSource::MOCK_CONFIG, new MockValidator() ),
+			$input_schema,
+			$output_schema,
+		);
+	}
+
+	public function get_query_runner(): QueryRunnerInterface {
+		return $this->mock_qr;
+	}
+}

--- a/tests/inc/Mocks/MockQueryRunner.php
+++ b/tests/inc/Mocks/MockQueryRunner.php
@@ -6,6 +6,7 @@ use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
 
 class MockQueryRunner implements QueryRunnerInterface {
 	private $query_results = [];
+	private $execute_call_inputs = [];
 
 	public function addResult( $field, $result ) {
 		if ( $result instanceof \WP_Error ) {
@@ -26,6 +27,11 @@ class MockQueryRunner implements QueryRunnerInterface {
 	}
 
 	public function execute( array $input_variables ): array|\WP_Error {
+		array_push( $this->execute_call_inputs, $input_variables );
 		return array_shift( $this->query_results );
+	}
+
+	public function getLastExecuteCallInput(): array|null {
+		return end( $this->execute_call_inputs ) ?? null;
 	}
 }

--- a/tests/inc/Mocks/MockWordPressFunctions.php
+++ b/tests/inc/Mocks/MockWordPressFunctions.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Tests\Mocks;
+
+class MockWordPressFunctions {
+    private static array $query_vars = [];
+
+    public static function set_query_var( string $key, $value ): void {
+        self::$query_vars[$key] = $value;
+    }
+
+    public static function get_query_var( string $var, $default = '' ): mixed {
+        return self::$query_vars[$var] ?? $default;
+    }
+
+    public static function reset(): void {
+        self::$query_vars = [];
+    }
+}

--- a/tests/inc/Mocks/MockWordPressFunctions.php
+++ b/tests/inc/Mocks/MockWordPressFunctions.php
@@ -3,17 +3,17 @@
 namespace RemoteDataBlocks\Tests\Mocks;
 
 class MockWordPressFunctions {
-    private static array $query_vars = [];
+	private static array $query_vars = [];
 
-    public static function set_query_var( string $key, $value ): void {
-        self::$query_vars[$key] = $value;
-    }
+	public static function set_query_var( string $key, $value ): void {
+		self::$query_vars[ $key ] = $value;
+	}
 
-    public static function get_query_var( string $var, $default = '' ): mixed {
-        return self::$query_vars[$var] ?? $default;
-    }
+	public static function get_query_var( string $var, $default = '' ): mixed {
+		return self::$query_vars[ $var ] ?? $default;
+	}
 
-    public static function reset(): void {
-        self::$query_vars = [];
-    }
+	public static function reset(): void {
+		self::$query_vars = [];
+	}
 }


### PR DESCRIPTION
# Description

This PR introduces a new optional 'generate' function field to the query input schema. This allows for dynamic query input generation which would be required for modifying the query input. One of the use cases for this is the PR #191 where we need to append the `".md"` suffix to the github file path if not provided. 

## Changes:
- **Enhanced Query Input Handling:**
  - Added support for `generate` functions in query input schemas to facilitate dynamic query input generation. This function receives the input values array as input and returns a new value which will be used as the value for the input field.
  - Implemented `transform_query_input_with_generators` method to apply these transformations before executing queries.
  - Modified `get_query_input` method to incorporate query input transformations after applying overrides.

- **Updated Query Execution Logic:**
  - Updated `execute_query` method to use the new `get_query_input` method, ensuring that query inputs are correctly transformed and overridden before execution.

- **Unit Tests Added**
  - Added unit tests for `BlockBindings` class in `BlockBindingsTest.php` covering:
    - Execution of queries with no configuration.
    - Execution of queries returning results.
    - Application of query input overrides.
    - Query input transformations with single and multiple inputs.
    - Combined transformations and overrides.