### PR TITLE
UPDATE @automattic/calypso-analytics to version 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@automattic/calypso-analytics": "^1.1.2"
+        "@automattic/calypso-analytics": "^1.1.3"
       },
       "devDependencies": {
         "@automattic/eslint-plugin-wpvip": "0.13.0",
@@ -111,16 +111,24 @@
       }
     },
     "node_modules/@automattic/calypso-analytics": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@automattic/calypso-analytics/-/calypso-analytics-1.1.2.tgz",
-      "integrity": "sha512-+pPM41BL8XYxHKoEidk3/J3XjKxinVZfB0/t8E2KPBqGclDSVg7PXxslOzWsQsNju64rSWcjIY5+c8fnnWRW5g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@automattic/calypso-analytics/-/calypso-analytics-1.1.3.tgz",
+      "integrity": "sha512-7DiQZLC2wzs5GW4PDXnSngYFNkMC8aB8FXgD5Xqgzo9cQmqo7Ka4sKITsp7b8yBHXrpEtMwCK265UAEQs8wSMg==",
       "dependencies": {
         "@automattic/load-script": "^1.0.0",
-        "cookie": "^0.4.1",
+        "cookie": "^0.7.0",
         "debug": "^4.3.3",
         "hash.js": "^1.1.7",
         "tslib": "^2.3.0",
         "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/@automattic/calypso-analytics/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@automattic/eslint-plugin-wpvip": {
@@ -11761,6 +11769,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
     "extends": "./node_modules/@wordpress/scripts/config/.stylelintrc.json"
   },
   "dependencies": {
-    "@automattic/calypso-analytics": "^1.1.2"
+    "@automattic/calypso-analytics": "^1.1.3"
   }
 }


### PR DESCRIPTION
Updating `calypso-analytics` package to version `1.1.3` which contains whitelisting logic (https://github.com/Automattic/wp-calypso/pull/96007) for `remotedatablocks` source.