### PR TITLE
Settings UI updates 

### DIFF
--- a/src/data-sources/AddDataSourceDropdown.tsx
+++ b/src/data-sources/AddDataSourceDropdown.tsx
@@ -1,0 +1,75 @@
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
+
+import { SUPPORTED_SERVICES_LABELS } from './constants';
+import { useSettingsContext } from '@/settings/hooks/useSettingsNav';
+import AirtableIcon from '@/settings/icons/AirtableIcon';
+import GoogleSheetsIcon from '@/settings/icons/GoogleSheetsIcon';
+import HttpIcon from '@/settings/icons/HttpIcon';
+import ShopifyIcon from '@/settings/icons/ShopifyIcon';
+
+import './DataSourceList.scss';
+
+export const AddDataSourceDropdown = () => {
+	const { pushState } = useSettingsContext();
+
+	function onAddDataSource( dataSource: string ) {
+		const newUrl = new URL( window.location.href );
+		newUrl.searchParams.set( 'addDataSource', dataSource );
+		pushState( newUrl );
+	}
+
+	return (
+		<DropdownMenu
+			className="rdb-settings-page_add-data-source-dropdown"
+			icon={ chevronDown }
+			label={ __( 'Add source', 'remote-data-blocks' ) }
+			text={ __( 'Add', 'remote-data-blocks' ) }
+			toggleProps={ {
+				className: 'rdb-settings-page_add-data-source-btn',
+				variant: 'primary',
+				showTooltip: false,
+				style: { flexDirection: 'row-reverse', paddingLeft: '12px', paddingRight: '8px' },
+			} }
+			children={ ( { onClose } ) => (
+				<MenuGroup>
+					{ [
+						{
+							icon: AirtableIcon,
+							label: SUPPORTED_SERVICES_LABELS.airtable,
+							value: 'airtable',
+						},
+						{
+							icon: GoogleSheetsIcon,
+							label: SUPPORTED_SERVICES_LABELS[ 'google-sheets' ],
+							value: 'google-sheets',
+						},
+						{
+							icon: ShopifyIcon,
+							label: SUPPORTED_SERVICES_LABELS.shopify,
+							value: 'shopify',
+						},
+						{
+							icon: HttpIcon,
+							label: SUPPORTED_SERVICES_LABELS[ 'generic-http' ],
+							value: 'generic-http',
+						},
+					].map( ( { icon, label, value } ) => (
+						<MenuItem
+							key={ value }
+							icon={ icon }
+							iconPosition="left"
+							onClick={ () => {
+								onAddDataSource( value );
+								onClose();
+							} }
+						>
+							{ label }
+						</MenuItem>
+					) ) }
+				</MenuGroup>
+			) }
+		/>
+	);
+};

--- a/src/data-sources/DataSourceList.scss
+++ b/src/data-sources/DataSourceList.scss
@@ -108,22 +108,3 @@ span.data-source-slug {
 	}
 }
 
-.confirm-delete-data-source-modal {
-
-	.action-buttons {
-		display: flex;
-		padding-top: 50px;
-		justify-content: end;
-		gap: 12px;
-	}
-
-	button.is-link {
-		padding: 6px 12px;
-		text-decoration: none;
-
-		&:hover {
-			box-shadow: none;
-			text-decoration: underline;
-		}
-	}
-}

--- a/src/data-sources/DataSourceList.tsx
+++ b/src/data-sources/DataSourceList.tsx
@@ -1,8 +1,8 @@
 import {
 	Button,
 	ButtonGroup,
+	__experimentalConfirmDialog as ConfirmDialog,
 	Icon,
-	Modal,
 	Placeholder,
 	Spinner,
 	__experimentalText as Text,
@@ -134,42 +134,22 @@ const DataSourceList = () => {
 				</table>
 
 				{ dataSourceToDelete && (
-					<Modal
-						className="confirm-delete-data-source-modal"
-						title={ __( 'Delete Data Source', 'remote-data-blocks' ) }
+					<ConfirmDialog
+						confirmButtonText={ __( 'Confirm', 'remote-data-blocks' ) }
+						onCancel={ () => onCancelDeleteDialog() }
+						onConfirm={ () => void onConfirmDeleteDataSource( dataSourceToDelete ) }
 						size="medium"
-						onRequestClose={ () => {
-							onCancelDeleteDialog();
-						} }
-						isDismissible={ true }
-						focusOnMount
-						shouldCloseOnEsc={ true }
-						shouldCloseOnClickOutside={ true }
+						title={ __( 'Delete Data Source', 'remote-data-blocks' ) }
 					>
-						<p>
-							{ sprintf(
-								__(
-									'Are you sure you want to delete "%s" data source with slug "%s"?',
-									'remote-data-blocks'
-								),
-								getServiceLabel( dataSourceToDelete.service ),
-								dataSourceToDelete.slug
-							) }
-						</p>
-
-						<div className="action-buttons">
-							<Button variant="link" onClick={ onCancelDeleteDialog }>
-								{ __( 'Cancel', 'remote-data-blocks' ) }
-							</Button>
-							<Button
-								variant="primary"
-								isDestructive
-								onClick={ () => void onConfirmDeleteDataSource( dataSourceToDelete ) }
-							>
-								{ __( 'Confirm', 'remote-data-blocks' ) }
-							</Button>
-						</div>
-					</Modal>
+						{ sprintf(
+							__(
+								'Are you sure you want to delete "%s" data source with slug "%s"?',
+								'remote-data-blocks'
+							),
+							getServiceLabel( dataSourceToDelete.service ),
+							dataSourceToDelete.slug
+						) }
+					</ConfirmDialog>
 				) }
 			</div>
 		);

--- a/src/data-sources/DataSourceList.tsx
+++ b/src/data-sources/DataSourceList.tsx
@@ -1,13 +1,7 @@
 import {
 	Button,
 	ButtonGroup,
-	Card,
-	CardBody,
-	CardHeader,
-	Dropdown,
 	Icon,
-	MenuGroup,
-	MenuItem,
 	Modal,
 	Placeholder,
 	Spinner,
@@ -15,16 +9,12 @@ import {
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { chevronDown, edit, info, trash } from '@wordpress/icons';
+import { edit, info, trash } from '@wordpress/icons';
 
 import { SUPPORTED_SERVICES, SUPPORTED_SERVICES_LABELS } from './constants';
 import { useDataSources } from '@/data-sources/hooks/useDataSources';
 import { DataSourceConfig } from '@/data-sources/types';
 import { useSettingsContext } from '@/settings/hooks/useSettingsNav';
-import AirtableIcon from '@/settings/icons/AirtableIcon';
-import GoogleSheetsIcon from '@/settings/icons/GoogleSheetsIcon';
-import HttpIcon from '@/settings/icons/HttpIcon';
-import ShopifyIcon from '@/settings/icons/ShopifyIcon';
 
 import './DataSourceList.scss';
 
@@ -72,74 +62,12 @@ const DataSourceList = () => {
 		) );
 	};
 
-	const AddDataSourceDropdown = () => {
-		function onAddDataSource( dataSource: string ) {
-			const newUrl = new URL( window.location.href );
-			newUrl.searchParams.set( 'addDataSource', dataSource );
-			pushState( newUrl );
-		}
-
-		return (
-			<Dropdown
-				className="add-data-source-dropdown"
-				contentClassName="add-data-source-dropdown-content"
-				focusOnMount={ false }
-				popoverProps={ { placement: 'bottom-end' } }
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<Button
-						className="add-data-source-btn"
-						variant="primary"
-						onClick={ onToggle }
-						aria-expanded={ isOpen }
-					>
-						Add <Icon icon={ chevronDown } size={ 18 } />
-					</Button>
-				) }
-				renderContent={ () => (
-					<MenuGroup>
-						{ [
-							{
-								icon: AirtableIcon,
-								label: SUPPORTED_SERVICES_LABELS.airtable,
-								value: 'airtable',
-							},
-							{
-								icon: GoogleSheetsIcon,
-								label: SUPPORTED_SERVICES_LABELS[ 'google-sheets' ],
-								value: 'google-sheets',
-							},
-							{
-								icon: ShopifyIcon,
-								label: SUPPORTED_SERVICES_LABELS.shopify,
-								value: 'shopify',
-							},
-							{
-								icon: HttpIcon,
-								label: SUPPORTED_SERVICES_LABELS[ 'generic-http' ],
-								value: 'generic-http',
-							},
-						].map( ( { icon, label, value } ) => (
-							<MenuItem
-								key={ value }
-								icon={ icon }
-								iconPosition="left"
-								onClick={ () => onAddDataSource( value ) }
-							>
-								{ label }
-							</MenuItem>
-						) ) }
-					</MenuGroup>
-				) }
-			/>
-		);
-	};
-
 	const getServiceLabel = ( service: ( typeof SUPPORTED_SERVICES )[ number ] ) => {
 		// eslint-disable-next-line security/detect-object-injection
 		return SUPPORTED_SERVICES_LABELS[ service ];
 	};
 
-	const CardBodyContent = (): JSX.Element => {
+	const DataSourceTable = (): JSX.Element => {
 		if ( loadingDataSources ) {
 			return (
 				<div className="card-loader">
@@ -247,17 +175,7 @@ const DataSourceList = () => {
 		);
 	};
 
-	return (
-		<Card className="data-source-list-card">
-			<CardHeader>
-				<h2>{ __( 'Data Sources', 'remote-data-blocks' ) }</h2>
-				<AddDataSourceDropdown />
-			</CardHeader>
-			<CardBody>
-				<CardBodyContent />
-			</CardBody>
-		</Card>
-	);
+	return <DataSourceTable />;
 };
 
 export default DataSourceList;

--- a/src/data-sources/DataSourceSettings.scss
+++ b/src/data-sources/DataSourceSettings.scss
@@ -1,15 +1,11 @@
-.add-update-data-source-card {
+.rdb-settings-page_data-source-form {
 
-	div.components-card-body {
-		padding: 34px 50px;
-	}
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 12px;
+	padding: 24px 48px;
 
-	form {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 12px;
-	}
 
 	.form-group {
 		width: 100%;

--- a/src/data-sources/airtable/AirtableSettings.tsx
+++ b/src/data-sources/airtable/AirtableSettings.tsx
@@ -1,17 +1,11 @@
-import {
-	BaseControl,
-	Card,
-	CardBody,
-	CardHeader,
-	CheckboxControl,
-	SelectControl,
-} from '@wordpress/components';
+import { BaseControl, CheckboxControl, SelectControl } from '@wordpress/components';
 import { InputChangeCallback } from '@wordpress/components/build-types/input-control/types';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { ChangeEvent } from 'react';
 
 import { AirtableFormState } from '@/data-sources/airtable/types';
+import { DataSourceForm } from '@/data-sources/components/DataSourceForm';
 import { DataSourceFormActions } from '@/data-sources/components/DataSourceFormActions';
 import PasswordInputControl from '@/data-sources/components/PasswordInputControl';
 import { SlugInput } from '@/data-sources/components/SlugInput';
@@ -312,88 +306,83 @@ export const AirtableSettings = ( {
 	}, [ state.table, tables ] );
 
 	return (
-		<Card className="add-update-data-source-card">
-			<CardHeader>
-				<h2>
-					{ mode === 'add' ? __( 'Add Airtable Data Source' ) : __( 'Edit Airtable Data Source' ) }
-				</h2>
-			</CardHeader>
-			<CardBody>
-				<form>
-					<div className="form-group">
-						<SlugInput slug={ state.slug } onChange={ onSlugChange } uuid={ uuidFromProps } />
-					</div>
+		<DataSourceForm
+			heading={
+				mode === 'add' ? __( 'Add Airtable Data Source' ) : __( 'Edit Airtable Data Source' )
+			}
+		>
+			<div className="form-group">
+				<SlugInput slug={ state.slug } onChange={ onSlugChange } uuid={ uuidFromProps } />
+			</div>
 
-					<div className="form-group">
-						<PasswordInputControl
-							label={ __( 'Access Token', 'remote-data-blocks' ) }
-							onChange={ onTokenInputChange }
-							value={ state.access_token }
-							help={ connectionMessage }
-						/>
-					</div>
+			<div className="form-group">
+				<PasswordInputControl
+					label={ __( 'Access Token', 'remote-data-blocks' ) }
+					onChange={ onTokenInputChange }
+					value={ state.access_token }
+					help={ connectionMessage }
+				/>
+			</div>
 
-					<div className="form-group">
-						<SelectControl
-							id="base"
-							label={ __( 'Base', 'remote-data-blocks' ) }
-							value={ state.base?.id ?? '' }
-							onChange={ onSelectChange }
-							options={ baseOptions }
-							help={ basesHelpText }
-							disabled={ fetchingBases || ! bases?.length }
-							__next40pxDefaultSize
-						/>
-					</div>
+			<div className="form-group">
+				<SelectControl
+					id="base"
+					label={ __( 'Base', 'remote-data-blocks' ) }
+					value={ state.base?.id ?? '' }
+					onChange={ onSelectChange }
+					options={ baseOptions }
+					help={ basesHelpText }
+					disabled={ fetchingBases || ! bases?.length }
+					__next40pxDefaultSize
+				/>
+			</div>
 
-					<div className="form-group">
-						<SelectControl
-							id="table"
-							label={ __( 'Table', 'remote-data-blocks' ) }
-							value={ state.table?.id ?? '' }
-							onChange={ onSelectChange }
-							options={ tableOptions }
-							help={ tablesHelpText }
-							disabled={ fetchingTables || ! tables?.length }
-							__next40pxDefaultSize
-						/>
-					</div>
+			<div className="form-group">
+				<SelectControl
+					id="table"
+					label={ __( 'Table', 'remote-data-blocks' ) }
+					value={ state.table?.id ?? '' }
+					onChange={ onSelectChange }
+					options={ tableOptions }
+					help={ tablesHelpText }
+					disabled={ fetchingTables || ! tables?.length }
+					__next40pxDefaultSize
+				/>
+			</div>
 
-					{ state.table && availableTableFields.length && (
-						<div className="form-group">
-							<BaseControl
-								label={ __( 'Table Fields', 'remote-data-blocks' ) }
-								help={ __(
-									'Select the fields to be used in the remote data block.',
-									'remote-data-blocks'
-								) }
-							>
-								{ availableTableFields.map( field => (
-									<CheckboxControl
-										key={ field }
-										label={ field }
-										checked={ state.table_fields.has( field ) }
-										onChange={ checked =>
-											handleOnChange(
-												'table_fields',
-												checked
-													? new Set( [ ...state.table_fields, field ] )
-													: new Set( [ ...state.table_fields ].filter( fld => fld !== field ) )
-											)
-										}
-									/>
-								) ) }
-							</BaseControl>
-						</div>
-					) }
+			{ state.table && availableTableFields.length && (
+				<div className="form-group">
+					<BaseControl
+						label={ __( 'Table Fields', 'remote-data-blocks' ) }
+						help={ __(
+							'Select the fields to be used in the remote data block.',
+							'remote-data-blocks'
+						) }
+					>
+						{ availableTableFields.map( field => (
+							<CheckboxControl
+								key={ field }
+								label={ field }
+								checked={ state.table_fields.has( field ) }
+								onChange={ checked =>
+									handleOnChange(
+										'table_fields',
+										checked
+											? new Set( [ ...state.table_fields, field ] )
+											: new Set( [ ...state.table_fields ].filter( fld => fld !== field ) )
+									)
+								}
+							/>
+						) ) }
+					</BaseControl>
+				</div>
+			) }
 
-					<DataSourceFormActions
-						onSave={ onSaveClick }
-						onCancel={ goToMainScreen }
-						isSaveDisabled={ ! shouldAllowSubmit }
-					/>
-				</form>
-			</CardBody>
-		</Card>
+			<DataSourceFormActions
+				onSave={ onSaveClick }
+				onCancel={ goToMainScreen }
+				isSaveDisabled={ ! shouldAllowSubmit }
+			/>
+		</DataSourceForm>
 	);
 };

--- a/src/data-sources/components/AddDataSourceDropdown.tsx
+++ b/src/data-sources/components/AddDataSourceDropdown.tsx
@@ -2,14 +2,14 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronDown } from '@wordpress/icons';
 
-import { SUPPORTED_SERVICES_LABELS } from './constants';
+import { SUPPORTED_SERVICES_LABELS } from '../constants';
 import { useSettingsContext } from '@/settings/hooks/useSettingsNav';
 import AirtableIcon from '@/settings/icons/AirtableIcon';
 import GoogleSheetsIcon from '@/settings/icons/GoogleSheetsIcon';
 import HttpIcon from '@/settings/icons/HttpIcon';
 import ShopifyIcon from '@/settings/icons/ShopifyIcon';
 
-import './DataSourceList.scss';
+import '../DataSourceList.scss';
 
 export const AddDataSourceDropdown = () => {
 	const { pushState } = useSettingsContext();

--- a/src/data-sources/components/DataSourceForm.tsx
+++ b/src/data-sources/components/DataSourceForm.tsx
@@ -1,0 +1,15 @@
+import { __experimentalHeading as Heading } from '@wordpress/components';
+
+type DataSourceFormProps = React.FormHTMLAttributes< HTMLFormElement > & {
+	children: React.ReactNode;
+	heading: string | React.ReactNode;
+};
+
+export const DataSourceForm = ( { children, heading }: DataSourceFormProps ) => {
+	return (
+		<form className="rdb-settings-page_data-source-form">
+			<Heading size={ 24 }>{ heading }</Heading>
+			{ children }
+		</form>
+	);
+};

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -1,8 +1,9 @@
-import { Card, CardHeader, CardBody, TextareaControl, SelectControl } from '@wordpress/components';
+import { TextareaControl, SelectControl } from '@wordpress/components';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ChangeEvent } from 'react';
 
+import { DataSourceForm } from '../components/DataSourceForm';
 import { getConnectionMessage } from '../utils';
 import { DataSourceFormActions } from '@/data-sources/components/DataSourceFormActions';
 import { SlugInput } from '@/data-sources/components/SlugInput';
@@ -261,64 +262,59 @@ export const GoogleSheetsSettings = ( {
 	}, [ state.spreadsheet, sheets ] );
 
 	return (
-		<Card className="add-update-data-source-card">
-			<CardHeader>
-				<h2>
-					{ mode === 'add'
-						? __( 'Add Google Sheets Data Source' )
-						: __( 'Edit Google Sheets Data Source' ) }
-				</h2>
-			</CardHeader>
-			<CardBody>
-				<form>
-					<div className="form-group">
-						<SlugInput slug={ state.slug } onChange={ onSlugChange } uuid={ uuidFromProps } />
-					</div>
+		<DataSourceForm
+			heading={
+				mode === 'add'
+					? __( 'Add Google Sheets Data Source' )
+					: __( 'Edit Google Sheets Data Source' )
+			}
+		>
+			<div className="form-group">
+				<SlugInput slug={ state.slug } onChange={ onSlugChange } uuid={ uuidFromProps } />
+			</div>
 
-					<div className="form-group">
-						<TextareaControl
-							label={ __( 'Credentials', 'remote-data-blocks' ) }
-							value={ state.credentials }
-							onChange={ onCredentialsChange }
-							help={ credentialsHelpText }
-							rows={ 14 }
-							className="code-input"
-						/>
-					</div>
+			<div className="form-group">
+				<TextareaControl
+					label={ __( 'Credentials', 'remote-data-blocks' ) }
+					value={ state.credentials }
+					onChange={ onCredentialsChange }
+					help={ credentialsHelpText }
+					rows={ 14 }
+					className="code-input"
+				/>
+			</div>
 
-					<div className="form-group">
-						<SelectControl
-							id="spreadsheet"
-							label={ __( 'Spreadsheet', 'remote-data-blocks' ) }
-							value={ state.spreadsheet?.id ?? '' }
-							onChange={ onSelectChange }
-							options={ spreadsheetOptions }
-							help={ spreadsheetHelpText }
-							disabled={ fetchingToken || ! spreadsheets?.length }
-							__next40pxDefaultSize
-						/>
-					</div>
+			<div className="form-group">
+				<SelectControl
+					id="spreadsheet"
+					label={ __( 'Spreadsheet', 'remote-data-blocks' ) }
+					value={ state.spreadsheet?.id ?? '' }
+					onChange={ onSelectChange }
+					options={ spreadsheetOptions }
+					help={ spreadsheetHelpText }
+					disabled={ fetchingToken || ! spreadsheets?.length }
+					__next40pxDefaultSize
+				/>
+			</div>
 
-					<div className="form-group">
-						<SelectControl
-							id="sheet"
-							label={ __( 'Sheet', 'remote-data-blocks' ) }
-							value={ state.sheet?.id ?? '' }
-							onChange={ onSelectChange }
-							options={ sheetOptions }
-							help={ sheetHelpText }
-							disabled={ fetchingToken || ! sheets?.length }
-							__next40pxDefaultSize
-						/>
-					</div>
+			<div className="form-group">
+				<SelectControl
+					id="sheet"
+					label={ __( 'Sheet', 'remote-data-blocks' ) }
+					value={ state.sheet?.id ?? '' }
+					onChange={ onSelectChange }
+					options={ sheetOptions }
+					help={ sheetHelpText }
+					disabled={ fetchingToken || ! sheets?.length }
+					__next40pxDefaultSize
+				/>
+			</div>
 
-					<DataSourceFormActions
-						onSave={ onSaveClick }
-						onCancel={ goToMainScreen }
-						isSaveDisabled={ ! shouldAllowSubmit }
-					/>
-				</form>
-			</CardBody>
-		</Card>
+			<DataSourceFormActions
+				onSave={ onSaveClick }
+				onCancel={ goToMainScreen }
+				isSaveDisabled={ ! shouldAllowSubmit }
+			/>
+		</DataSourceForm>
 	);
 };

--- a/src/data-sources/http/HttpSettings.tsx
+++ b/src/data-sources/http/HttpSettings.tsx
@@ -1,7 +1,8 @@
-import { Card, CardBody, CardHeader, TextControl } from '@wordpress/components';
+import { TextControl } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+import { DataSourceForm } from '../components/DataSourceForm';
 import { DataSourceFormActions } from '@/data-sources/components/DataSourceFormActions';
 import { HttpAuthSettingsInput } from '@/data-sources/components/HttpAuthSettingsInput';
 import { SlugInput } from '@/data-sources/components/SlugInput';
@@ -120,38 +121,33 @@ export const HttpSettings = ( {
 	};
 
 	return (
-		<Card className="add-update-data-source-card">
-			<CardHeader>
-				<h2>{ mode === 'add' ? __( 'Add HTTP Data Source' ) : __( 'Edit HTTP Data Source' ) }</h2>
-			</CardHeader>
-			<CardBody>
-				<form>
-					<div className="form-group">
-						<SlugInput slug={ state.slug } onChange={ onSlugChange } uuid={ uuidFromProps } />
-					</div>
+		<DataSourceForm
+			heading={ mode === 'add' ? __( 'Add HTTP Data Source' ) : __( 'Edit HTTP Data Source' ) }
+		>
+			<div className="form-group">
+				<SlugInput slug={ state.slug } onChange={ onSlugChange } uuid={ uuidFromProps } />
+			</div>
 
-					<div className="form-group">
-						<TextControl
-							type="url"
-							id="url"
-							label={ __( 'URL', 'remote-data-blocks' ) }
-							value={ state.url }
-							onChange={ value => handleOnChange( 'url', value ) }
-							autoComplete="off"
-							__next40pxDefaultSize
-							help={ __( 'The URL for the HTTP endpoint.', 'remote-data-blocks' ) }
-						/>
-					</div>
+			<div className="form-group">
+				<TextControl
+					type="url"
+					id="url"
+					label={ __( 'URL', 'remote-data-blocks' ) }
+					value={ state.url }
+					onChange={ value => handleOnChange( 'url', value ) }
+					autoComplete="off"
+					__next40pxDefaultSize
+					help={ __( 'The URL for the HTTP endpoint.', 'remote-data-blocks' ) }
+				/>
+			</div>
 
-					<HttpAuthSettingsInput auth={ getAuthState() } onChange={ handleOnChange } />
+			<HttpAuthSettingsInput auth={ getAuthState() } onChange={ handleOnChange } />
 
-					<DataSourceFormActions
-						onSave={ onSaveClick }
-						onCancel={ goToMainScreen }
-						isSaveDisabled={ ! shouldAllowSubmit }
-					/>
-				</form>
-			</CardBody>
-		</Card>
+			<DataSourceFormActions
+				onSave={ onSaveClick }
+				onCancel={ goToMainScreen }
+				isSaveDisabled={ ! shouldAllowSubmit }
+			/>
+		</DataSourceForm>
 	);
 };

--- a/src/data-sources/shopify/ShopifySettings.tsx
+++ b/src/data-sources/shopify/ShopifySettings.tsx
@@ -1,7 +1,8 @@
-import { Card, CardBody, CardHeader, TextControl } from '@wordpress/components';
+import { TextControl } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+import { DataSourceForm } from '../components/DataSourceForm';
 import { DataSourceFormActions } from '@/data-sources/components/DataSourceFormActions';
 import PasswordInputControl from '@/data-sources/components/PasswordInputControl';
 import { SlugInput } from '@/data-sources/components/SlugInput';
@@ -81,61 +82,56 @@ export const ShopifySettings = ( {
 	};
 
 	return (
-		<Card className="add-update-data-source-card">
-			<CardHeader>
-				<h2>
-					{ mode === 'add' ? __( 'Add Shopify Data Source' ) : __( 'Edit Shopify Data Source' ) }
-				</h2>
-			</CardHeader>
-			<CardBody>
-				<form>
-					<div className="form-group">
-						<SlugInput slug={ state.slug } onChange={ onSlugChange } uuid={ uuidFromProps } />
-					</div>
+		<DataSourceForm
+			heading={
+				mode === 'add' ? __( 'Add Shopify Data Source' ) : __( 'Edit Shopify Data Source' )
+			}
+		>
+			<div className="form-group">
+				<SlugInput slug={ state.slug } onChange={ onSlugChange } uuid={ uuidFromProps } />
+			</div>
 
-					<div className="form-group">
-						<TextControl
-							type="url"
-							label={ __( 'Store Slug', 'remote-data-blocks' ) }
-							onChange={ storeName => {
-								handleOnChange( 'store_name', storeName ?? '' );
-							} }
-							value={ state.store_name }
-							placeholder="your-shop-name"
-							help={ __( 'Example: https://your-shop-name.myshopify.com', 'remote-data-blocks' ) }
-							autoComplete="off"
-							__next40pxDefaultSize
-						/>
-					</div>
+			<div className="form-group">
+				<TextControl
+					type="url"
+					label={ __( 'Store Slug', 'remote-data-blocks' ) }
+					onChange={ storeName => {
+						handleOnChange( 'store_name', storeName ?? '' );
+					} }
+					value={ state.store_name }
+					placeholder="your-shop-name"
+					help={ __( 'Example: https://your-shop-name.myshopify.com', 'remote-data-blocks' ) }
+					autoComplete="off"
+					__next40pxDefaultSize
+				/>
+			</div>
 
-					<div className="form-group">
-						<PasswordInputControl
-							label={ __( 'Access Token', 'remote-data-blocks' ) }
-							onChange={ onTokenInputChange }
-							value={ state.access_token }
-							help={ connectionMessage }
-						/>
-					</div>
+			<div className="form-group">
+				<PasswordInputControl
+					label={ __( 'Access Token', 'remote-data-blocks' ) }
+					onChange={ onTokenInputChange }
+					value={ state.access_token }
+					help={ connectionMessage }
+				/>
+			</div>
 
-					<div className="form-group">
-						<TextControl
-							label={ __( 'Store Name', 'remote-data-blocks' ) }
-							placeholder={ __( 'Auto-filled on successful connection.', 'remote-data-blocks' ) }
-							value={ shopName ?? '' }
-							onChange={ () => {} }
-							tabIndex={ -1 }
-							readOnly
-							__next40pxDefaultSize
-						/>
-					</div>
+			<div className="form-group">
+				<TextControl
+					label={ __( 'Store Name', 'remote-data-blocks' ) }
+					placeholder={ __( 'Auto-filled on successful connection.', 'remote-data-blocks' ) }
+					value={ shopName ?? '' }
+					onChange={ () => {} }
+					tabIndex={ -1 }
+					readOnly
+					__next40pxDefaultSize
+				/>
+			</div>
 
-					<DataSourceFormActions
-						onSave={ onSaveClick }
-						onCancel={ goToMainScreen }
-						isSaveDisabled={ ! shouldAllowSubmit }
-					/>
-				</form>
-			</CardBody>
-		</Card>
+			<DataSourceFormActions
+				onSave={ onSaveClick }
+				onCancel={ goToMainScreen }
+				isSaveDisabled={ ! shouldAllowSubmit }
+			/>
+		</DataSourceForm>
 	);
 };

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -1,5 +1,8 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { Button, ExternalLink, __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronLeft } from '@wordpress/icons';
 
+import { AddDataSourceDropdown } from '@/data-sources/AddDataSourceDropdown';
 import DataSourceList from '@/data-sources/DataSourceList';
 import DataSourceSettings from '@/data-sources/DataSourceSettings';
 import Notices from '@/settings/Notices';
@@ -7,31 +10,41 @@ import { SettingsContext, useDataSourceRouter } from '@/settings/hooks/useSettin
 
 import './SettingsPage.scss';
 
-function versionAndBuild() {
-	const localized = window.REMOTE_DATA_BLOCKS_SETTINGS;
-	const version = localized?.version ?? '0.0.0';
-	const branch = localized?.branch ?? '';
-	const hash = localized?.hash ?? '';
-
-	const shortHash = hash.slice( 0, 7 );
-	const devString = [ branch, shortHash ].filter( Boolean ).join( ' @ ' );
-
-	return devString ? `${ version } (${ devString })` : version;
-}
-
 const SettingsPage = () => {
 	const settingsContext = useDataSourceRouter();
 
 	return (
 		<div className="rdb-settings-page">
-			<div className="page-title">
-				<h1>{ __( 'Remote Data Blocks', 'remote-data-blocks' ) }</h1>
-				<p className="plugin-version">
-					{ sprintf( __( '-- Version %s', 'remote-data-blocks' ), versionAndBuild() ) }
-				</p>
-			</div>
-			<div className="page-content">
-				<SettingsContext.Provider value={ settingsContext }>
+			<SettingsContext.Provider value={ settingsContext }>
+				<div className="rdb-settings-page_header">
+					{ [ 'addDataSource', 'editDataSource' ].includes( settingsContext.screen ) ? (
+						<HStack className="rdb-settings-page_header-return">
+							<Button icon={ chevronLeft } onClick={ () => settingsContext.goToMainScreen() } />
+							<h2>
+								{ __(
+									`${
+										[ 'addDataSource' ].includes( settingsContext.screen ) ? 'New ' : 'Edit'
+									} Data Source`,
+									'remote-data-blocks'
+								) }
+							</h2>
+						</HStack>
+					) : (
+						<>
+							<h1>{ __( 'Data', 'remote-data-blocks' ) }</h1>
+							<p>
+								{ __(
+									'Add and manage data sources used for blocks and content across your site. '
+								) }
+								<ExternalLink href="https://remotedatablocks.com/">
+									{ __( 'Learn more', 'remote-data-blocks' ) }
+								</ExternalLink>
+							</p>
+							<AddDataSourceDropdown />
+						</>
+					) }
+				</div>
+				<div className="page-content">
 					<Notices />
 
 					{ [ 'addDataSource', 'editDataSource' ].includes( settingsContext.screen ) ? (
@@ -39,8 +52,8 @@ const SettingsPage = () => {
 					) : (
 						<DataSourceList />
 					) }
-				</SettingsContext.Provider>
-			</div>
+				</div>
+			</SettingsContext.Provider>
 		</div>
 	);
 };

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -31,7 +31,7 @@ const SettingsPage = () => {
 						</HStack>
 					) : (
 						<>
-							<h1>{ __( 'Data', 'remote-data-blocks' ) }</h1>
+							<h1>{ __( 'Data sources', 'remote-data-blocks' ) }</h1>
 							<p>
 								{ __(
 									'Add and manage data sources used for blocks and content across your site. '

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -2,9 +2,9 @@ import { Button, ExternalLink, __experimentalHStack as HStack } from '@wordpress
 import { __ } from '@wordpress/i18n';
 import { chevronLeft } from '@wordpress/icons';
 
-import { AddDataSourceDropdown } from '@/data-sources/AddDataSourceDropdown';
 import DataSourceList from '@/data-sources/DataSourceList';
 import DataSourceSettings from '@/data-sources/DataSourceSettings';
+import { AddDataSourceDropdown } from '@/data-sources/components/AddDataSourceDropdown';
 import Notices from '@/settings/Notices';
 import { SettingsContext, useDataSourceRouter } from '@/settings/hooks/useSettingsNav';
 

--- a/src/settings/index.scss
+++ b/src/settings/index.scss
@@ -6,38 +6,38 @@
 		padding: 0;
 	}
 
-	#remote-data-blocks-settings-wrapper {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		padding: 24px 20px;
+	#wpwrap {
+		background: rgb(255, 255, 255);
 	}
 
-	#remote-data-blocks-settings {
-		width: 100%;
-		max-width: 1400px;
+	.components-external-link__contents {
+		text-decoration: none;
 	}
 
-	.page-title {
-		display: flex;
-		align-items: center;
+	.rdb-settings-page_header {
+		display: grid;
+		padding: 24px 48px;
+		border-bottom: 1px solid var(--Alias-border-border-secondary, #ebebeb);
+	}
 
-		h1 {
-			font-weight: 500;
-			line-height: 32px;
-			margin: 0;
-		}
+	.rdb-settings-page_header-return {
+		justify-content: flex-start;
+	}
 
-		p {
-			margin: 5px 0 0 6px;
-		}
+	h1 {
+		margin-bottom: 0;
+	}
+
+	.rdb-settings-page_add-data-source-dropdown {
+		grid-area: 1 / 2 / span 1 / span 1;
+		justify-self: end;
 	}
 
 	.page-content {
-		margin-top: 24px;
 
 		> *:not(:first-child) {
 			margin-top: 18px;
 		}
 	}
 }
+


### PR DESCRIPTION
## Description

Some small changes to the design of the settings page, mainly in the header:

<img width="1261" alt="Screenshot 2024-11-18 at 2 33 12 PM" src="https://github.com/user-attachments/assets/3bab97eb-af67-4412-9135-cdbaf4a65f23">

- replaced the `Dropdown` with the `DropdownMenu` component for improved a11y. Before, it wasn't possible to tab/use arrow keys to navigate within the popover as expected. Focus available on submenu now: 
<img width="267" alt="Screenshot 2024-11-18 at 2 33 19 PM" src="https://github.com/user-attachments/assets/1b9c24fe-580a-4e82-ae15-cc5bf4f3b829">

- replaced the deletion confirmation `Modal` with the `ConfirmDialog` component

<img width="958" alt="Screenshot 2024-11-18 at 2 39 29 PM" src="https://github.com/user-attachments/assets/f4350d14-764e-4e1a-bdb5-4f28ed3da65a">

There is also a back button in the header on the edit/add source pages. As a result, there are a few visual changes and a new form component added. The form will be handled in a follow-up, but it was added here so the header didn't look odd in the meantime:
<img width="842" alt="Screenshot 2024-11-18 at 1 36 04 PM" src="https://github.com/user-attachments/assets/54df01c7-d866-417c-8817-231065a8c43c">
After with form component: 
<img width="1411" alt="Screenshot 2024-11-18 at 2 34 26 PM" src="https://github.com/user-attachments/assets/617e6226-92b1-48f5-b0b1-4a92ecc375ce">

## Testing Instructions

- On the settings page, tab to the 'Add' menu button and use tab/arrow keys to navigate and select subitems 
- Click on the delete icon to access confirmation dialog. Click 'cancel' and then open it again and click 'Confirm' to verify the behaviour is the same as before
- Edit/add source pages should behave the same as before, and have a back button in the header