### PR TITLE
fix data source slug update in the form

### DIFF
--- a/src/data-sources/components/SlugInput.tsx
+++ b/src/data-sources/components/SlugInput.tsx
@@ -21,7 +21,7 @@ export const SlugInput: React.FC< SlugInputProps > = ( { slug, onChange, uuid } 
 	const debouncedCheckSlugConflict = useDebounce( checkSlugConflict, 500 );
 	const onSlugUpdate = () => {
 		const sanitizedSlug = slugify( newSlug ?? '' );
-		if ( sanitizedSlug !== newSlug ) {
+		if ( sanitizedSlug !== slug ) {
 			setNewSlug( sanitizedSlug );
 			onChange( sanitizedSlug );
 			void debouncedCheckSlugConflict( sanitizedSlug, uuid ?? '' );


### PR DESCRIPTION
## Issue
A bug was introduced in #195 where the slug field in the data source form wouldn't update properly under certain conditions. The bug occurred because the `SlugInput` component was comparing the sanitized slug with its local state instead of the form's state.

## Bug Details
The component would:
1. Compare sanitized slug with local unsanitized slug
2. Only update in form state if they were different
3. Ignore whether the value differed from form state

This caused the form state to retain old/empty values even when the user had entered valid input.

## Steps to Reproduce
1. Open "Add Data Source" form
2. Enter a slug that remains unchanged after sanitization (e.g., "my-data-source")
3. Submit form
4. Form fails because slug remains empty in form state

## Fix
Modified the comparison to check against the form's slug prop instead of local state, ensuring form state updates correctly regardless of sanitization results.

## Testing
1. Open "Add Data Source" form
2. Enter various slugs:
   - Slugs needing sanitization (e.g., "My Data Source")
   - Slugs already sanitized (e.g., "my-data-source")
3. Verify form state updates correctly
4. Confirm successful form submission