### PR TITLE
Improve "expected error" types

### DIFF
--- a/src/blocks/remote-data-container/index.ts
+++ b/src/blocks/remote-data-container/index.ts
@@ -1,5 +1,4 @@
-// @ts-expect-error -- Temporary registerBlockBindingsSource type error workaround for WordPress 6.7
-import { registerBlockType, registerBlockBindingsSource } from '@wordpress/blocks';
+import { registerBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 import { registerFormatType } from '@wordpress/rich-text';
 
@@ -8,6 +7,7 @@ import { FieldShortcodeButton } from '@/blocks/remote-data-container/components/
 import { Edit } from '@/blocks/remote-data-container/edit';
 import { withBlockBindingShim } from '@/blocks/remote-data-container/filters/withBlockBinding';
 import { Save } from '@/blocks/remote-data-container/save';
+import { registerBlockBindingsSource } from '@/types/expected-errors/registerBlockBindingsSource';
 import { getBlocksConfig } from '@/utils/localized-block-data';
 import './style.scss';
 
@@ -47,13 +47,11 @@ addFilter(
 	5 // Ensure this runs before core filters
 );
 
-// eslint-disable-next-line -- Temporary registerBlockBindingsSource type error workaround for WordPress 6.7
 registerBlockBindingsSource( {
 	name: 'remote-data/binding',
 	label: 'Remote Data Binding',
 	usesContext: [ 'remote-data-blocks/remoteData' ],
-	// eslint-disable-next-line -- Temporary registerBlockBindingsSource type error workaround for WordPress 6.7
-	getValues( { select, clientId, context, bindings }: any ) {
+	getValues() {
 		return {};
 	},
 } );

--- a/src/types/expected-errors/registerBlockBindingsSource.ts
+++ b/src/types/expected-errors/registerBlockBindingsSource.ts
@@ -1,0 +1,36 @@
+// @ts-expect-error Temporary registerBlockBindingsSource type error workaround for WordPress 6.7
+import { registerBlockBindingsSource as originalRegisterBlockBindingsSource } from '@wordpress/blocks';
+
+import type {
+	BlockEditorStoreActions,
+	BlockEditorStoreSelectors,
+	BlockEditorStoreDescriptor,
+} from '@wordpress/block-editor';
+
+interface GetValuesPayload< Context, Values > {
+	bindings: Values;
+	clientId: string;
+	context: Context;
+	select: ( store: BlockEditorStoreDescriptor ) => BlockEditorStoreSelectors;
+}
+
+interface SetValuesPayload< Context, Values > extends GetValuesPayload< Context, Values > {
+	dispatch: ( store: BlockEditorStoreDescriptor ) => BlockEditorStoreActions;
+	values: Values;
+}
+
+export interface BlockBindingsSource< Context = Record< string, unknown >, Values = unknown > {
+	canUserEditValue?: ( payload: GetValuesPayload< Context, Values > ) => boolean;
+	getValues?: ( payload: GetValuesPayload< Context, Values > ) => Values;
+	label?: string;
+	name: string;
+	setValues?: ( payload: SetValuesPayload< Context, Values > ) => void;
+	usesContext?: string[];
+}
+
+export function registerBlockBindingsSource< Context, Values >(
+	source: BlockBindingsSource< Context, Values >
+): void {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+	originalRegisterBlockBindingsSource( source );
+}

--- a/types/localized-settings.d.ts
+++ b/types/localized-settings.d.ts
@@ -3,7 +3,3 @@ interface LocalizedSettingsData {
 	hash: string;
 	version: string;
 }
-
-type NullableKeys< T, K extends keyof T > = Omit< T, K > & {
-	[ P in K ]: T[ P ] | null;
-};

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -1,0 +1,3 @@
+type NullableKeys< T, K extends keyof T > = Omit< T, K > & {
+	[ P in K ]: T[ P ] | null;
+};

--- a/types/wordpress__notices/index.d.ts
+++ b/types/wordpress__notices/index.d.ts
@@ -20,7 +20,7 @@ declare module '@wordpress/notices' {
 		__unstableHTML?: boolean;
 	}
 
-	export interface WPNotice {
+	interface WPNotice {
 		id: string;
 		status: string;
 		content: string;
@@ -46,13 +46,13 @@ declare module '@wordpress/notices' {
 		id: string;
 	}
 
-	export interface NoticeStoreActions {
+	interface NoticeStoreActions {
 		createSuccessNotice: ( content: string, options?: CreateNoticeOptions ) => CreateNoticeReturn;
 		createErrorNotice: ( content: string, options?: CreateNoticeOptions ) => CreateNoticeReturn;
 		removeNotice: ( id: string, context?: string ) => RemoveNoticeReturn;
 	}
 
-	export interface NoticeStoreSelectors {
+	interface NoticeStoreSelectors {
 		getNotices: ( state: object = {}, context?: string ) => WPNotice[];
 	}
 }


### PR DESCRIPTION
- In special circumstances where we are faced with insufficient library types that we cannot augment, we should still work to preserve type safety. Instead of ignoring type errors and effectively relaxing to an `any` type, we can cordon the problematic entity and reexport it with strict typing. In this PR, we do this for `registerBlockBindingsSource`.
- Miscellaneous fixes:
  - Remove redundant `export` keywords in type declarations.
  - Move `NullableKeys` utility type to its own file.