### PR TITLE
Documentation Changes based on Walkthrough

### DIFF
--- a/docs/extending/hooks.md
+++ b/docs/extending/hooks.md
@@ -28,7 +28,7 @@ add_filter( 'wpcomvip_log_to_query_monitor', '__return_false' );
 Filter whether to register the included example API block ("Conference Event") (default: `true`).
 
 ```php
-add_filter( 'remote_data_blocks_register_example_block', '__return false' );
+add_filter( 'remote_data_blocks_register_example_block', '__return_false' );
 ```
 
 ### remote_data_blocks_allowed_url_schemes

--- a/docs/extending/query.md
+++ b/docs/extending/query.md
@@ -67,7 +67,15 @@ The `get_input_schema` method defines the input data expected by the query. The 
 - `overrides` (optional): An array of possible [overrides](overrides.md) for the input variable. Each override is an associative array with the following keys:
   - `type`: The type of the override. Supported values are `query_var` and `url`.
   - `target`: The targeted entity for the override (e.g., the query or URL variable that contains the overridde).
-- `type` (required): The type of the input variable. Supported types are `string`, `number`, and `boolean`.
+- `type` (required): The type of the input variable. Supported types are:
+  - `base64`
+  - `boolean`
+  - `button_url`
+  - `image_alt`
+  - `image_url`
+  - `number`
+  - `price`
+  - `string`
 
 #### Example
 


### PR DESCRIPTION
* Fixed a typo on the hook implementation
* Updated the allowed types based on [this definition](https://github.com/Automattic/remote-data-blocks/blob/41091e6db9ba57e0ee21185f5c51584ff2e32d5c/src/blocks/remote-data-container/config/constants.ts#L12).