### PR TITLE
Restore missing block binding controls

### DIFF
--- a/src/blocks/remote-data-container/config/constants.ts
+++ b/src/blocks/remote-data-container/config/constants.ts
@@ -1,6 +1,13 @@
 import { getRestUrl } from '@/utils/localized-block-data';
 import { getClassName } from '@/utils/string';
 
+export const SUPPORTED_CORE_BLOCKS = [
+	'core/button',
+	'core/heading',
+	'core/image',
+	'core/paragraph',
+];
+
 export const DISPLAY_QUERY_KEY = '__DISPLAY__';
 export const REMOTE_DATA_CONTEXT_KEY = 'remote-data-blocks/remoteData';
 export const REMOTE_DATA_REST_API_URL = getRestUrl();

--- a/src/blocks/remote-data-container/filters/addUsesContext.ts
+++ b/src/blocks/remote-data-container/filters/addUsesContext.ts
@@ -1,0 +1,26 @@
+import { BlockConfiguration } from '@wordpress/blocks';
+
+import {
+	REMOTE_DATA_CONTEXT_KEY,
+	SUPPORTED_CORE_BLOCKS,
+} from '@/blocks/remote-data-container/config/constants';
+
+export function addUsesContext(
+	settings: BlockConfiguration< RemoteDataInnerBlockAttributes >,
+	name: string
+) {
+	if ( ! SUPPORTED_CORE_BLOCKS.includes( name ) ) {
+		return settings;
+	}
+
+	const { usesContext = [] } = settings;
+
+	if ( ! usesContext?.includes( REMOTE_DATA_CONTEXT_KEY ) ) {
+		return {
+			...settings,
+			usesContext: [ ...usesContext, REMOTE_DATA_CONTEXT_KEY ],
+		};
+	}
+
+	return settings;
+}

--- a/src/blocks/remote-data-container/index.ts
+++ b/src/blocks/remote-data-container/index.ts
@@ -5,6 +5,7 @@ import { registerFormatType } from '@wordpress/rich-text';
 import { formatTypeSettings } from '@/blocks/remote-data-container/components/field-shortcode';
 import { FieldShortcodeButton } from '@/blocks/remote-data-container/components/field-shortcode/FieldShortcodeButton';
 import { Edit } from '@/blocks/remote-data-container/edit';
+import { addUsesContext } from '@/blocks/remote-data-container/filters/addUsesContext';
 import { withBlockBindingShim } from '@/blocks/remote-data-container/filters/withBlockBinding';
 import { Save } from '@/blocks/remote-data-container/save';
 import { registerBlockBindingsSource } from '@/types/expected-errors/registerBlockBindingsSource';
@@ -46,6 +47,11 @@ addFilter(
 	withBlockBindingShim,
 	5 // Ensure this runs before core filters
 );
+
+/**
+ * Use a filter to inject usesContext to core block settings.
+ */
+addFilter( 'blocks.registerBlockType', 'remote-data-blocks/addUsesContext', addUsesContext, 10 );
 
 registerBlockBindingsSource( {
 	name: 'remote-data/binding',


### PR DESCRIPTION
Restore missing block binding controls by filtering `blocks.registerBlockType` and adding our context to `usesContext` for supported blocks.
