### PR TITLE
Make QueryRunner an implementation detail and provide `execute` on public interface

### DIFF
--- a/docs/extending/query.md
+++ b/docs/extending/query.md
@@ -179,9 +179,9 @@ Override this method to define a request body for this query. The return value w
 
 Override this method to specify a name that represents the query in UI.
 
-### get_query_runner(): QueryRunnerInterface
+### execute(): array|WP_Error
 
-Override this method to specify a custom [query runner](query-runner.md) for this query. The default query runner works well with most HTTP-powered APIs.
+Override this method to specify a custom execution implementation. By default, we execute this query with our [query runner](query-runner.md), which works well with most HTTP-powered APIs.
 
 ### process_response( string $raw_response_data, array $input_variables ): string|array|object|null
 

--- a/inc/Config/QueryContext/HttpQueryContext.php
+++ b/inc/Config/QueryContext/HttpQueryContext.php
@@ -6,9 +6,9 @@ use RemoteDataBlocks\Config\ArraySerializableInterface;
 use RemoteDataBlocks\Config\DataSource\HttpDataSource;
 use RemoteDataBlocks\Config\DataSource\HttpDataSourceInterface;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
-use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
 use RemoteDataBlocks\Validation\Validator;
 use RemoteDataBlocks\Validation\ValidatorInterface;
+use WP_Error;
 
 defined( 'ABSPATH' ) || exit();
 
@@ -98,6 +98,15 @@ class HttpQueryContext implements QueryContextInterface, HttpQueryContextInterfa
 
 		// @todo: expand or kill this
 		$this->config = $config;
+	}
+
+	/**
+	 * Override this method to provide a custom execution implementation.
+	 */
+	public function execute( array $input_variables ): array|WP_Error {
+		$query_runner = new QueryRunner( $this );
+		
+		return $query_runner->execute( $input_variables );
 	}
 
 	/**
@@ -198,13 +207,6 @@ class HttpQueryContext implements QueryContextInterface, HttpQueryContextInterfa
 	 */
 	public function get_query_name(): string {
 		return 'Query';
-	}
-
-	/**
-	 * Override this method to specify a custom query runner for this query.
-	 */
-	public function get_query_runner(): QueryRunnerInterface {
-		return new QueryRunner( $this );
 	}
 
 	/**

--- a/inc/Config/QueryContext/QueryContextInterface.php
+++ b/inc/Config/QueryContext/QueryContextInterface.php
@@ -2,18 +2,18 @@
 
 namespace RemoteDataBlocks\Config\QueryContext;
 
-use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
+use WP_Error;
 
 /**
  * QueryContextInterface interface
  *
  */
 interface QueryContextInterface {
+	public function execute( array $input_variables ): array|WP_Error;
 	public function get_image_url(): string|null;
 	public function get_input_schema(): array;
 	public function get_output_schema(): array;
 	public function get_query_name(): string;
-	public function get_query_runner(): QueryRunnerInterface;
 	public function is_response_data_collection(): bool;
 	public function process_response( string $raw_response_data, array $input_variables ): string|array|object|null;
 }

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -200,9 +200,7 @@ class BlockBindings {
 		try {
 			$query_config = $block_config['queries']['__DISPLAY__'];
 			$query_input = self::get_query_input( $block_context, $query_config );
-
-			$query_runner = $query_config->get_query_runner();
-			$query_results = $query_runner->execute( $query_input );
+			$query_results = $query_config->execute( $query_input );
 
 			if ( is_wp_error( $query_results ) ) {
 				self::log_error( 'Error executing query for block binding: ' . $query_results->get_error_message(), $block_name, $operation_name );

--- a/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetRecordQuery.php
@@ -3,9 +3,14 @@
 namespace RemoteDataBlocks\ExampleApi\Queries;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
-use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
+use WP_Error;
 
 class ExampleApiGetRecordQuery extends HttpQueryContext {
+	public function execute( array $input_variables ): array|WP_Error {
+		$query_runner = new ExampleApiQueryRunner( $this );
+		return $query_runner->execute( $input_variables );
+	}
+
 	public function get_input_schema(): array {
 		return [
 			'record_id' => [
@@ -51,9 +56,5 @@ class ExampleApiGetRecordQuery extends HttpQueryContext {
 
 	public function get_query_name(): string {
 		return 'Get event';
-	}
-
-	public function get_query_runner(): QueryRunnerInterface {
-		return new ExampleApiQueryRunner( $this );
 	}
 }

--- a/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
+++ b/inc/ExampleApi/Queries/ExampleApiGetTableQuery.php
@@ -3,9 +3,14 @@
 namespace RemoteDataBlocks\ExampleApi\Queries;
 
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
-use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
+use WP_Error;
 
 class ExampleApiGetTableQuery extends HttpQueryContext {
+	public function execute( array $input_variables ): array|WP_Error {
+		$query_runner = new ExampleApiQueryRunner( $this );
+		return $query_runner->execute( $input_variables );
+	}
+
 	public function get_output_schema(): array {
 		return [
 			'root_path' => '$.records[*]',
@@ -37,9 +42,5 @@ class ExampleApiGetTableQuery extends HttpQueryContext {
 
 	public function get_query_name(): string {
 		return 'List events';
-	}
-
-	public function get_query_runner(): QueryRunnerInterface {
-		return new ExampleApiQueryRunner( $this );
 	}
 }

--- a/inc/REST/RemoteDataController.php
+++ b/inc/REST/RemoteDataController.php
@@ -65,8 +65,7 @@ class RemoteDataController {
 		// expects, so only include those defined by the query.
 		$query_input = array_intersect_key( $query_input, $query->input_schema );
 
-		$query_runner = $query->get_query_runner();
-		$query_result = $query_runner->execute( $query_input );
+		$query_result = $query->execute( $query_input );
 
 		if ( is_wp_error( $query_result ) ) {
 			$logger = LoggerManager::instance();

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -33,6 +33,11 @@ class QueryRunnerTest extends TestCase {
 				parent::__construct( $http_data_source );
 			}
 
+			public function execute( array $input_variables ): array|WP_Error {
+				$query_runner = new QueryRunner( $this, $this->http_client );
+				return $query_runner->execute( $input_variables );
+			}
+
 			public function get_endpoint( array $input_variables = [] ): string {
 				return $this->http_data_source->get_endpoint();
 			}
@@ -51,10 +56,6 @@ class QueryRunnerTest extends TestCase {
 
 			public function get_query_name(): string {
 				return 'Query';
-			}
-
-			public function get_query_runner(): QueryRunnerInterface {
-				return new QueryRunner( $this, $this->http_client );
 			}
 
 			public function process_response( string $raw_response_data, array $input_variables ): string|array|object|null {
@@ -124,8 +125,7 @@ class QueryRunnerTest extends TestCase {
 		$this->http_data_source->set_endpoint( $endpoint );
 		$this->http_client->method( 'request' )->willReturn( $response );
 
-		$query_runner = $this->query_context->get_query_runner();
-		$result = $query_runner->execute( $input_variables );
+		$result = $this->query_context->execute( $input_variables );
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'is_collection', $result );
@@ -181,8 +181,7 @@ class QueryRunnerTest extends TestCase {
 
 		$this->http_data_source->set_endpoint( $endpoint );
 
-		$query_runner = $this->query_context->get_query_runner();
-		$result = $query_runner->execute( $input_variables );
+		$result = $this->query_context->execute( $input_variables );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( $expected_error_code, $result->get_error_code() );
@@ -234,8 +233,7 @@ class QueryRunnerTest extends TestCase {
 			],
 		];
 
-		$query_runner = $this->query_context->get_query_runner();
-		$result = $query_runner->execute( $input_variables );
+		$result = $this->query_context->execute( $input_variables );
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'is_collection', $result );
@@ -280,8 +278,7 @@ class QueryRunnerTest extends TestCase {
 			],
 		];
 
-		$query_runner = $this->query_context->get_query_runner();
-		$result = $query_runner->execute( [] );
+		$result = $this->query_context->execute( [] );
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'is_collection', $result );
@@ -326,8 +323,7 @@ class QueryRunnerTest extends TestCase {
 			],
 		];
 
-		$query_runner = $this->query_context->get_query_runner();
-		$result = $query_runner->execute( [] );
+		$result = $this->query_context->execute( [] );
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'is_collection', $result );
@@ -375,8 +371,7 @@ class QueryRunnerTest extends TestCase {
 			],
 		];
 
-		$query_runner = $this->query_context->get_query_runner();
-		$result = $query_runner->execute( [] );
+		$result = $this->query_context->execute( [] );
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'is_collection', $result );

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use RemoteDataBlocks\Config\DataSource\HttpDataSource;
 use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
-use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
 use RemoteDataBlocks\HttpClient\HttpClient;
 use RemoteDataBlocks\Tests\Mocks\MockDataSource;
 use RemoteDataBlocks\Tests\Mocks\MockValidator;

--- a/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
+++ b/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
@@ -3,25 +3,12 @@
 namespace RemoteDataBlocks\Tests\Integrations\VipBlockDataApi;
 
 use PHPUnit\Framework\TestCase;
-use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
-use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
 use RemoteDataBlocks\Editor\BlockManagement\ConfigRegistry;
 use RemoteDataBlocks\Integrations\VipBlockDataApi\VipBlockDataApi;
+use RemoteDataBlocks\Tests\Mocks\MockQueryContext;
 use RemoteDataBlocks\Tests\Mocks\MockQueryRunner;
-use RemoteDataBlocks\Tests\Mocks\MockDataSource;
-use RemoteDataBlocks\Tests\Mocks\MockValidator;
 
 use function register_remote_data_block;
-
-class TestQueryContext extends HttpQueryContext {
-	public function __construct( private QueryRunnerInterface $mock_qr ) {
-		parent::__construct( MockDataSource::from_array( MockDataSource::MOCK_CONFIG, new MockValidator() ) );
-	}
-
-	public function get_query_runner(): QueryRunnerInterface {
-		return $this->mock_qr;
-	}
-}
 
 class VipBlockDataApiTest extends TestCase {
 	private static $sourced_block1 = [
@@ -160,7 +147,7 @@ class VipBlockDataApiTest extends TestCase {
 		$mock_qr->addResult( 'title', $expected1 );
 		$mock_qr->addResult( 'location', $expected2 );
 
-		$mock_query_context = new TestQueryContext( $mock_qr );
+		$mock_query_context = new MockQueryContext( $mock_qr );
 		register_remote_data_block( 'Events', $mock_query_context );
 
 		$result = VipBlockDataApi::resolve_remote_data( self::$sourced_block1, 'remote-data-blocks/events', 12, self::$parsed_block1, $mock_qr );
@@ -179,7 +166,7 @@ class VipBlockDataApiTest extends TestCase {
 		$mock_qr->addResult( 'title', 'Happy happy hour! No networking!' );
 		$mock_qr->addResult( 'location', new \WP_Error( 'rdb-uh-oh', 'uh-oh!' ) );
 
-		$mock_query_context = new TestQueryContext( $mock_qr );
+		$mock_query_context = new MockQueryContext( $mock_qr );
 		register_remote_data_block( 'Events', $mock_query_context );
 
 		$result = VipBlockDataApi::resolve_remote_data( self::$sourced_block1, 'remote-data-blocks/events', 12, self::$parsed_block1, $mock_qr );

--- a/tests/inc/Mocks/MockQueryContext.php
+++ b/tests/inc/Mocks/MockQueryContext.php
@@ -6,6 +6,7 @@ use RemoteDataBlocks\Config\QueryContext\HttpQueryContext;
 use RemoteDataBlocks\Tests\Mocks\MockDataSource;
 use RemoteDataBlocks\Tests\Mocks\MockValidator;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
+use WP_Error;
 
 class MockQueryContext extends HttpQueryContext {
 	public function __construct(
@@ -20,7 +21,7 @@ class MockQueryContext extends HttpQueryContext {
 		);
 	}
 
-	public function get_query_runner(): QueryRunnerInterface {
-		return $this->mock_qr;
+	public function execute( array $input_variables ): array|WP_Error {
+		return $this->mock_qr->execute( $input_variables );
 	}
 }


### PR DESCRIPTION
Make QueryRunner an implementation detail and provide `execute` on public interface