### PR TITLE
[UI] Fix modal size

### DIFF
--- a/src/blocks/remote-data-container/components/modals/BaseModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/BaseModal.tsx
@@ -28,7 +28,7 @@ export function BaseModal( props: BaseModalProps ) {
 				</>
 			}
 			onRequestClose={ props.onClose }
-			size={ props.size ?? 'large' }
+			size={ props.size ?? 'fill' }
 			title={ props.title }
 		>
 			{ props.children }


### PR DESCRIPTION
I removed CSS for the modal in #241 but forgot to include this update. This just makes the modal full screen again, without the need for the CSS. 

| Before  | After |
| ------------- | ------------- |
|  <img width="1351" alt="Screenshot 2024-12-17 at 8 28 45 AM" src="https://github.com/user-attachments/assets/ab1f0301-060d-495e-ad9f-978a122fd3cc" /> | <img width="1330" alt="Screenshot 2024-12-17 at 8 28 21 AM" src="https://github.com/user-attachments/assets/6db16cf4-c7f7-4292-9e35-92883b16218a" /> |
