### PR TITLE
airtable field mapping improvments

### DIFF
--- a/src/data-sources/airtable/constants.ts
+++ b/src/data-sources/airtable/constants.ts
@@ -56,7 +56,7 @@ export const SUPPORTED_AIRTABLE_TYPES = Object.freeze( [
 	'lastModifiedBy',
 	'singleCollaborator',
 	// Other types
-	'multipleCollaborator',
+	'multipleCollaborators',
 	'currency',
 	'checkbox',
 	'multipleAttachments',

--- a/src/data-sources/airtable/constants.ts
+++ b/src/data-sources/airtable/constants.ts
@@ -14,6 +14,7 @@ export const AIRTABLE_STRING_TYPES = Object.freeze(
 		'multipleRecordLinks',
 		'rollup',
 		'externalSyncSource',
+		'url',
 	] )
 );
 
@@ -42,6 +43,7 @@ export const SUPPORTED_AIRTABLE_TYPES = Object.freeze( [
 	'multipleRecordLinks',
 	'rollup',
 	'externalSyncSource',
+	'url',
 	// Number types
 	'number',
 	'autoNumber',
@@ -55,7 +57,6 @@ export const SUPPORTED_AIRTABLE_TYPES = Object.freeze( [
 	'singleCollaborator',
 	// Other types
 	'multipleCollaborator',
-	'url',
 	'button',
 	'currency',
 	'checkbox',

--- a/src/data-sources/airtable/constants.ts
+++ b/src/data-sources/airtable/constants.ts
@@ -57,7 +57,6 @@ export const SUPPORTED_AIRTABLE_TYPES = Object.freeze( [
 	'singleCollaborator',
 	// Other types
 	'multipleCollaborator',
-	'button',
 	'currency',
 	'checkbox',
 	'multipleAttachments',

--- a/src/data-sources/airtable/utils.ts
+++ b/src/data-sources/airtable/utils.ts
@@ -59,7 +59,7 @@ export const getAirtableOutputQueryMappingValue = (
 				type: 'image_url',
 			};
 
-		case 'multipleCollaborator':
+		case 'multipleCollaborators':
 			return {
 				...baseField,
 				path: `$.fields["${ field.name }"][*].name`,

--- a/src/data-sources/airtable/utils.ts
+++ b/src/data-sources/airtable/utils.ts
@@ -28,9 +28,6 @@ export const getAirtableOutputQueryMappingValue = (
 	}
 
 	switch ( field.type ) {
-		case 'button':
-			return { ...baseField, type: 'button_url' };
-
 		case 'currency':
 			return {
 				...baseField,

--- a/src/data-sources/airtable/utils.ts
+++ b/src/data-sources/airtable/utils.ts
@@ -28,7 +28,6 @@ export const getAirtableOutputQueryMappingValue = (
 	}
 
 	switch ( field.type ) {
-		case 'url':
 		case 'button':
 			return { ...baseField, type: 'button_url' };
 


### PR DESCRIPTION
- Map airtable [url field](https://airtable.com/developers/web/api/field-model#urltext) to RDB's string type [[CAFE-1087](https://vipjira.atlassian.net/browse/CAFE-1087)]
- Removes support for airtable [button field](https://airtable.com/developers/web/api/field-model#button) (slack [thread](https://a8c.slack.com/archives/C06HTDH3STW/p1734125928900399?thread_ts=1734125910.671419&cid=C06HTDH3STW)) [[CAFE-1089](https://vipjira.atlassian.net/browse/CAFE-1089)]
- Fix the type in Multiple Users field type to make them available for selection when configuring airtable source via settings page [[CAFE-1088](https://vipjira.atlassian.net/browse/CAFE-1088)]