### PR TITLE
Add "Code" badge to code-configured data sources

### DIFF
--- a/src/data-sources/DataSourceList.scss
+++ b/src/data-sources/DataSourceList.scss
@@ -51,7 +51,6 @@ table.data-source-list {
 	}
 }
 
-
 .data-source-actions {
 
 	button.components-button {
@@ -67,3 +66,12 @@ table.data-source-list {
 	}
 }
 
+.data-source-badge {
+	background-color: rgba(56, 88, 233, 0.04);
+	border-radius: 4px;
+	display: inline-block;
+	font-weight: 500;
+	margin: 0 8px 0 -8px;
+	padding: 4px 8px;
+	vertical-align: baseline;
+}

--- a/src/data-sources/DataSourceList.tsx
+++ b/src/data-sources/DataSourceList.tsx
@@ -13,10 +13,11 @@ import {
 } from '@wordpress/dataviews/wp';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { chevronRightSmall, info } from '@wordpress/icons';
+import { info } from '@wordpress/icons';
 import { store as noticesStore, NoticeStoreActions, WPNotice } from '@wordpress/notices';
 
 import { SUPPORTED_SERVICES, SUPPORTED_SERVICES_LABELS } from './constants';
+import DataSourceMetaTags from '@/data-sources/DataSourceMetaTags';
 import { useDataSources } from '@/data-sources/hooks/useDataSources';
 import { DataSourceConfig } from '@/data-sources/types';
 import { useSettingsContext } from '@/settings/hooks/useSettingsNav';
@@ -53,44 +54,6 @@ const DataSourceList = () => {
 		await Promise.all( sources.map( src => deleteDataSource( src ).catch( () => null ) ) );
 		setDataSourceToDelete( null );
 		await fetchDataSources().catch( () => null );
-	};
-
-	const renderDataSourceMeta = ( source: DataSourceConfig ) => {
-		const tags: { key: string; primaryValue: string; secondaryValue?: string }[] = [];
-		switch ( source.service ) {
-			case 'airtable':
-				tags.push( {
-					key: 'base',
-					primaryValue: source.service_config.base?.name,
-					secondaryValue: source.service_config.tables?.[ 0 ]?.name,
-				} );
-				break;
-			case 'shopify':
-				tags.push( { key: 'store', primaryValue: source.service_config.store_name } );
-				break;
-			case 'google-sheets':
-				tags.push( {
-					key: 'spreadsheet',
-					primaryValue: source.service_config.spreadsheet.name ?? 'Google Sheet',
-					secondaryValue: source.service_config.sheet.name,
-				} );
-				break;
-		}
-
-		return tags.filter( Boolean ).map( tag => (
-			<span key={ tag.key } className="data-source-meta">
-				{ tag.primaryValue }
-				{ tag.secondaryValue && (
-					<>
-						<Icon
-							icon={ chevronRightSmall }
-							style={ { fill: '#949494', verticalAlign: 'middle' } }
-						/>
-						{ tag.secondaryValue }
-					</>
-				) }
-			</span>
-		) );
 	};
 
 	const getServiceLabel = ( service: ( typeof SUPPORTED_SERVICES )[ number ] ) => {
@@ -168,7 +131,7 @@ const DataSourceList = () => {
 			id: 'meta',
 			label: __( 'Meta', 'remote-data-blocks' ),
 			enableGlobalSearch: true,
-			render: ( { item }: { item: DataSourceConfig } ) => renderDataSourceMeta( item ),
+			render: ( { item }: { item: DataSourceConfig } ) => <DataSourceMetaTags source={ item } />,
 		},
 	];
 

--- a/src/data-sources/DataSourceMetaTags.tsx
+++ b/src/data-sources/DataSourceMetaTags.tsx
@@ -1,0 +1,66 @@
+import { Icon } from '@wordpress/components';
+import { chevronRightSmall } from '@wordpress/icons';
+
+import { DataSourceConfig } from '@/data-sources/types';
+import './DataSourceList.scss';
+
+interface DataSourceMetaTagsProps {
+	source: DataSourceConfig;
+}
+
+interface DataSourceMetaTag {
+	key: string;
+	primaryValue: string;
+	secondaryValue?: string;
+}
+
+const DataSourceDescriptor = ( props: DataSourceMetaTagsProps ) => {
+	let tag: DataSourceMetaTag | undefined;
+
+	switch ( props.source.service ) {
+		case 'airtable':
+			tag = {
+				key: 'base',
+				primaryValue: props.source.service_config.base?.name,
+				secondaryValue: props.source.service_config.tables?.[ 0 ]?.name,
+			};
+			break;
+		case 'shopify':
+			tag = { key: 'store', primaryValue: props.source.service_config.store_name };
+			break;
+		case 'google-sheets':
+			tag = {
+				key: 'spreadsheet',
+				primaryValue: props.source.service_config.spreadsheet.name ?? 'Google Sheet',
+				secondaryValue: props.source.service_config.sheet.name,
+			};
+			break;
+	}
+
+	if ( ! tag ) {
+		return null;
+	}
+
+	return (
+		<span key={ tag.key } className="data-source-meta">
+			{ tag.primaryValue }
+			{ tag.secondaryValue && (
+				<>
+					<Icon icon={ chevronRightSmall } style={ { fill: '#949494', verticalAlign: 'middle' } } />
+					{ tag.secondaryValue }
+				</>
+			) }
+		</span>
+	);
+};
+
+const DataSourceMetaTags = ( props: DataSourceMetaTagsProps ) => {
+	return (
+		<>
+			{ ! props.source.uuid && <span className="data-source-badge">Code</span> }
+			<DataSourceDescriptor source={ props.source } />
+		</>
+	);
+};
+
+export default DataSourceMetaTags;

--- a/src/data-sources/DataSourceMetaTags.tsx
+++ b/src/data-sources/DataSourceMetaTags.tsx
@@ -1,4 +1,5 @@
-import { Icon } from '@wordpress/components';
+import { Icon, Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { chevronRightSmall } from '@wordpress/icons';
 
 import { DataSourceConfig } from '@/data-sources/types';
@@ -54,10 +55,18 @@ const DataSourceDescriptor = ( props: DataSourceMetaTagsProps ) => {
 	);
 };
 
+const CodeBadge = () => {
+	return (
+		<Tooltip text={ __( 'This data source is configured in code.', 'remote-data-blocks' ) }>
+			<span className="data-source-badge">Code</span>
+		</Tooltip>
+	);
+};
+
 const DataSourceMetaTags = ( props: DataSourceMetaTagsProps ) => {
 	return (
 		<>
-			{ ! props.source.uuid && <span className="data-source-badge">Code</span> }
+			{ ! props.source.uuid && <CodeBadge /> }
 			<DataSourceDescriptor source={ props.source } />
 		</>
 	);


### PR DESCRIPTION
Add "Code" badge to code-configured data sources to help explain why their actions are disabled.

<img width="1310" alt="Screenshot 2024-12-26 at 12 30 17" src="https://github.com/user-attachments/assets/83af44f9-8a3d-40e7-b381-ca92a09234f2" />
