### PR TITLE
Improve block registration shape to allow query options

### DIFF
--- a/docs/extending/block-patterns.md
+++ b/docs/extending/block-patterns.md
@@ -20,7 +20,7 @@ Example:
 ```php
 register_remote_data_block( [
 	'title' => 'My Remote Data Block',
-	'queries' => [ /* ... */ ],
+	'render_query' => [ /* ... */ ],
 	'patterns' => [
 		[
 			'title' => 'My Pattern',

--- a/docs/extending/block-registration.md
+++ b/docs/extending/block-registration.md
@@ -17,7 +17,7 @@ function register_your_custom_block() {
 		],
 	] );
 
-	$display_query = HttpQuery::from_array( [
+	$render_query = HttpQuery::from_array( [
 		'display_name' => 'Example Query',
 		'data_source' => $data_source,
 		'output_schema' => [
@@ -38,8 +38,8 @@ function register_your_custom_block() {
 
 	register_remote_data_block( [
 		'title' => 'My Block',
-		'queries' => [
-			'display' => $display_query,
+		'render_query' => [
+			'query' => $render_query,
 		],
 	] );
 }

--- a/docs/workflows/rest-api-with-code.md
+++ b/docs/workflows/rest-api-with-code.md
@@ -58,8 +58,8 @@ function register_zipcode_block(): void {
 
 	register_remote_data_block( [
 		'title' => 'Zip Code',
-		'queries' => [
-			'display' => $zipcode_query,
+		'render_query' => [
+			'query' => $zipcode_query,
 		],
 	] );
 }

--- a/docs/workflows/rest-api.md
+++ b/docs/workflows/rest-api.md
@@ -72,8 +72,8 @@ function register_zipcode_block(): void {
 
 	register_remote_data_block( [
 		'title' => 'Zip Code',
-		'queries' => [
-			'display' => $zipcode_query,
+		'render_query' => [
+			'query' => $zipcode_query,
 		],
 	] );
 }

--- a/example/airtable/elden-ring-map/register.php
+++ b/example/airtable/elden-ring-map/register.php
@@ -99,9 +99,14 @@ function register_airtable_elden_ring_map_block(): void {
 
 	register_remote_data_block( [
 		'title' => $block_name,
-		'queries' => [
-			'display' => $list_locations_query,
-			'list' => $list_maps_query,
+		'render_query' => [
+			'query' => $list_locations_query,
+		],
+		'selection_queries' => [
+			[
+				'query' => $list_maps_query,
+				'type' => 'list',
+			],
 		],
 		'patterns' => [
 			[

--- a/example/github/remote-data-blocks/register.php
+++ b/example/github/remote-data-blocks/register.php
@@ -96,17 +96,21 @@ function register_github_file_as_html_block(): void {
 
 	register_remote_data_block( [
 		'title' => $block_title,
-		'queries' => [
-			'display' => $github_get_file_as_html_query,
-			'list' => $github_get_list_files_query,
+		'render_query' => [
+			'query' => $github_get_file_as_html_query,
+			'input_overrides' => [
+				[
+					'source' => 'file_path',
+					'source_type' => 'page',
+					'target' => 'file_path',
+					'target_type' => 'input_var',
+				],
+			],
 		],
-		'query_input_overrides' => [
+		'selection_queries' => [
 			[
-				'query' => 'display',
-				'source' => 'file_path',
-				'source_type' => 'page',
-				'target' => 'file_path',
-				'target_type' => 'input_var',
+				'query' => $github_get_list_files_query,
+				'type' => 'list',
 			],
 		],
 		'pages' => [

--- a/example/google-sheets/westeros-houses/register.php
+++ b/example/google-sheets/westeros-houses/register.php
@@ -158,17 +158,21 @@ function register_westeros_houses_block(): void {
 
 	register_remote_data_block( [
 		'title' => 'Westeros House',
-		'queries' => [
-			'display' => $get_westeros_houses_query,
-			'list' => $list_westeros_houses_query,
+		'render_query' => [
+			'query' => $get_westeros_houses_query,
+			'input_overrides' => [
+				[
+					'source' => 'house',
+					'source_type' => 'page',
+					'target' => 'row_id',
+					'target_type' => 'input_var',
+				],
+			],
 		],
-		'query_input_overrides' => [
+		'selection_queries' => [
 			[
-				'query' => 'display',
-				'source' => 'house',
-				'source_type' => 'page',
-				'target' => 'row_id',
-				'target_type' => 'input_var',
+				'query' => $list_westeros_houses_query,
+				'type' => 'list',
 			],
 		],
 		'pages' => [
@@ -181,9 +185,9 @@ function register_westeros_houses_block(): void {
 
 	register_remote_data_block( [
 		'title' => 'Westeros Houses List',
-		'loop' => true,
-		'queries' => [
-			'display' => $list_westeros_houses_query,
+		'render_query' => [
+			'loop' => true,
+			'query' => $list_westeros_houses_query,
 		],
 	] );
 }

--- a/example/rest-api/art-institute/register.php
+++ b/example/rest-api/art-institute/register.php
@@ -88,9 +88,14 @@ function register_aic_block(): void {
 
 	register_remote_data_block( [
 		'title' => 'Art Institute of Chicago',
-		'queries' => [
-			'display' => $get_art_query,
-			'search' => $search_art_query,
+		'render_query' => [
+			'query' => $get_art_query,
+		],
+		'selection_queries' => [
+			[
+				'query' => $search_art_query,
+				'type' => 'search',
+			],
 		],
 	] );
 }

--- a/example/rest-api/zip-code/register.php
+++ b/example/rest-api/zip-code/register.php
@@ -51,8 +51,8 @@ function register_zipcode_block(): void {
 
 	register_remote_data_block( [
 		'title' => 'Zip Code',
-		'queries' => [
-			'display' => $zipcode_query,
+		'render_query' => [
+			'query' => $zipcode_query,
 		],
 	] );
 }

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -20,6 +20,8 @@ use function wp_insert_post;
 class ConfigRegistry {
 	private static LoggerInterface $logger;
 
+	public const RENDER_QUERY_KEY = 'render_query';
+	public const SELECTION_QUERIES_KEY = 'selection_queries';
 	public const DISPLAY_QUERY_KEY = 'display';
 	public const LIST_QUERY_KEY = 'list';
 	public const SEARCH_QUERY_KEY = 'search';
@@ -46,7 +48,7 @@ class ConfigRegistry {
 			return self::create_error( $block_title, sprintf( 'Block %s has already been registered', $block_name ) );
 		}
 
-		$display_query = $user_config['queries'][ self::DISPLAY_QUERY_KEY ];
+		$display_query = $user_config[ self::RENDER_QUERY_KEY ]['query'];
 		$input_schema = $display_query->get_input_schema();
 
 		// Build the base configuration for the block. This is our own internal
@@ -55,7 +57,7 @@ class ConfigRegistry {
 		$config = [
 			'description' => '',
 			'name' => $block_name,
-			'loop' => $user_config['loop'] ?? false,
+			'loop' => $user_config[ self::RENDER_QUERY_KEY ]['loop'] ?? false,
 			'patterns' => [],
 			'queries' => [
 				self::DISPLAY_QUERY_KEY => $display_query,
@@ -82,53 +84,48 @@ class ConfigRegistry {
 
 		// Register "selectors" which allow the user to use a query to assist in
 		// selecting data for display by the block.
-		foreach ( [ self::LIST_QUERY_KEY, self::SEARCH_QUERY_KEY ] as $from_query_type ) {
-			if ( isset( $user_config['queries'][ $from_query_type ] ) ) {
-				$to_query = $display_query;
-				$from_query = $user_config['queries'][ $from_query_type ];
+		foreach ( $user_config[ self::SELECTION_QUERIES_KEY ] ?? [] as $selection_query ) {
+			$from_query = $selection_query['query'];
+			$from_query_type = $selection_query['type'];
+			$to_query = $display_query;
 
-				$config['queries'][ $from_query_type ] = $from_query;
+			$config['queries'][ $from_query::class ] = $from_query;
 
-				$from_input_schema = $from_query->get_input_schema();
-				$from_output_schema = $from_query->get_output_schema();
+			$from_input_schema = $from_query->get_input_schema();
+			$from_output_schema = $from_query->get_output_schema();
 
-				foreach ( array_keys( $to_query->get_input_schema() ) as $to ) {
-					if ( ! isset( $from_output_schema['type'][ $to ] ) ) {
-						return self::create_error( $block_title, sprintf( 'Cannot map key "%s" from %s query', esc_html( $to ), $from_query_type ) );
-					}
+			foreach ( array_keys( $to_query->get_input_schema() ) as $to ) {
+				if ( ! isset( $from_output_schema['type'][ $to ] ) ) {
+					return self::create_error( $block_title, sprintf( 'Cannot map key "%s" from %s query', esc_html( $to ), $from_query_type ) );
 				}
-
-				if ( self::SEARCH_QUERY_KEY === $from_query_type && ! isset( $from_input_schema['search_terms'] ) ) {
-					return self::create_error( $block_title, 'A search query must have a "search_terms" input variable' );
-				}
-
-				// Add the selector to the configuration.
-				array_unshift(
-					$config['selectors'],
-					[
-						'image_url' => $from_query->get_image_url(),
-						'inputs' => [],
-						'name' => ucfirst( $from_query_type ),
-						'query_key' => $from_query_type,
-						'type' => $from_query_type,
-					]
-				);
 			}
+
+			if ( self::SEARCH_QUERY_KEY === $from_query_type && ! isset( $from_input_schema['search_terms'] ) ) {
+				return self::create_error( $block_title, 'A search query must have a "search_terms" input variable' );
+			}
+
+			// Add the selector to the configuration.
+			array_unshift(
+				$config['selectors'],
+				[
+					'image_url' => $from_query->get_image_url(),
+					'inputs' => [],
+					'name' => $selection_query['display_name'] ?? ucfirst( $from_query_type ),
+					'query_key' => $from_query::class,
+					'type' => $from_query_type,
+				]
+			);
 		}
 
 		// Register query input overrides which allow the user to specify how
 		// query inputs can be overridden by URL parameters or query variables.
-		foreach ( $user_config['query_input_overrides'] ?? [] as $override ) {
-			if ( ! isset( $config['queries'][ $override['query'] ] ) ) {
-				return self::create_error( $block_title, sprintf( 'Query input override targets a non-existent query "%s"', esc_html( $override['query'] ) ) );
-			}
-
+		foreach ( $user_config[ self::RENDER_QUERY_KEY ]['input_overrides'] ?? [] as $override ) {
 			if ( 'input_var' !== $override['target_type'] ) {
 				return self::create_error( $block_title, 'Only input variables can be targeted by query input overrides' );
 			}
 
-			if ( ! isset( $config['queries'][ $override['query'] ]->get_input_schema()[ $override['target'] ] ) ) {
-				return self::create_error( $block_title, sprintf( 'Query input override "%s" does not exist as input variable for query "%s"', esc_html( $override['target'] ), esc_html( $override['query'] ) ) );
+			if ( ! isset( $input_schema[ $override['target'] ] ) ) {
+				return self::create_error( $block_title, sprintf( 'Input override "%s" does not exist as input variable for render query', esc_html( $override['target'] ) ) );
 			}
 
 			$config['query_input_overrides'][] = $override;
@@ -196,11 +193,11 @@ class ConfigRegistry {
 	 */
 	private static function register_page( array $query_input_overrides, string $block_title, array $options = [] ): bool|WP_Error {
 		$overrides = array_values( array_filter( $query_input_overrides, function ( $override ) {
-			return 'page' === $override['source_type'] && ConfigRegistry::DISPLAY_QUERY_KEY === $override['query'];
+			return 'page' === $override['source_type'];
 		} ) );
 
 		if ( empty( $overrides ) ) {
-			return new WP_Error( 'useless_page', 'A page is only useful with query input overrides with page sources.' );
+			return new WP_Error( 'useless_page', 'A page is only useful when there are query input overrides with page sources.' );
 		}
 
 		$allow_nested_paths = $options['allow_nested_paths'] ?? false;

--- a/inc/ExampleApi/ExampleApi.php
+++ b/inc/ExampleApi/ExampleApi.php
@@ -116,9 +116,14 @@ class ExampleApi {
 
 		register_remote_data_block( [
 			'title' => self::$block_title,
-			'queries' => [
-				'display' => $get_record_query,
-				'list' => $get_table_query,
+			'render_query' => [
+				'query' => $get_record_query,
+			],
+			'selection_queries' => [
+				[
+					'query' => $get_table_query,
+					'type' => 'list',
+				],
 			],
 		] );
 	}

--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -19,9 +19,14 @@ class AirtableIntegration {
 			array_merge(
 				[
 					'title' => $data_source->get_display_name(),
-					'queries' => [
-						'display' => $data_source->___temp_get_query(),
-						'list' => $data_source->___temp_get_list_query(),
+					'render_query' => [
+						'query' => $data_source->___temp_get_query(),
+					],
+					'selection_queries' => [
+						[
+							'query' => $data_source->___temp_get_list_query(),
+							'type' => 'list',
+						],
 					],
 				],
 				$block_overrides
@@ -34,9 +39,9 @@ class AirtableIntegration {
 			array_merge(
 				[
 					'title' => sprintf( '%s Loop', $data_source->get_display_name() ),
-					'loop' => true,
-					'queries' => [
-						'display' => $data_source->___temp_get_list_query(),
+					'render_query' => [
+						'loop' => true,
+						'query' => $data_source->___temp_get_list_query(),
 					],
 				],
 				$block_overrides

--- a/inc/Integrations/SalesforceB2C/SalesforceB2CIntegration.php
+++ b/inc/Integrations/SalesforceB2C/SalesforceB2CIntegration.php
@@ -138,17 +138,26 @@ class SalesforceB2CIntegration {
 	}
 
 	public static function register_blocks_for_salesforce_data_source( SalesforceB2CDataSource $data_source ): void {
+		$queries = self::get_queries( $data_source );
+
 		register_remote_data_block(
 			[
 				'title' => $data_source->get_display_name(),
-				'queries' => self::get_queries( $data_source ),
-				'query_input_overrides' => [
+				'render_query' => [
+					'query' => $queries['display'],
+					'input_overrides' => [
+						[
+							'source' => 'utm_content',
+							'source_type' => 'query_var',
+							'target' => 'product_id',
+							'target_type' => 'input_var',
+						],
+					],
+				],
+				'selection_queries' => [
 					[
-						'query' => 'display',
-						'source' => 'utm_content',
-						'source_type' => 'query_var',
-						'target' => 'product_id',
-						'target_type' => 'input_var',
+						'query' => $queries['search'],
+						'type' => 'search',
 					],
 				],
 			]

--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -114,9 +114,14 @@ class ShopifyIntegration {
 
 		register_remote_data_block( [
 			'title' => $block_title,
-			'queries' => [
-				'display' => $queries['shopify_get_product'],
-				'search' => $queries['shopify_search_products'],
+			'render_query' => [
+				'query' => $queries['shopify_get_product'],
+			],
+			'selection_queries' => [
+				[
+					'query' => $queries['shopify_search_products'],
+					'type' => 'search',
+				],
 			],
 			'patterns' => [
 				[

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -64,23 +64,6 @@ final class ConfigSchemas {
 
 	private static function generate_remote_data_block_config_schema(): array {
 		return Types::object( [
-			'queries' => Types::object( [
-				ConfigRegistry::DISPLAY_QUERY_KEY => Types::instance_of( QueryInterface::class ),
-				ConfigRegistry::LIST_QUERY_KEY => Types::nullable( Types::instance_of( QueryInterface::class ) ),
-				ConfigRegistry::SEARCH_QUERY_KEY => Types::nullable( Types::instance_of( QueryInterface::class ) ),
-			] ),
-			'query_input_overrides' => Types::nullable(
-				Types::list_of(
-					Types::object( [
-						'query' => Types::enum( ConfigRegistry::DISPLAY_QUERY_KEY ), // only display query for now
-						'source' => Types::string(), // e.g., the name of the query var
-						'source_type' => Types::enum( 'page', 'query_var' ),
-						'target' => Types::string(), // e.g., input variable name
-						'target_type' => Types::const( 'input_var' ),
-					] ),
-				)
-			),
-			'loop' => Types::nullable( Types::boolean() ),
 			'pages' => Types::nullable(
 				Types::list_of(
 					Types::object( [
@@ -96,6 +79,32 @@ final class ConfigSchemas {
 						'html' => Types::html(),
 						'role' => Types::nullable( Types::enum( 'inner_blocks' ) ),
 						'title' => Types::string(),
+					] )
+				)
+			),
+			'render_query' => Types::object( [
+				'query' => Types::instance_of( QueryInterface::class ),
+				'input_overrides' => Types::nullable(
+					Types::list_of(
+						Types::object( [
+							'source' => Types::string(), // e.g., the name of the query var
+							'source_type' => Types::enum( 'page', 'query_var' ),
+							'target' => Types::string(), // e.g., input variable name
+							'target_type' => Types::const( 'input_var' ),
+						] ),
+					)
+				),
+				'loop' => Types::nullable( Types::boolean() ),
+			] ),
+			'selection_queries' => Types::nullable(
+				Types::list_of(
+					Types::object( [
+						'display_name' => Types::nullable( Types::string() ),
+						'query' => Types::instance_of( QueryInterface::class ),
+						'type' => Types::enum(
+							ConfigRegistry::LIST_QUERY_KEY,
+							ConfigRegistry::SEARCH_QUERY_KEY
+						),
 					] )
 				)
 			),

--- a/tests/inc/Functions/FunctionsTest.php
+++ b/tests/inc/Functions/FunctionsTest.php
@@ -38,8 +38,8 @@ class FunctionsTest extends TestCase {
 	public function testRegisterBlock() {
 		register_remote_data_block( [
 			'title' => 'Test Block',
-			'queries' => [
-				'display' => $this->mock_query,
+			'render_query' => [
+				'query' => $this->mock_query,
 			],
 		] );
 
@@ -56,10 +56,10 @@ class FunctionsTest extends TestCase {
 	public function testRegisterLoopBlock() {
 		register_remote_data_block( [
 			'title' => 'Loop Block',
-			'queries' => [
-				'display' => $this->mock_list_query,
+			'render_query' => [
+				'loop' => true,
+				'query' => $this->mock_list_query,
 			],
-			'loop' => true,
 		] );
 
 		$block_name = 'remote-data-blocks/loop-block';
@@ -73,9 +73,14 @@ class FunctionsTest extends TestCase {
 	public function testRegisterListQuery() {
 		register_remote_data_block( [
 			'title' => 'Test Block with List Query',
-			'queries' => [
-				'display' => $this->mock_query,
-				'list' => $this->mock_list_query,
+			'render_query' => [
+				'query' => $this->mock_query,
+			],
+			'selection_queries' => [
+				[
+					'query' => $this->mock_list_query,
+					'type' => 'list',
+				],
 			],
 		] );
 
@@ -87,9 +92,14 @@ class FunctionsTest extends TestCase {
 	public function testRegisterSearchQuery() {
 		register_remote_data_block( [
 			'title' => 'Test Block with Search Query',
-			'queries' => [
-				'display' => $this->mock_query,
-				'search' => $this->mock_search_query,
+			'render_query' => [
+				'query' => $this->mock_query,
+			],
+			'selection_queries' => [
+				[
+					'query' => $this->mock_search_query,
+					'type' => 'search',
+				],
 			],
 		] );
 
@@ -101,8 +111,8 @@ class FunctionsTest extends TestCase {
 	public function testIsRegisteredBlockReturnsTrueForRegisteredBlock() {
 		register_remote_data_block( [
 			'title' => 'Some Slick Block',
-			'queries' => [
-				'display' => $this->mock_query,
+			'render_query' => [
+				'query' => $this->mock_query,
 			],
 		] );
 
@@ -123,14 +133,14 @@ class FunctionsTest extends TestCase {
 	public function testRegisterDuplicateBlock() {
 		register_remote_data_block( [
 			'title' => 'Duplicate Block',
-			'queries' => [
-				'display' => $this->mock_query,
+			'render_query' => [
+				'query' => $this->mock_query,
 			],
 		] );
 		register_remote_data_block( [
 			'title' => 'Duplicate Block',
-			'queries' => [
-				'display' => $this->mock_query,
+			'render_query' => [
+				'query' => $this->mock_query,
 			],
 		] );
 
@@ -142,9 +152,14 @@ class FunctionsTest extends TestCase {
 	public function testRegisterSearchQueryWithoutSearchTerms() {
 		register_remote_data_block( [
 			'title' => 'Invalid Search Block',
-			'queries' => [
-				'display' => $this->mock_query,
-				'search' => $this->mock_query,
+			'render_query' => [
+				'query' => $this->mock_query,
+			],
+			'selection_queries' => [
+				[
+					'query' => $this->mock_query,
+					'type' => 'search',
+				],
 			],
 		] );
 

--- a/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
+++ b/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
@@ -150,8 +150,8 @@ class VipBlockDataApiTest extends TestCase {
 		$mock_query = MockQuery::from_array( [ 'query_runner' => $mock_qr ] );
 		register_remote_data_block( [
 			'title' => 'Events',
-			'queries' => [
-				'display' => $mock_query,
+			'render_query' => [
+				'query' => $mock_query,
 			],
 		] );
 
@@ -174,8 +174,8 @@ class VipBlockDataApiTest extends TestCase {
 		$mock_query = MockQuery::from_array( [ 'query_runner' => $mock_qr ] );
 		register_remote_data_block( [
 			'title' => 'Events',
-			'queries' => [
-				'display' => $mock_query,
+			'render_query' => [
+				'query' => $mock_query,
 			],
 		] );
 


### PR DESCRIPTION
When pairing with @brookewp during her work on data views in the editor, I realized the shape of the configuration options passed to `register_remote_data_block` was insufficient, e.g.:

```php
register_remote_data_block( [
	'title' => 'My Block',
	'queries' => [
		'display' => $display_query,
		'search' => $search_query,
	],
	'query_input_overrides' => [ /* overrides * / ],
] );
```

Specifically, the shape of the `queries` property does not allow us to pass any options alongside the query. Example: We might want to pass some options alongside the search query that describe what filters or pagination options we want to enable in the corresponding data view in the block editor. Or we might want to customize the display text in various places in the block editor, like button or placeholder text.

We could cram that kind of configuration in the query itself, but it overloads the query with things that are only relevant to the block editor, and it also inhibits reusability.

Another issue with this shape is that the "display" queries and other queries are fundamentally different. The display query is required, there can only be one, and it has a distinct role for fetching and rendering content. The other queries are optional and repeatable—i.e., you can have more than one search query but this shape doesn't allow it.

Finally, this shape relegated "query input overrides" to a sibling property. This was fine, but they really only relate to the display query and are effectively an option for that query.

We can reconfigure the configuration shape to solve for all of these issues:

```php
register_remote_data_block( [
	'title' => 'My Block',
	'render_query' => [
		'query' => $render_query,
		'input_overrides' => [ /* overrides * / ],
	],
	'selection_queries' => [
		[
			'display_name' => 'Search products',
			'query' => $search_query,
			'type' => 'search',
		],
	],
] );
```

This allows for repeatability where allowed, improves schema validation, and colocates options with the query they relate to. I would like feedback on names; if we prefer "render query" or another term over "display query" I will probably make additional adjustments to variable naming throughout the codebase.