### PR TITLE
[UI] Airtable field fixes 

### DIFF
--- a/src/data-sources/DataSourceSettings.scss
+++ b/src/data-sources/DataSourceSettings.scss
@@ -79,7 +79,6 @@
 
 
 .rdb-settings-page_data-source-form {
-	overflow-y: auto;
 	padding: 0 16px 40px;
 
 	@media screen and (min-width: 782px) {
@@ -231,6 +230,11 @@
 			}
 		}
 	}
+}
+
+.components-form-token-field__input-container > div:first-child {
+	max-height: 220px;
+	overflow-y: scroll;
 }
 
 .components-form-token-field__input-container.is-active {

--- a/src/data-sources/airtable/AirtableSettings.tsx
+++ b/src/data-sources/airtable/AirtableSettings.tsx
@@ -1,6 +1,6 @@
 import { SelectControl } from '@wordpress/components';
 import { InputChangeCallback } from '@wordpress/components/build-types/input-control/types';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { ChangeEvent } from 'react';
 
@@ -131,6 +131,13 @@ export const AirtableSettings = ( {
 			handleOnChange( id, value );
 		}
 	};
+
+	// if the selected table changes, reset the fields
+	useEffect( () => {
+		if ( currentTableId !== state.tables?.[ 0 ]?.id ) {
+			setTableFields( [] );
+		}
+	}, [ currentTableId ] );
 
 	let connectionMessage: React.ReactNode = (
 		<span>


### PR DESCRIPTION
Previously selected fields remained after changing tables, even if those fields aren't part of the newly selected table: 

| Before  | After |
| ------------- | ------------- |
| ![Screen Recording 2025-01-06 at 12 51 51 PM](https://github.com/user-attachments/assets/66197abd-d530-4d9c-9034-5caded80fc19) | ![Screen Recording 2025-01-06 at 12 53 10 PM](https://github.com/user-attachments/assets/c1686843-f35d-47a6-b1e2-32c1e3657095) |

Sometimes the dropdown for fields was cut off:

| Before  | After |
| ------------- | ------------- |
| <img width="661" alt="Screenshot 2025-01-06 at 12 48 32 PM" src="https://github.com/user-attachments/assets/486772c6-42bb-4dcd-aa6a-006bc55a8fc7" />  | <img width="683" alt="Screenshot 2025-01-06 at 12 47 26 PM" src="https://github.com/user-attachments/assets/4d1985c2-208d-416d-ad58-e9d79a3f7e59" />  |

The selected fields input could be any height, so this PR introduces a height limit: 

<img width="600" alt="Screenshot 2025-01-06 at 12 47 54 PM" src="https://github.com/user-attachments/assets/53c29e9c-c52b-4685-a8c8-c3732c5cd1c1" />
