### PR TITLE
Remove null values to prevent search errors

### DIFF
--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -20,18 +20,28 @@ export function ItemList( props: ItemListProps ) {
 
 	const instanceId = useInstanceId( ItemList, blockName );
 
-	// ensure each result has an 'id' key
 	const data = useMemo( () => {
-		return ( results ?? [] ).map( ( item: Record< string, unknown > ) =>
-			item.id
-				? item
-				: {
-						...item,
-						id: Object.keys( item ).find( key => /(^|_)(id)$/i.test( key ) ) // Regex to match 'id' or part of '_id'
-							? item[ Object.keys( item ).find( key => /(^|_)(id)$/i.test( key ) ) as string ]
-							: instanceId,
-				  }
-		) as RemoteDataResult[];
+		// Remove null values from the data to prevent errors in filterSortAndPaginate
+		const removeNullValues = ( obj: Record< string, unknown > ): Record< string, unknown > => {
+			return Object.fromEntries(
+				Object.entries( obj ).filter( ( [ _, value ] ) => value !== null ) // Keep only non-null values
+			);
+		};
+
+		return ( results ?? [] ).map( ( item: Record< string, unknown > ) => {
+			const parsedItem = removeNullValues( item );
+
+			if ( parsedItem.id ) {
+				return parsedItem;
+			}
+
+			// ensure each result has an 'id' key
+			const idKey = Object.keys( parsedItem ).find( key => /(^|_)(id)$/i.test( key ) );
+			return {
+				...parsedItem,
+				id: idKey ? parsedItem[ idKey ] : instanceId,
+			};
+		} ) as RemoteDataResult[];
 	}, [ results ] );
 
 	// get fields from results data to use as columns

--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -21,10 +21,10 @@ export function ItemList( props: ItemListProps ) {
 	const instanceId = useInstanceId( ItemList, blockName );
 
 	const data = useMemo( () => {
-		// Remove null values from the data to prevent errors in filterSortAndPaginate
+		// remove null values from the data to prevent errors in filterSortAndPaginate
 		const removeNullValues = ( obj: Record< string, unknown > ): Record< string, unknown > => {
 			return Object.fromEntries(
-				Object.entries( obj ).filter( ( [ _, value ] ) => value !== null ) // Keep only non-null values
+				Object.entries( obj ).filter( ( [ _, value ] ) => value !== null )
 			);
 		};
 


### PR DESCRIPTION
The search in the search modal breaks if a value in a dataset is `null`. This occurs in the `filterSortAndPaginate` method from `DataViews`, which tries to use `trim()` on `null`. 

This PR removes data with a value of `null` in the modal, which also prevents empty fields/columns from showing:

| Before  | After |
| ------------- | ------------- |
| ![Screen Recording 2025-01-06 at 5 49 43 PM](https://github.com/user-attachments/assets/d80e8605-d84e-4417-8f82-5313986cad91)  | ![Screen Recording 2025-01-06 at 5 48 54 PM](https://github.com/user-attachments/assets/03208a31-9623-4390-b4cd-aa5291b235c0)  |

(If we want all fields to show regardless, we could replace `null` values with `''`)