### PR TITLE
add multi select for tables in data sources settings

### DIFF
--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -234,7 +234,7 @@ class BlockBindings {
 			$fallback_content = $block_attributes['content'] ?? null;
 		}
 
-		return $fallback_content;
+		return strval( $fallback_content );
 	}
 
 	public static function get_remote_value( array $block_context, array $source_args ): string|null {

--- a/src/data-sources/airtable/AirtableSettings.tsx
+++ b/src/data-sources/airtable/AirtableSettings.tsx
@@ -1,11 +1,9 @@
 import { SelectControl } from '@wordpress/components';
 import { InputChangeCallback } from '@wordpress/components/build-types/input-control/types';
-import { useState, useEffect } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { ChangeEvent } from 'react';
 
-import { SUPPORTED_AIRTABLE_TYPES } from '@/data-sources/airtable/constants';
-import { getAirtableOutputQueryMappingValue } from '@/data-sources/airtable/utils';
+import { getAirtableOutputQueryMappingValues } from '@/data-sources/airtable/utils';
 import { DataSourceForm } from '@/data-sources/components/DataSourceForm';
 import { FieldsSelection } from '@/data-sources/components/FieldsSelection';
 import PasswordInputControl from '@/data-sources/components/PasswordInputControl';
@@ -18,7 +16,7 @@ import { useDataSources } from '@/data-sources/hooks/useDataSources';
 import {
 	AirtableConfig,
 	AirtableServiceConfig,
-	DataSourceQueryMappingValue,
+	AirtableTableConfig,
 	SettingsComponentProps,
 } from '@/data-sources/types';
 import { getConnectionMessage } from '@/data-sources/utils';
@@ -34,12 +32,6 @@ const defaultSelectBaseOption: SelectOption = {
 	value: '',
 };
 
-const defaultSelectTableOption: SelectOption = {
-	disabled: true,
-	label: __( 'Auto-filled on valid base.', 'remote-data-blocks' ),
-	value: '',
-};
-
 // eslint-disable-next-line complexity
 export const AirtableSettings = ( {
 	mode,
@@ -51,13 +43,6 @@ export const AirtableSettings = ( {
 	const { state, handleOnChange, validState } = useForm< AirtableServiceConfig >( {
 		initialValues: config?.service_config ?? { __version: SERVICE_CONFIG_VERSION },
 	} );
-
-	const [ currentTableId, setCurrentTableId ] = useState< string | null >(
-		state.tables?.[ 0 ]?.id ?? null
-	);
-	const [ tableFields, setTableFields ] = useState< string[] >(
-		state.tables?.[ 0 ]?.output_query_mappings.map( mapping => mapping.key ).filter( Boolean ) ?? []
-	);
 	const { fetchingUserId, userId, userIdError } = useAirtableApiUserId( state.access_token ?? '' );
 	const { bases, basesError, fetchingBases } = useAirtableApiBases(
 		state.access_token ?? '',
@@ -68,11 +53,8 @@ export const AirtableSettings = ( {
 		state.base?.id ?? ''
 	);
 
-	const selectedTable = tables?.find( table => table.id === currentTableId ) ?? null;
-	const availableTableFields: string[] =
-		selectedTable?.fields
-			.filter( field => SUPPORTED_AIRTABLE_TYPES.includes( field.type ) )
-			.map( field => field.name ) ?? [];
+	const availableTables = tables?.length ? tables?.map( table => table.name ) : [];
+	const selectedTables = state.tables?.map( table => table.name ) ?? [];
 
 	const baseOptions = [
 		{
@@ -81,16 +63,9 @@ export const AirtableSettings = ( {
 		},
 		...( bases ?? [] ).map( ( { name, id } ) => ( { label: name, value: id } ) ),
 	];
-	const tableOptions = [
-		{
-			...defaultSelectTableOption,
-			label: __( 'Select a table', 'remote-data-blocks' ),
-		},
-		...( tables ?? [] ).map( ( { name, id } ) => ( { label: name, value: id, disabled: false } ) ),
-	];
 
 	const onSaveClick = async () => {
-		if ( ! validState || ! selectedTable ) {
+		if ( ! validState || ! selectedTables?.length ) {
 			return;
 		}
 
@@ -107,23 +82,12 @@ export const AirtableSettings = ( {
 		handleOnChange( 'access_token', token ?? '' );
 	};
 
-	const onSelectChange = (
-		value: string,
-		extra?: { event?: ChangeEvent< HTMLSelectElement > }
-	) => {
+	const onBaseChange = ( value: string, extra?: { event?: ChangeEvent< HTMLSelectElement > } ) => {
 		if ( extra?.event ) {
 			const { id } = extra.event.target;
 			if ( id === 'base' ) {
 				const selectedBase = bases?.find( base => base.id === value );
 				handleOnChange( 'base', { id: value, name: selectedBase?.name ?? '' } );
-				return;
-			}
-
-			if ( id === 'tables' ) {
-				if ( selectedTable ) {
-					return;
-				}
-
 				handleOnChange( 'tables', [] );
 				return;
 			}
@@ -132,12 +96,21 @@ export const AirtableSettings = ( {
 		}
 	};
 
-	// if the selected table changes, reset the fields
-	useEffect( () => {
-		if ( currentTableId !== state.tables?.[ 0 ]?.id ) {
-			setTableFields( [] );
+	const onTablesChange = ( tablesNames: string[] ) => {
+		let newTables: AirtableTableConfig[] = [];
+
+		if ( tables?.length ) {
+			newTables = tables
+				?.filter( table => tablesNames.includes( table.name ) )
+				.map( table => ( {
+					id: table.id,
+					name: table.name,
+					output_query_mappings: getAirtableOutputQueryMappingValues( table.fields ),
+				} ) );
 		}
-	}, [ currentTableId ] );
+
+		handleOnChange( 'tables', newTables );
+	};
 
 	let connectionMessage: React.ReactNode = (
 		<span>
@@ -163,7 +136,7 @@ export const AirtableSettings = ( {
 
 	const shouldAllowContinue = userId !== null;
 	const shouldAllowSubmit =
-		bases !== null && tables !== null && Boolean( state.base ) && Boolean( selectedTable );
+		bases !== null && tables !== null && Boolean( state.base ) && Boolean( selectedTables?.length );
 
 	let basesHelpText: React.ReactNode = 'Select a base from which to fetch data.';
 	if ( userId ) {
@@ -178,10 +151,7 @@ export const AirtableSettings = ( {
 		}
 	}
 
-	let tablesHelpText: string = __(
-		'Select a table to attach with this data source.',
-		'remote-data-blocks'
-	);
+	let tablesHelpText: string = __( 'Auto-filled on valid base.', 'remote-data-blocks' );
 	if ( bases?.length && state.base ) {
 		if ( tablesError ) {
 			tablesHelpText = __(
@@ -190,20 +160,11 @@ export const AirtableSettings = ( {
 			);
 		} else if ( fetchingTables ) {
 			tablesHelpText = __( 'Fetching tables...', 'remote-data-blocks' );
-		} else if ( tables ) {
-			if ( selectedTable ) {
-				tablesHelpText = sprintf(
-					__( '%s fields found', 'remote-data-blocks' ),
-					selectedTable.fields.length
-				);
-			}
-
-			if ( ! tables.length ) {
-				tablesHelpText = __( 'No tables found', 'remote-data-blocks' );
-			}
+		} else if ( ! tables?.length ) {
+			tablesHelpText = __( 'No tables found', 'remote-data-blocks' );
+		} else {
+			tablesHelpText = __( 'Select tables to attach with this data source.', 'remote-data-blocks' );
 		}
-
-		tablesHelpText = __( 'Select a table from which to fetch data.', 'remote-data-blocks' );
 	}
 
 	return (
@@ -228,59 +189,21 @@ export const AirtableSettings = ( {
 						id="base"
 						label={ __( 'Base', 'remote-data-blocks' ) }
 						value={ state.base?.id ?? '' }
-						onChange={ onSelectChange }
+						onChange={ onBaseChange }
 						options={ baseOptions }
 						help={ basesHelpText }
 						disabled={ fetchingBases || ! bases?.length }
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>
-					<SelectControl
-						id="table"
-						label={ __( 'Table', 'remote-data-blocks' ) }
-						value={ selectedTable?.id ?? '' }
-						onChange={ setCurrentTableId }
-						options={ tableOptions }
-						help={ tablesHelpText }
-						disabled={ fetchingTables || ! tables?.length }
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-					/>
 
 					<FieldsSelection
-						selectedFields={ tableFields }
-						availableFields={ availableTableFields }
-						disabled={ ! selectedTable }
-						customHelpText={
-							! selectedTable ? __( 'Please select a table first.', 'remote-data-blocks' ) : null
-						}
-						onFieldsChange={ newFields => {
-							if ( ! selectedTable ) {
-								return;
-							}
-
-							setTableFields( newFields );
-							handleOnChange( 'tables', [
-								{
-									id: selectedTable.id,
-									name: selectedTable.name,
-									output_query_mappings: newFields
-										.map( key => {
-											const field = selectedTable?.fields.find(
-												tableField => tableField.name === key
-											);
-											if ( field ) {
-												return getAirtableOutputQueryMappingValue( field );
-											}
-											/**
-											 * Remove any fields which are not from this table or not supported.
-											 */
-											return null;
-										} )
-										.filter( ( value ): value is DataSourceQueryMappingValue => value !== null ),
-								},
-							] );
-						} }
+						label={ __( 'Tables', 'remote-data-blocks' ) }
+						customHelpText={ tablesHelpText }
+						selectedFields={ selectedTables }
+						availableFields={ availableTables }
+						disabled={ ! availableTables?.length }
+						onFieldsChange={ onTablesChange }
 					/>
 				</DataSourceForm.Scope>
 			</DataSourceForm>

--- a/src/data-sources/airtable/utils.ts
+++ b/src/data-sources/airtable/utils.ts
@@ -6,7 +6,7 @@ import {
 import { AirtableField } from '@/data-sources/airtable/types';
 import { DataSourceQueryMappingValue } from '@/data-sources/types';
 
-export const getAirtableOutputQueryMappingValue = (
+const getAirtableFieldOutputQueryMappingValue = (
 	field: AirtableField
 ): DataSourceQueryMappingValue => {
 	const baseField = {
@@ -75,7 +75,7 @@ export const getAirtableOutputQueryMappingValue = (
 		case 'formula':
 		case 'lookup':
 			if ( field.options?.result?.type ) {
-				return getAirtableOutputQueryMappingValue( {
+				return getAirtableFieldOutputQueryMappingValue( {
 					...field,
 					type: field.options.result.type,
 				} );
@@ -85,4 +85,10 @@ export const getAirtableOutputQueryMappingValue = (
 		default:
 			return { ...baseField, type: 'string' };
 	}
+};
+
+export const getAirtableOutputQueryMappingValues = (
+	fields: AirtableField[]
+): DataSourceQueryMappingValue[] => {
+	return fields.map( field => getAirtableFieldOutputQueryMappingValue( field ) );
 };

--- a/src/data-sources/api-clients/google.ts
+++ b/src/data-sources/api-clients/google.ts
@@ -86,4 +86,23 @@ export class GoogleApi {
 		const values = await this.getSheetValues( spreadsheetId, sheetTitle, 'A1:Z1' );
 		return values.values[ 0 ] ?? [];
 	}
+
+	/**
+	 * Get all fields for all sheets in a spreadsheet.
+	 *
+	 * @param spreadsheetId - The ID of the spreadsheet.
+	 * @returns An object with sheet titles as keys and their corresponding fields as values.
+	 */
+	public async getSpreadsheetFields(
+		spreadsheetId: string
+	): Promise< Record< string, string[] > > {
+		const sheets = await this.getSheetsOptions( spreadsheetId );
+		const fields = await Promise.all(
+			sheets.map( sheet => this.getSheetFields( spreadsheetId, sheet.label ) )
+		);
+
+		return Object.fromEntries(
+			sheets.map( ( sheet, index ) => [ sheet.label, fields.at( index ) ?? [] ] )
+		);
+	}
 }

--- a/src/data-sources/api-clients/google.ts
+++ b/src/data-sources/api-clients/google.ts
@@ -5,6 +5,9 @@ import {
 	GoogleDriveFileList,
 	GoogleDriveFile,
 	GoogleSheetsValueRange,
+	GoogleSpreadsheetFields,
+	GoogleSheetWithFields,
+	GoogleSheetIdName,
 } from '@/types/google';
 import { SelectOption } from '@/types/input';
 
@@ -64,14 +67,6 @@ export class GoogleApi {
 		return result;
 	}
 
-	public async getSheetsOptions( spreadsheetId: string ): Promise< SelectOption[] > {
-		const spreadsheet = await this.getSpreadsheet( spreadsheetId );
-		return spreadsheet.sheets.map( sheet => ( {
-			label: sheet.properties.title,
-			value: sheet.properties.sheetId.toString(),
-		} ) );
-	}
-
 	private async getSheetValues(
 		spreadsheetId: string,
 		sheetTitle: string,
@@ -84,6 +79,9 @@ export class GoogleApi {
 
 	public async getSheetFields( spreadsheetId: string, sheetTitle: string ): Promise< string[] > {
 		const values = await this.getSheetValues( spreadsheetId, sheetTitle, 'A1:Z1' );
+		if ( ! values?.values?.length ) {
+			return [];
+		}
 		return values.values[ 0 ] ?? [];
 	}
 
@@ -91,18 +89,51 @@ export class GoogleApi {
 	 * Get all fields for all sheets in a spreadsheet.
 	 *
 	 * @param spreadsheetId - The ID of the spreadsheet.
-	 * @returns An object with sheet titles as keys and their corresponding fields as values.
+	 * @returns A Map with sheet titles as keys and their corresponding fields as values.
 	 */
 	public async getSpreadsheetFields(
-		spreadsheetId: string
-	): Promise< Record< string, string[] > > {
-		const sheets = await this.getSheetsOptions( spreadsheetId );
+		spreadsheetId: string,
+		sheets: GoogleSheetIdName[]
+	): Promise< Map< string, string[] > > {
 		const fields = await Promise.all(
-			sheets.map( sheet => this.getSheetFields( spreadsheetId, sheet.label ) )
+			sheets.map( sheet => this.getSheetFields( spreadsheetId, sheet.name ) )
 		);
 
-		return Object.fromEntries(
-			sheets.map( ( sheet, index ) => [ sheet.label, fields.at( index ) ?? [] ] )
-		);
+		return new Map( sheets.map( ( sheet, index ) => [ sheet.name, fields.at( index ) ?? [] ] ) );
+	}
+
+	/**
+	 * Get all sheets with their corresponding fields.
+	 *
+	 * @param spreadsheetId - The ID of the spreadsheet.
+	 * @returns An object with sheet titles as keys and their corresponding fields as values.
+	 */
+	public async getSheetsWithFieldNames(
+		spreadsheetId: string
+	): Promise< GoogleSpreadsheetFields > {
+		const spreadsheet = await this.getSpreadsheet( spreadsheetId );
+		const sheets: GoogleSheetIdName[] = spreadsheet.sheets.map( sheet => ( {
+			id: sheet.properties.sheetId,
+			name: sheet.properties.title,
+		} ) );
+
+		const sheetFields = await this.getSpreadsheetFields( spreadsheetId, sheets );
+
+		const sheetsWithFields = new Map< string, GoogleSheetWithFields >();
+		sheets.forEach( sheet => {
+			const fields = sheetFields.get( sheet.name ) ?? [];
+
+			if ( fields.length ) {
+				/**
+				 * Only include sheets that have fields.
+				 */
+				sheetsWithFields.set( sheet.name, {
+					...sheet,
+					fields,
+				} );
+			}
+		} );
+
+		return sheetsWithFields;
 	}
 }

--- a/src/data-sources/components/FieldsSelection.tsx
+++ b/src/data-sources/components/FieldsSelection.tsx
@@ -8,6 +8,7 @@ interface FieldsSelectionProps {
 	onFieldsChange: ( fields: string[] ) => void;
 	disabled?: boolean;
 	customHelpText?: string | null;
+	label?: string;
 }
 
 export const FieldsSelection = ( {
@@ -16,10 +17,11 @@ export const FieldsSelection = ( {
 	onFieldsChange,
 	customHelpText,
 	disabled = false,
+	label,
 }: FieldsSelectionProps ) => {
 	return (
 		<CustomFormFieldToken
-			label={ __( 'Fields', 'remote-data-blocks' ) }
+			label={ label ?? __( 'Fields', 'remote-data-blocks' ) }
 			onChange={ selection => {
 				let newFields: string[];
 				if ( selection.includes( 'Select All' ) ) {

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -8,8 +8,7 @@ import { GOOGLE_SHEETS_API_SCOPES } from '@/data-sources/constants';
 import { useDataSources } from '@/data-sources/hooks/useDataSources';
 import {
 	useGoogleSpreadsheetsOptions,
-	useGoogleSheetsOptions,
-	useGoogleSheetFields,
+	useGoogleSheetsWithFields,
 } from '@/data-sources/hooks/useGoogleApi';
 import { useGoogleAuth } from '@/data-sources/hooks/useGoogleAuth';
 import {
@@ -72,16 +71,13 @@ export const GoogleSheetsSettings = ( {
 	);
 	const { spreadsheets, isLoadingSpreadsheets, errorSpreadsheets } =
 		useGoogleSpreadsheetsOptions( token );
-	const { sheets, isLoadingSheets, errorSheets } = useGoogleSheetsOptions(
+	const { sheets, sheetsWithFields, isLoadingSheets, errorSheets } = useGoogleSheetsWithFields(
 		token,
 		state.spreadsheet?.id ?? ''
 	);
 
-	const availableSheets = sheets?.length ? sheets?.map( sheet => sheet.label ) : [];
+	const availableSheets = sheets?.length ? sheets?.map( sheet => sheet.name ) : [];
 	const selectedSheets = state.sheets?.map( sheet => sheet.name ) ?? [];
-
-	const { spreadsheetFields, isLoadingSpreadsheetFields, errorSpreadsheetFields } =
-		useGoogleSheetFields( token, state.spreadsheet?.id ?? '' );
 
 	const onSaveClick = async () => {
 		if ( ! validState ) {
@@ -113,14 +109,29 @@ export const GoogleSheetsSettings = ( {
 	const onSheetsChange = ( sheetNames: string[] ) => {
 		let newSheets: GoogleSheetsSheetConfig[] = [];
 
-		if ( state.sheets?.length ) {
-			newSheets = state.sheets
-				.filter( sheet => sheetNames.includes( sheet.name ) )
-				.map( sheet => ( {
-					id: sheet.id,
-					name: sheet.name,
-					output_query_mappings: [] as DataSourceQueryMappingValue[],
-				} ) );
+		if ( sheetNames.length ) {
+			newSheets = sheetNames
+				.map( name => {
+					const sheet = sheetsWithFields?.get( name );
+
+					if ( ! sheet ) {
+						return null;
+					}
+
+					const outputQueryMappings: DataSourceQueryMappingValue[] = sheet.fields.map( field => ( {
+						key: field,
+						name: field,
+						path: `$.${ field }`,
+						type: 'string',
+					} ) );
+
+					return {
+						id: `${ sheet.id }`,
+						name: sheet.name,
+						output_query_mappings: outputQueryMappings,
+					};
+				} )
+				.filter( Boolean ) as GoogleSheetsSheetConfig[];
 		}
 
 		handleOnChange( 'sheets', newSheets );
@@ -184,7 +195,7 @@ export const GoogleSheetsSettings = ( {
 	}, [ spreadsheets ] );
 
 	const getSheetsHelpText = () => {
-		if ( token && ! state.spreadsheet ) {
+		if ( token && state.spreadsheet ) {
 			if ( errorSheets ) {
 				const errorMessage = errorSheets?.message ?? __( 'Unknown error', 'remote-data-blocks' );
 				return __( 'Failed to fetch sheets.', 'remote-data-blocks' ) + ' ' + errorMessage;
@@ -194,7 +205,11 @@ export const GoogleSheetsSettings = ( {
 				return __( 'Fetching sheets...', 'remote-data-blocks' );
 			}
 
-			return __( 'No sheets found', 'remote-data-blocks' );
+			if ( ! sheets?.length ) {
+				return __( 'No sheets found', 'remote-data-blocks' );
+			}
+
+			return __( 'Select sheets to attach with this data source.', 'remote-data-blocks' );
 		}
 
 		return __( 'Auto-filled on valid spreadsheet.', 'remote-data-blocks' );
@@ -242,7 +257,7 @@ export const GoogleSheetsSettings = ( {
 					selectedFields={ selectedSheets }
 					availableFields={ availableSheets }
 					onFieldsChange={ onSheetsChange }
-					disabled={ ! state.spreadsheet }
+					disabled={ ! availableSheets?.length }
 					customHelpText={ getSheetsHelpText() }
 				/>
 			</DataSourceForm.Scope>

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -15,14 +15,16 @@ import { useGoogleAuth } from '@/data-sources/hooks/useGoogleAuth';
 import {
 	GoogleSheetsConfig,
 	GoogleSheetsServiceConfig,
+	GoogleSheetsSheetConfig,
 	SettingsComponentProps,
+	DataSourceQueryMappingValue,
 } from '@/data-sources/types';
 import { getConnectionMessage } from '@/data-sources/utils';
 import { useForm, ValidationRules } from '@/hooks/useForm';
 import { GoogleSheetsIcon, GoogleSheetsIconWithText } from '@/settings/icons/GoogleSheetsIcon';
 import { GoogleServiceAccountKey } from '@/types/google';
 import { SelectOption } from '@/types/input';
-import { isPositiveIntegerString, safeParseJSON } from '@/utils/string';
+import { safeParseJSON } from '@/utils/string';
 
 const SERVICE_CONFIG_VERSION = 1;
 
@@ -57,20 +59,10 @@ export const GoogleSheetsSettings = ( {
 		validationRules,
 	} );
 
-	const currentSheet = state?.sheets?.length ? state.sheets[ 0 ] : null;
-	const currentSheetIdString = currentSheet ? currentSheet.id.toString() : '';
-	const currentSheetTitle = currentSheet ? currentSheet.name : '';
-
 	const [ spreadsheetOptions, setSpreadsheetOptions ] = useState< SelectOption[] >( [
 		{
 			...defaultSelectOption,
 			label: __( 'Auto-filled on successful connection.', 'remote-data-blocks' ),
-		},
-	] );
-	const [ sheetOptions, setSheetOptions ] = useState< SelectOption[] >( [
-		{
-			...defaultSelectOption,
-			label: __( 'Auto-filled on valid spreadsheet.', 'remote-data-blocks' ),
 		},
 	] );
 
@@ -84,20 +76,12 @@ export const GoogleSheetsSettings = ( {
 		token,
 		state.spreadsheet?.id ?? ''
 	);
-	const { sheetFields, isLoadingSheetFields, errorSheetFields } = useGoogleSheetFields(
-		token,
-		state.spreadsheet?.id ?? '',
-		currentSheetTitle
-	);
-	const availableSheetFields = sheetFields ?? [];
-	const showFieldsSelection =
-		currentSheet &&
-		isLoadingSheetFields === false &&
-		availableSheetFields.length > 0 &&
-		! errorSheetFields;
-	const selectedSheetFields = state.sheets?.[ 0 ]?.output_query_mappings?.length
-		? state.sheets[ 0 ].output_query_mappings.map( mapping => mapping.key )
-		: [];
+
+	const availableSheets = sheets?.length ? sheets?.map( sheet => sheet.label ) : [];
+	const selectedSheets = state.sheets?.map( sheet => sheet.name ) ?? [];
+
+	const { spreadsheetFields, isLoadingSpreadsheetFields, errorSpreadsheetFields } =
+		useGoogleSheetFields( token, state.spreadsheet?.id ?? '' );
 
 	const onSaveClick = async () => {
 		if ( ! validState ) {
@@ -120,41 +104,26 @@ export const GoogleSheetsSettings = ( {
 		}
 	};
 
-	const onSheetChange = ( value: string ) => {
-		if ( isPositiveIntegerString( value ) ) {
-			const selectedSheet = sheets?.find( sheet => sheet.value === value );
-			handleOnChange( 'sheets', [
-				{
-					id: value,
-					name: selectedSheet?.label ?? '',
-					output_query_mappings: [],
-				},
-			] );
-		}
-	};
-
 	const onSpreadsheetChange = ( value: string ) => {
 		const selectedSpreadsheet = spreadsheets?.find( spreadsheet => spreadsheet.value === value );
 		handleOnChange( 'spreadsheet', { id: value, name: selectedSpreadsheet?.label ?? '' } );
 		handleOnChange( 'sheets', [] );
 	};
 
-	const onSheetsFieldsChange = ( newFields: string[] ) => {
-		if ( ! currentSheet ) {
-			return;
+	const onSheetsChange = ( sheetNames: string[] ) => {
+		let newSheets: GoogleSheetsSheetConfig[] = [];
+
+		if ( state.sheets?.length ) {
+			newSheets = state.sheets
+				.filter( sheet => sheetNames.includes( sheet.name ) )
+				.map( sheet => ( {
+					id: sheet.id,
+					name: sheet.name,
+					output_query_mappings: [] as DataSourceQueryMappingValue[],
+				} ) );
 		}
 
-		handleOnChange( 'sheets', [
-			{
-				...currentSheet,
-				output_query_mappings: newFields.map( key => ( {
-					key,
-					name: key,
-					path: `$.${ key }`,
-					type: 'string',
-				} ) ),
-			},
-		] );
+		handleOnChange( 'sheets', newSheets );
 	};
 
 	const credentialsHelpText = useMemo( () => {
@@ -200,21 +169,6 @@ export const GoogleSheetsSettings = ( {
 		return __( 'Select a spreadsheet from which to fetch data.', 'remote-data-blocks' );
 	}, [ token, errorSpreadsheets, isLoadingSpreadsheets, spreadsheets ] );
 
-	const sheetHelpText = useMemo( () => {
-		if ( token ) {
-			if ( errorSheets ) {
-				const errorMessage = errorSheets?.message ?? __( 'Unknown error', 'remote-data-blocks' );
-				return __( 'Failed to fetch sheets.', 'remote-data-blocks' ) + ' ' + errorMessage;
-			} else if ( isLoadingSheets ) {
-				return __( 'Fetching sheets...', 'remote-data-blocks' );
-			} else if ( sheets?.length === 0 ) {
-				return __( 'No sheets found', 'remote-data-blocks' );
-			}
-		}
-
-		return __( 'Select a sheet from which to fetch data.', 'remote-data-blocks' );
-	}, [ token, errorSheets, isLoadingSheets, sheets ] );
-
 	useEffect( () => {
 		if ( ! spreadsheets?.length ) {
 			return;
@@ -229,30 +183,21 @@ export const GoogleSheetsSettings = ( {
 		] );
 	}, [ spreadsheets ] );
 
-	useEffect( () => {
-		if ( ! state.spreadsheet ) {
-			return;
+	const getSheetsHelpText = () => {
+		if ( token && ! state.spreadsheet ) {
+			if ( errorSheets ) {
+				const errorMessage = errorSheets?.message ?? __( 'Unknown error', 'remote-data-blocks' );
+				return __( 'Failed to fetch sheets.', 'remote-data-blocks' ) + ' ' + errorMessage;
+			}
+
+			if ( isLoadingSheets ) {
+				return __( 'Fetching sheets...', 'remote-data-blocks' );
+			}
+
+			return __( 'No sheets found', 'remote-data-blocks' );
 		}
 
-		setSheetOptions( [
-			{
-				...defaultSelectOption,
-				label: __( 'Select a sheet', 'remote-data-blocks' ),
-			},
-			...( sheets ?? [] ).map( ( { label, value } ) => ( { label, value } ) ),
-		] );
-	}, [ state.spreadsheet, sheets ] );
-
-	const getCustomHelpText = () => {
-		if ( ! sheets?.length ) {
-			return __( 'Please select a sheet first.', 'remote-data-blocks' );
-		}
-
-		if ( isLoadingSheetFields ) {
-			return __( 'Fetching fields...', 'remote-data-blocks' );
-		}
-
-		return null;
+		return __( 'Auto-filled on valid spreadsheet.', 'remote-data-blocks' );
 	};
 
 	return (
@@ -292,22 +237,13 @@ export const GoogleSheetsSettings = ( {
 					__nextHasNoMarginBottom
 				/>
 
-				<SelectControl
-					id="sheets"
-					label={ __( 'Sheet', 'remote-data-blocks' ) }
-					value={ currentSheetIdString }
-					onChange={ onSheetChange }
-					options={ sheetOptions }
-					help={ sheetHelpText }
-					disabled={ fetchingToken || ! sheets?.length }
-					__next40pxDefaultSize
-				/>
 				<FieldsSelection
-					selectedFields={ selectedSheetFields }
-					availableFields={ availableSheetFields }
-					onFieldsChange={ onSheetsFieldsChange }
-					disabled={ ! showFieldsSelection }
-					customHelpText={ getCustomHelpText() }
+					label={ __( 'Sheets', 'remote-data-blocks' ) }
+					selectedFields={ selectedSheets }
+					availableFields={ availableSheets }
+					onFieldsChange={ onSheetsChange }
+					disabled={ ! state.spreadsheet }
+					customHelpText={ getSheetsHelpText() }
 				/>
 			</DataSourceForm.Scope>
 		</DataSourceForm>

--- a/src/data-sources/hooks/useAirtable.ts
+++ b/src/data-sources/hooks/useAirtable.ts
@@ -65,10 +65,7 @@ export const useAirtableApiTables = ( token: string, base: string ) => {
 		isLoading: fetchingTables,
 		error: tablesError,
 		refetch: fetchTables,
-	} = useQuery( queryFn, { manualFetchOnly: true } );
-
-	const debouncedFetchTables = useDebounce( fetchTables, 500 );
-	useEffect( debouncedFetchTables, [ token, base, debouncedFetchTables ] );
+	} = useQuery( queryFn );
 
 	return { fetchingTables, fetchTables, tables, tablesError };
 };

--- a/src/data-sources/hooks/useGoogleApi.ts
+++ b/src/data-sources/hooks/useGoogleApi.ts
@@ -27,48 +27,28 @@ export const useGoogleSpreadsheetsOptions = ( token: string | null ) => {
 	return { spreadsheets, isLoadingSpreadsheets, errorSpreadsheets, refetchSpreadsheets };
 };
 
-export const useGoogleSheetsOptions = ( token: string | null, spreadsheetId: string ) => {
+export const useGoogleSheetsWithFields = ( token: string | null, spreadsheetId: string ) => {
 	const api = useMemo( () => new GoogleApi( token ), [ token ] );
 
 	const queryFn = useCallback( async () => {
 		if ( ! token || ! spreadsheetId ) {
 			return null;
 		}
-		return api.getSheetsOptions( spreadsheetId );
+		return api.getSheetsWithFieldNames( spreadsheetId );
 	}, [ api, token, spreadsheetId ] );
 
 	const {
-		data: sheets,
+		data: sheetsWithFields,
 		isLoading: isLoadingSheets,
 		error: errorSheets,
-		refetch: refetchSheets,
-	} = useQuery( queryFn, { manualFetchOnly: true } );
+	} = useQuery( queryFn );
 
-	const debouncedFetchSheets = useDebounce( refetchSheets, 500 );
-	useEffect( debouncedFetchSheets, [ token, debouncedFetchSheets ] );
+	const sheets = sheetsWithFields
+		? Array.from( sheetsWithFields.values() ).map( sheet => ( {
+				id: sheet.id,
+				name: sheet.name,
+		  } ) )
+		: null;
 
-	return { sheets, isLoadingSheets, errorSheets, refetchSheets };
-};
-
-export const useGoogleSheetFields = ( token: string | null, spreadsheetId: string ) => {
-	const api = useMemo( () => new GoogleApi( token ), [ token ] );
-
-	const queryFn = useCallback( async () => {
-		if ( ! token || ! spreadsheetId ) {
-			return null;
-		}
-		return api.getSpreadsheetFields( spreadsheetId );
-	}, [ api, token, spreadsheetId ] );
-
-	const {
-		data: spreadsheetFields,
-		isLoading: isLoadingSpreadsheetFields,
-		error: errorSpreadsheetFields,
-		refetch: refetchSpreadsheetFields,
-	} = useQuery( queryFn, { manualFetchOnly: true } );
-
-	const debouncedFetchSpreadsheetFields = useDebounce( refetchSpreadsheetFields, 500 );
-	useEffect( debouncedFetchSpreadsheetFields, [ token, debouncedFetchSpreadsheetFields ] );
-
-	return { spreadsheetFields, isLoadingSpreadsheetFields, errorSpreadsheetFields };
+	return { sheets, sheetsWithFields, isLoadingSheets, errorSheets };
 };

--- a/src/data-sources/hooks/useGoogleApi.ts
+++ b/src/data-sources/hooks/useGoogleApi.ts
@@ -50,29 +50,25 @@ export const useGoogleSheetsOptions = ( token: string | null, spreadsheetId: str
 	return { sheets, isLoadingSheets, errorSheets, refetchSheets };
 };
 
-export const useGoogleSheetFields = (
-	token: string | null,
-	spreadsheetId: string,
-	sheetTitle: string
-) => {
+export const useGoogleSheetFields = ( token: string | null, spreadsheetId: string ) => {
 	const api = useMemo( () => new GoogleApi( token ), [ token ] );
 
 	const queryFn = useCallback( async () => {
-		if ( ! token || ! spreadsheetId || ! sheetTitle ) {
+		if ( ! token || ! spreadsheetId ) {
 			return null;
 		}
-		return api.getSheetFields( spreadsheetId, sheetTitle );
-	}, [ api, token, spreadsheetId, sheetTitle ] );
+		return api.getSpreadsheetFields( spreadsheetId );
+	}, [ api, token, spreadsheetId ] );
 
 	const {
-		data: sheetFields,
-		isLoading: isLoadingSheetFields,
-		error: errorSheetFields,
-		refetch: refetchSheetFields,
+		data: spreadsheetFields,
+		isLoading: isLoadingSpreadsheetFields,
+		error: errorSpreadsheetFields,
+		refetch: refetchSpreadsheetFields,
 	} = useQuery( queryFn, { manualFetchOnly: true } );
 
-	const debouncedFetchSheetFields = useDebounce( refetchSheetFields, 500 );
-	useEffect( debouncedFetchSheetFields, [ token, debouncedFetchSheetFields ] );
+	const debouncedFetchSpreadsheetFields = useDebounce( refetchSpreadsheetFields, 500 );
+	useEffect( debouncedFetchSpreadsheetFields, [ token, debouncedFetchSpreadsheetFields ] );
 
-	return { sheetFields, isLoadingSheetFields, errorSheetFields };
+	return { spreadsheetFields, isLoadingSpreadsheetFields, errorSpreadsheetFields };
 };

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -26,6 +26,7 @@ export function useQuery< T >(
 	const [ error, setError ] = useState< Error | null >( null );
 
 	const fetchData = useCallback( async () => {
+		setData( null );
 		setIsLoading( true );
 		setError( null );
 		try {

--- a/src/types/google.ts
+++ b/src/types/google.ts
@@ -1,3 +1,5 @@
+import { NumberIdName } from '@/types/common';
+
 // Google Drive
 export interface GoogleDriveFile {
 	kind: 'drive#file';
@@ -70,6 +72,16 @@ export interface GoogleSheetsValueRange {
 	majorDimension: 'ROWS' | 'COLUMNS' | 'DIMENSION_UNSPECIFIED';
 	values: GoogleSheetsValues[];
 }
+
+// Derived Google Sheet types
+
+export type GoogleSheetIdName = NumberIdName;
+
+export type GoogleSheetWithFields = GoogleSheetIdName & {
+	fields: string[];
+};
+
+export type GoogleSpreadsheetFields = Map< string, GoogleSheetWithFields >;
 
 // Service Account
 export interface GoogleServiceAccountKey {


### PR DESCRIPTION
# Description

This PR adds option to add multiple sheets from a spreadsheet for Google Sheets data source and multiple tables from a base for Airtable data source. When sheets/tables are added, all supported fields from the sheet/table are added to the data source to be used in the remote data blocks.

A separate PR will add the auto-registering blocks for each of selected sheets/tables. For now, it continues with existing behavior of registering block for the first sheet/table.

| <img width="972" alt="Screenshot 2025-01-10 at 5 45 40 PM" src="https://github.com/user-attachments/assets/45316d2a-1d85-4559-8f57-378bde3c8b4a" /> |
| :----: |
| Airtable data source with multiple tables |

## Changes

- Converted the sheets/tables selection into a multi-select input.
- Removed the input to select the fields from the sheet/table. All the supported fields are added automatically.
- Removed debouncing API requests for Google Sheets/Airtable when it depends on discreet changes in the input fields (e.g. when it depends on change in select input).


# Testing

- Start the local development environment ([docs](https://github.com/Automattic/remote-data-blocks/blob/trunk/docs/local-development.md))
- Try adding new Airtable or Google Sheets data source and verify that you can now add multiple sheets/tables. By inspecting the network calls, verify that all the supported fields are added for each sheet/table selected for the data source.