### PR TITLE
[UI] Fix bulk delete + add duplicate source option

### DIFF
--- a/inc/REST/DataSourceController.php
+++ b/inc/REST/DataSourceController.php
@@ -102,6 +102,23 @@ class DataSourceController extends WP_REST_Controller {
 				],
 			]
 		);
+
+		// delete_multiple_items
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<uuids>[a-zA-Z0-9,-]+)',
+			[
+				'methods' => 'DELETE',
+				'callback' => [ $this, 'delete_multiple_items' ], 
+				'permission_callback' => [ $this, 'delete_items_permissions_check' ],
+				'args' => [
+					'uuids' => [
+						'type' => 'string',
+						'required' => true,
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -219,6 +236,49 @@ class DataSourceController extends WP_REST_Controller {
 		return rest_ensure_response( $result );
 	}
 
+	/**
+	 * Deletes multiple items.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function delete_multiple_items( $request ) {
+		$uuids = explode( ',', $request->get_param( 'uuids' ) );
+
+		if ( empty( $uuids ) ) {
+			return new WP_Error(
+				'no_uuids_provided',
+				__( 'No items provided for deletion.', 'remote-data-blocks' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$failed = [];
+		foreach ( $uuids as $uuid ) {
+			$result = DataSourceCrud::delete_config_by_uuid( $uuid );
+			if ( is_wp_error( $result ) ) {
+				$failed[] = [
+					'uuid' => $uuid,
+					'error' => $result->get_error_message(),
+				];
+			}
+		}
+
+		if ( ! empty( $failed ) ) {
+			return rest_ensure_response([
+				'status' => 'partial_success',
+				'message' => __( 'Some items could not be deleted.', 'remote-data-blocks' ),
+				'failed' => $failed,
+			]);
+		}
+
+		return rest_ensure_response([
+			'status' => 'success',
+			'message' => __( 'All items deleted successfully.', 'remote-data-blocks' ),
+		]);
+	}
+
+
 	// These all require manage_options for now, but we can adjust as needed
 
 	public function get_item_permissions_check( $request ) {
@@ -238,6 +298,10 @@ class DataSourceController extends WP_REST_Controller {
 	}
 
 	public function delete_item_permissions_check( $request ) {
+		return current_user_can( 'manage_options' );
+	}
+
+	public function delete_items_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
 	}
 

--- a/inc/REST/DataSourceController.php
+++ b/inc/REST/DataSourceController.php
@@ -110,7 +110,7 @@ class DataSourceController extends WP_REST_Controller {
 			[
 				'methods' => 'DELETE',
 				'callback' => [ $this, 'delete_multiple_items' ], 
-				'permission_callback' => [ $this, 'delete_items_permissions_check' ],
+				'permission_callback' => [ $this, 'delete_item_permissions_check' ],
 				'args' => [
 					'uuids' => [
 						'type' => 'string',
@@ -298,10 +298,6 @@ class DataSourceController extends WP_REST_Controller {
 	}
 
 	public function delete_item_permissions_check( $request ) {
-		return current_user_can( 'manage_options' );
-	}
-
-	public function delete_items_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
 	}
 

--- a/src/data-sources/DataSourceList.tsx
+++ b/src/data-sources/DataSourceList.tsx
@@ -30,7 +30,14 @@ import { ShopifyIcon } from '@/settings/icons/ShopifyIcon';
 const DataSourceList = () => {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch< NoticeStoreActions >( noticesStore );
-	const { dataSources, loadingDataSources, deleteDataSource, fetchDataSources } = useDataSources();
+	const {
+		dataSources,
+		loadingDataSources,
+		deleteDataSource,
+		deleteMultipleDataSources,
+		fetchDataSources,
+		addDataSource,
+	} = useDataSources();
 	const [ dataSourceToDelete, setDataSourceToDelete ] = useState<
 		DataSourceConfig | DataSourceConfig[] | null
 	>( null );
@@ -50,8 +57,11 @@ const DataSourceList = () => {
 	};
 
 	const onConfirmDeleteDataSource = async ( source: DataSourceConfig | DataSourceConfig[] ) => {
-		const sources = Array.isArray( source ) ? source : [ source ];
-		await Promise.all( sources.map( src => deleteDataSource( src ).catch( () => null ) ) );
+		if ( Array.isArray( source ) ) {
+			await deleteMultipleDataSources( source );
+		} else {
+			await deleteDataSource( source );
+		}
 		setDataSourceToDelete( null );
 		await fetchDataSources().catch( () => null );
 	};
@@ -198,6 +208,38 @@ const DataSourceList = () => {
 				}
 			},
 			supportsBulk: true,
+		},
+		{
+			id: 'duplicate',
+			label: __( 'Duplicate', 'remote-data-blocks' ),
+			isEligible: ( item: DataSourceConfig ) => {
+				return Boolean( item?.uuid );
+			},
+			callback: ( [ item ]: DataSourceConfig[] ) => {
+				if ( item ) {
+					const duplicatedSource = {
+						...item,
+						uuid: null,
+						service: item.service,
+						service_config: {
+							...item.service_config,
+							display_name: item.service_config.display_name + __( ' copy ', 'remote-data-blocks' ),
+						} as DataSourceConfig[ 'service_config' ],
+					};
+					addDataSource( duplicatedSource as DataSourceConfig )
+						.then( result => {
+							if ( result && result.uuid ) {
+								return onEditDataSource( result.uuid );
+							}
+						} )
+						.catch( () => {
+							showSnackbar(
+								'error',
+								__( 'Failed to duplicate data source.', 'remote-data-blocks' )
+							);
+						} );
+				}
+			},
 		},
 	];
 

--- a/src/data-sources/hooks/useDataSources.ts
+++ b/src/data-sources/hooks/useDataSources.ts
@@ -121,6 +121,23 @@ export const useDataSources = < SourceConfig extends DataSourceConfig = DataSour
 		);
 	}
 
+	async function deleteMultipleDataSources( sources: DataSourceConfig[] ) {
+		const uuids = sources.map( source => source.uuid ).join( ',' );
+
+		try {
+			await apiFetch( {
+				path: `${ REST_BASE_DATA_SOURCES }/${ uuids }`,
+				method: 'DELETE',
+			} );
+		} catch ( error ) {
+			showSnackbar(
+				'error',
+				__( 'Failed to delete selected data sources.', 'remote-data-blocks' )
+			);
+			throw error;
+		}
+	}
+
 	async function onSave( config: SourceConfig, mode: 'add' | 'edit' ): Promise< void > {
 		if ( mode === 'add' ) {
 			await addDataSource( config );
@@ -155,6 +172,7 @@ export const useDataSources = < SourceConfig extends DataSourceConfig = DataSour
 		addDataSource,
 		dataSources,
 		deleteDataSource,
+		deleteMultipleDataSources,
 		loadingDataSources,
 		updateDataSource,
 		fetchDataSources,

--- a/src/data-sources/hooks/useDataSources.ts
+++ b/src/data-sources/hooks/useDataSources.ts
@@ -136,6 +136,11 @@ export const useDataSources = < SourceConfig extends DataSourceConfig = DataSour
 			);
 			throw error;
 		}
+
+		showSnackbar(
+			'success',
+			__( 'Selected data sources have been successfully deleted.', 'remote-data-blocks' )
+		);
 	}
 
 	async function onSave( config: SourceConfig, mode: 'add' | 'edit' ): Promise< void > {


### PR DESCRIPTION
Bulk deletion was included in previous UI updates, but the feature wasn't working. 

This adds a new endpoint and methods for bulk deletion. I also included an option to duplicate sources, which is helpful for testing. 


https://github.com/user-attachments/assets/4c82f721-6ec9-419d-94ae-31633e270762

