### PR TITLE
Add `targetFolderName` to blueprint pluginData options

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -32,7 +32,8 @@
     {
       "step": "installPlugin",
       "options": {
-        "activate": true
+        "activate": true,
+        "targetFolderName": "remote-data-blocks"
       },
       "pluginData": {
         "caption": "Installing Remote Data Blocks",


### PR DESCRIPTION
Attempt to resolve recent errors when launching in playground