### PR TITLE
[UI] Add display name check back

### DIFF
--- a/src/data-sources/DataSourceList.tsx
+++ b/src/data-sources/DataSourceList.tsx
@@ -223,7 +223,7 @@ const DataSourceList = () => {
 						service: item.service,
 						service_config: {
 							...item.service_config,
-							display_name: item.service_config.display_name + __( ' copy ', 'remote-data-blocks' ),
+							display_name: item.service_config.display_name + __( ' copy', 'remote-data-blocks' ),
 						} as DataSourceConfig[ 'service_config' ],
 					};
 					addDataSource( duplicatedSource as DataSourceConfig )

--- a/src/data-sources/airtable/AirtableSettings.tsx
+++ b/src/data-sources/airtable/AirtableSettings.tsx
@@ -176,6 +176,7 @@ export const AirtableSettings = ( {
 					heading={ { icon: AirtableIconWithText, width: '113.81px', height: '25px' } }
 					inputIcon={ AirtableIcon }
 					canProceed={ shouldAllowContinue }
+					uuid={ uuid }
 				>
 					<PasswordInputControl
 						label={ __( 'Access Token', 'remote-data-blocks' ) }

--- a/src/data-sources/components/DataSourceForm.tsx
+++ b/src/data-sources/components/DataSourceForm.tsx
@@ -7,14 +7,7 @@ import {
 	__experimentalInputControl as InputControl,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';
-import {
-	Children,
-	createPortal,
-	isValidElement,
-	useEffect,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { Children, createPortal, isValidElement, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { lockSmall } from '@wordpress/icons';
 
@@ -213,8 +206,6 @@ const DataSourceFormSetup = ( {
 	const [ displayName, setDisplayName ] = useState( initialDisplayName );
 	const [ errors, setErrors ] = useState< Record< string, string > >( {} );
 
-	const initialValidationDone = useRef( false ); // Track whether initial validation is complete.
-
 	const { icon, height, label, width, verticalAlign } = heading;
 
 	const onDisplayNameChange = ( displayNameInput: string | undefined ) => {
@@ -250,9 +241,8 @@ const DataSourceFormSetup = ( {
 	};
 
 	useEffect( () => {
-		if ( ! initialValidationDone.current || canProceed ) {
+		if ( canProceed || ( displayName === '' && screen === 'editDataSource' ) ) {
 			validateDisplayName();
-			initialValidationDone.current = true;
 		}
 	}, [ canProceed, displayName ] );
 
@@ -295,7 +285,7 @@ const DataSourceFormSetup = ( {
 				data-1p-ignore
 				className={ `rdb-settings-page_data-source-form-input ${
 					errors.displayName ? 'has-error' : ''
-				}` }
+				}   ` }
 				help={
 					<span>
 						{ errors.displayName

--- a/src/data-sources/components/DataSourceForm.tsx
+++ b/src/data-sources/components/DataSourceForm.tsx
@@ -7,11 +7,19 @@ import {
 	__experimentalInputControl as InputControl,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';
-import { Children, createPortal, isValidElement, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import {
+	Children,
+	createPortal,
+	isValidElement,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { lockSmall } from '@wordpress/icons';
 
 import { DataSourceFormActions } from './DataSourceFormActions';
+import { useDataSources } from '../hooks/useDataSources';
 import { useSettingsContext } from '@/settings/hooks/useSettingsNav';
 
 interface DataSourceFormProps {
@@ -42,7 +50,7 @@ interface DataSourceFormSetupProps {
 	inputIcon: IconType;
 	newUUID?: string | null;
 	setNewUUID?: ( uuid: string | null ) => void;
-	uuidFromProps?: string;
+	uuid?: string;
 }
 
 const DataSourceFormStep = ( {
@@ -64,6 +72,7 @@ const DataSourceFormStep = ( {
 const DataSourceForm = ( { children, onSave }: DataSourceFormProps ) => {
 	const [ currentStep, setCurrentStep ] = useState( 1 );
 	const { goToMainScreen, screen } = useSettingsContext();
+	const { checkDisplayNameConflict } = useDataSources();
 
 	const steps = Children.toArray( children );
 	const singleStep = steps.length === 1 || screen === 'editDataSource';
@@ -72,10 +81,11 @@ const DataSourceForm = ( { children, onSave }: DataSourceFormProps ) => {
 
 	const canProceedToNextStep = (): boolean => {
 		const step = steps[ currentStep - 1 ];
-		if (
-			isValidElement< { canProceed?: boolean; displayName: string; uuidFromProps: string } >( step )
-		) {
-			return Boolean( step.props?.canProceed );
+		if ( isValidElement< { canProceed?: boolean; displayName: string; uuid: string } >( step ) ) {
+			const { displayName, uuid } = step.props;
+			if ( currentStep === 1 ) {
+				return Boolean( step.props?.canProceed ) && checkDisplayNameConflict( displayName, uuid );
+			}
 		}
 		return false;
 	};
@@ -189,16 +199,21 @@ const DataSourceForm = ( { children, onSave }: DataSourceFormProps ) => {
 };
 
 const DataSourceFormSetup = ( {
+	canProceed,
 	children,
 	displayName: initialDisplayName,
 	handleOnChange,
 	heading,
 	inputIcon,
+	uuid,
 }: DataSourceFormSetupProps ) => {
 	const { screen, service } = useSettingsContext();
+	const { checkDisplayNameConflict } = useDataSources();
 
 	const [ displayName, setDisplayName ] = useState( initialDisplayName );
 	const [ errors, setErrors ] = useState< Record< string, string > >( {} );
+
+	const initialValidationDone = useRef( false ); // Track whether initial validation is complete.
 
 	const { icon, height, label, width, verticalAlign } = heading;
 
@@ -213,14 +228,33 @@ const DataSourceFormSetup = ( {
 	};
 
 	const validateDisplayName = () => {
+		const hasConflict = ! checkDisplayNameConflict( displayName, uuid ?? '' );
+
 		if ( ! displayName.trim() ) {
 			setErrors( {
 				displayName: __( 'Please provide a name for your data source.', 'remote-data-blocks' ),
+			} );
+		} else if ( hasConflict ) {
+			setErrors( {
+				displayName: sprintf(
+					__(
+						'Data source "%s" already exists. Please choose another name.',
+						'remote-data-blocks'
+					),
+					displayName
+				),
 			} );
 		} else {
 			setErrors( {} );
 		}
 	};
+
+	useEffect( () => {
+		if ( ! initialValidationDone.current || canProceed ) {
+			validateDisplayName();
+			initialValidationDone.current = true;
+		}
+	}, [ canProceed, displayName ] );
 
 	return (
 		<DataSourceFormStep
@@ -261,7 +295,7 @@ const DataSourceFormSetup = ( {
 				data-1p-ignore
 				className={ `rdb-settings-page_data-source-form-input ${
 					errors.displayName ? 'has-error' : ''
-				}   ` }
+				}` }
 				help={
 					<span>
 						{ errors.displayName

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -228,6 +228,7 @@ export const GoogleSheetsSettings = ( {
 					verticalAlign: 'text-top',
 				} }
 				inputIcon={ GoogleSheetsIcon }
+				uuid={ uuid }
 			>
 				<TextareaControl
 					label={ __( 'Credentials', 'remote-data-blocks' ) }

--- a/src/data-sources/hooks/useDataSources.ts
+++ b/src/data-sources/hooks/useDataSources.ts
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore, NoticeStoreActions, WPNotice } from '@wordpress/notices';
 
@@ -16,6 +16,19 @@ export const useDataSources = < SourceConfig extends DataSourceConfig = DataSour
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch< NoticeStoreActions >( noticesStore );
 	const { goToMainScreen } = useSettingsContext();
+
+	const checkDisplayNameConflict = useCallback(
+		( displayName: string, uuid: string ): boolean => {
+			if ( ! displayName ) {
+				return false;
+			}
+			const existingSource = dataSources.find(
+				source => source.uuid !== uuid && source.service_config.display_name === displayName
+			);
+			return ! existingSource;
+		},
+		[ dataSources ]
+	);
 
 	async function fetchDataSources() {
 		setLoadingDataSources( true );
@@ -176,6 +189,7 @@ export const useDataSources = < SourceConfig extends DataSourceConfig = DataSour
 	return {
 		addDataSource,
 		dataSources,
+		checkDisplayNameConflict,
 		deleteDataSource,
 		deleteMultipleDataSources,
 		loadingDataSources,

--- a/src/data-sources/http/HttpSettings.tsx
+++ b/src/data-sources/http/HttpSettings.tsx
@@ -76,6 +76,7 @@ export const HttpSettings = ( { mode, uuid, config }: SettingsComponentProps< Ht
 				handleOnChange={ handleOnChange }
 				heading={ { label: __( 'Connect HTTP Data Source', 'remote-data-blocks' ) } }
 				inputIcon={ HttpIcon }
+				uuid={ uuid }
 			>
 				<TextControl
 					type="url"

--- a/src/data-sources/salesforce-b2c/SalesforceB2CSettings.tsx
+++ b/src/data-sources/salesforce-b2c/SalesforceB2CSettings.tsx
@@ -57,6 +57,7 @@ export const SalesforceB2CSettings = ( {
 					verticalAlign: 'middle',
 				} }
 				inputIcon={ SalesforceCommerceB2CIcon }
+				uuid={ uuid }
 			>
 				<TextControl
 					type="text"

--- a/src/data-sources/shopify/ShopifySettings.tsx
+++ b/src/data-sources/shopify/ShopifySettings.tsx
@@ -69,6 +69,7 @@ export const ShopifySettings = ( {
 				handleOnChange={ handleOnChange }
 				heading={ { icon: ShopifyIconWithText, width: '102px', height: '32px' } }
 				inputIcon={ ShopifyIcon }
+				uuid={ uuid }
 			>
 				<TextControl
 					type="url"


### PR DESCRIPTION
At the end of the year when a lot of changes were happening, there were many conflicts and these changes were overwritten along the way. 

This adds back a check so a data source cannot be registered with an empty or existing display name. This is important now since blocks only contain the display name, so to find them, we need to make sure there aren't issues/conflicts. 

<img width="954" alt="Screenshot 2025-01-13 at 1 04 36 PM" src="https://github.com/user-attachments/assets/660d6f04-cec0-4e62-895e-8a5b11722bd4" />
