### PR TITLE
settings forms fixes

### DIFF
--- a/example/airtable/events/register.php
+++ b/example/airtable/events/register.php
@@ -62,8 +62,8 @@ function register_airtable_events_block(): void {
 		],
 	] );
 
-	AirtableIntegration::register_block_for_airtable_data_source( $airtable_data_source );
-	AirtableIntegration::register_loop_block_for_airtable_data_source( $airtable_data_source );
+	AirtableIntegration::register_blocks_for_airtable_data_source( $airtable_data_source );
+	AirtableIntegration::register_loop_blocks_for_airtable_data_source( $airtable_data_source );
 }
 
 add_action( 'init', __NAMESPACE__ . '\\register_airtable_events_block' );

--- a/src/data-sources/airtable/AirtableSettings.tsx
+++ b/src/data-sources/airtable/AirtableSettings.tsx
@@ -80,6 +80,8 @@ export const AirtableSettings = ( {
 
 	const onTokenInputChange: InputChangeCallback = ( token: string | undefined ) => {
 		handleOnChange( 'access_token', token ?? '' );
+		handleOnChange( 'tables', [] );
+		handleOnChange( 'base', undefined );
 	};
 
 	const onBaseChange = ( value: string, extra?: { event?: ChangeEvent< HTMLSelectElement > } ) => {

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -103,6 +103,8 @@ export const GoogleSheetsSettings = ( {
 		setRawCredentials( nextValue );
 		const credentials = safeParseJSON< GoogleServiceAccountKey >( nextValue );
 		handleOnChange( 'credentials', credentials ?? undefined );
+		handleOnChange( 'sheets', [] );
+		handleOnChange( 'spreadsheet', undefined );
 	};
 
 	const onSpreadsheetChange = ( value: string ) => {

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -37,7 +37,7 @@ const validationRules: ValidationRules< GoogleSheetsServiceConfig > = {
 	credentials: ( state: Partial< GoogleSheetsServiceConfig > ) => {
 		if ( ! state.credentials ) {
 			return __(
-				'Please provide credentials JSON for the service account to connect to Google Sheets.',
+				'Please provide valid credentials JSON for the service account to connect to Google Sheets.',
 				'remote-data-blocks'
 			);
 		}

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -51,6 +51,12 @@ export const GoogleSheetsSettings = ( {
 	uuid,
 	config,
 }: SettingsComponentProps< GoogleSheetsConfig > ) => {
+	const [ rawCredentials, setRawCredentials ] = useState< string >(
+		config?.service_config?.credentials
+			? JSON.stringify( config?.service_config?.credentials, null, 2 )
+			: ''
+	);
+
 	const { onSave } = useDataSources< GoogleSheetsConfig >( false );
 
 	const { state, errors, handleOnChange, validState } = useForm< GoogleSheetsServiceConfig >( {
@@ -66,7 +72,7 @@ export const GoogleSheetsSettings = ( {
 	] );
 
 	const { fetchingToken, token, tokenError } = useGoogleAuth(
-		JSON.stringify( state.credentials ),
+		JSON.stringify( state.credentials ) ?? '',
 		GOOGLE_SHEETS_API_SCOPES
 	);
 	const { spreadsheets, isLoadingSpreadsheets, errorSpreadsheets } =
@@ -94,10 +100,9 @@ export const GoogleSheetsSettings = ( {
 	};
 
 	const onCredentialsChange = ( nextValue: string ) => {
+		setRawCredentials( nextValue );
 		const credentials = safeParseJSON< GoogleServiceAccountKey >( nextValue );
-		if ( credentials ) {
-			handleOnChange( 'credentials', credentials );
-		}
+		handleOnChange( 'credentials', credentials ?? undefined );
 	};
 
 	const onSpreadsheetChange = ( value: string ) => {
@@ -232,7 +237,7 @@ export const GoogleSheetsSettings = ( {
 			>
 				<TextareaControl
 					label={ __( 'Credentials', 'remote-data-blocks' ) }
-					value={ state.credentials ? JSON.stringify( state.credentials, null, 2 ) : '' }
+					value={ rawCredentials }
 					onChange={ onCredentialsChange }
 					help={ credentialsHelpText }
 					rows={ 10 }

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -104,7 +104,7 @@ export const GoogleSheetsSettings = ( {
 		const credentials = safeParseJSON< GoogleServiceAccountKey >( nextValue );
 		handleOnChange( 'credentials', credentials ?? undefined );
 		handleOnChange( 'sheets', [] );
-		handleOnChange( 'spreadsheet', undefined );
+		handleOnChange( 'spreadsheet' );
 	};
 
 	const onSpreadsheetChange = ( value: string ) => {

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -48,7 +48,7 @@ export interface UseForm< T extends StateObject > {
 	setFormState: ( newState: Partial< T > ) => void;
 	resetFormState: () => void;
 	resetErrorState: () => void;
-	handleOnChange: < K extends keyof T >( id: K, value: T[ K ] ) => void;
+	handleOnChange: < K extends keyof T >( id: K, value: T[ K ] | undefined ) => void;
 	handleOnBlur: ( id: string ) => void;
 	handleOnSubmit: () => void;
 	validState: T | null;

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -48,7 +48,7 @@ export interface UseForm< T extends StateObject > {
 	setFormState: ( newState: Partial< T > ) => void;
 	resetFormState: () => void;
 	resetErrorState: () => void;
-	handleOnChange: < K extends keyof T >( id: K, value: T[ K ] | undefined ) => void;
+	handleOnChange: < K extends keyof T >( id: K, value?: T[ K ] ) => void;
 	handleOnBlur: ( id: string ) => void;
 	handleOnSubmit: () => void;
 	validState: T | null;
@@ -109,7 +109,7 @@ export const useForm = < T extends StateObject >( {
 		dispatch( { type: 'setState', payload: { value: newState } } );
 	};
 
-	const handleOnChange = < K extends keyof T = keyof T >( id: K, value: T[ K ] ): void => {
+	const handleOnChange = < K extends keyof T = keyof T >( id: K, value?: T[ K ] ): void => {
 		dispatch( { type: 'setField', payload: { id, value } } );
 		if ( isNonEmptyObj( validationRules ) && Object.prototype.hasOwnProperty.call( errors, id ) ) {
 			setErrors( {


### PR DESCRIPTION
# Changes

- Update the signature of the [`handleOnChange`](https://github.com/Automattic/remote-data-blocks/blob/a87ddff75d5bb7dd4284c12ebc97b68c5c7d881f/src/hooks/useForm.ts#L112-L123) function to make the `value` parameter optional to align with the type of the [`state`](https://github.com/Automattic/remote-data-blocks/blob/a87ddff75d5bb7dd4284c12ebc97b68c5c7d881f/src/hooks/useForm.ts#L46) object which is a partial of the `T` type and thus allows for undefined values. This helps with the Google Sheets settings page where the `credentials` field can be passed as undefined in case of invalid credentials and then the validation for the credentials can be relied on to generate the error message.
- Allow adding any string in the `credentials` input field in the Google Sheets settings page. This is change over the previous behavior where it only accepted valid JSON strings which only practically allowed pasting the complete JSON string and did not allow typing in the field as during the typing the string for a good chunk of time the input wouldn't be valid as JSON string. I considered automatically formatting the input string to formatted JSON string with the operation being debounced but then I thought that it's better to let the user do it manually as the value changing after a deboucne delay might be confusing.
- Changing the `credentials` input field value for Google Sheets settings and `token` input field value for Airtable settings now resets the subsequent fields (`spreadsheet` and `sheets` for Google Sheets settings and `base` and `tables` for Airtable settings). This avoids stale values being used in the subsequent fields.

## Links
- JIRA - [CAFE-1120](https://vipjira.atlassian.net/browse/CAFE-1120)

# Testing

- Start the local development environment ([docs](https://github.com/Automattic/remote-data-blocks/blob/trunk/docs/local-development.md))
- Try adding or editing the Google Sheets settings and verify that the `credentials` input field can be edited with any string values. It should show a validation error message below the input until the string is a valid JSON string.
- Try editing an existing Google Sheets or Airtable data source and verify that editing the `credentials` input field for Google Sheets settings or `token` input field for Airtable settings resets the subsequent fields (`spreadsheet` and `sheets` for Google Sheets settings and `base` and `tables` for Airtable settings).