### PR TITLE
url encode sheet name to fix invalid endpoint error

### DIFF
--- a/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
@@ -110,7 +110,7 @@ class GoogleSheetsIntegration {
 
 		return HttpQuery::from_array( [
 			'data_source' => $data_source,
-			'endpoint' => $data_source->get_endpoint() . '/values/' . $sheet['name'],
+			'endpoint' => $data_source->get_endpoint() . '/values/' . rawurlencode( $sheet['name'] ),
 			'input_schema' => $input_schema,
 			'output_schema' => $output_schema,
 			'preprocess_response' => function ( mixed $response_data, array $input_variables ): array {
@@ -146,7 +146,7 @@ class GoogleSheetsIntegration {
 
 		return HttpQuery::from_array( [
 			'data_source' => $data_source,
-			'endpoint' => $data_source->get_endpoint() . '/values/' . $sheet['name'],
+			'endpoint' => $data_source->get_endpoint() . '/values/' . rawurlencode( $sheet['name'] ),
 			'input_schema' => [],
 			'output_schema' => $output_schema,
 			'preprocess_response' => function ( mixed $response_data ): array {

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -128,7 +128,7 @@ export const GoogleSheetsSettings = ( {
 					const outputQueryMappings: DataSourceQueryMappingValue[] = sheet.fields.map( field => ( {
 						key: field,
 						name: field,
-						path: `$.${ field }`,
+						path: `$["${ field }"]`,
 						type: 'string',
 					} ) );
 


### PR DESCRIPTION
# Changes

- Fixes the following bug which led to error in case of the Google Sheet name containing spaces: -

    ```sh
    [RemoteDataBlocks\Config\Query\HttpQuery] Object must have valid property: endpoint; Value must be one of the specified types: https://sheets.googleapis.com/v4/spreadsheets/1TNzTWHKvLByff54zetjGylYlAGZ8EFN5ih86b22R15A/values/To do
    ```

    URL Encoding the sheet name before appending it to the Google Sheets API URL to create the HTTPQuery endpoint solves the issue.

- Fixes the bug columns with spaces for Google Sheets data sources are not being displayed in the Google Sheets settings page by using the brackets notation for the field paths in the output query mappings.

## Links
- JIRA - [CAFE-1124](https://vipjira.atlassian.net/browse/CAFE-1124)

# Testing

- Start the local development environment ([docs](https://github.com/Automattic/remote-data-blocks/blob/trunk/docs/local-development.md))
- Try adding a Google Sheets data source with a sheet name containing spaces and verify that the data source is added successfully. Verify that the blocks are added for this data source and they work as expected.