### PR TITLE
Add type to manual input button

### DIFF
--- a/src/blocks/remote-data-container/components/modals/InputModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/InputModal.tsx
@@ -60,7 +60,7 @@ export function InputModal( props: InputModalProps ) {
 						style={ { marginBottom: '8px' } }
 					/>
 				) ) }
-				<Button variant="primary" onClick={ onSelectItem }>
+				<Button variant="primary" onClick={ onSelectItem } type="submit">
 					{ __( 'Save' ) }
 				</Button>
 			</form>

--- a/src/blocks/remote-data-container/components/modals/InputModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/InputModal.tsx
@@ -48,7 +48,13 @@ export function InputModal( props: InputModalProps ) {
 			onOpen={ open }
 			title={ props.title }
 		>
-			<form style={ { marginTop: '1rem' } }>
+			<form
+				style={ { marginTop: '1rem' } }
+				onSubmit={ ( event: React.FormEvent ) => {
+					event.preventDefault();
+					onSelectItem();
+				} }
+			>
 				{ props.inputs.map( input => (
 					<TextControl
 						key={ input.slug }
@@ -60,7 +66,7 @@ export function InputModal( props: InputModalProps ) {
 						style={ { marginBottom: '8px' } }
 					/>
 				) ) }
-				<Button variant="primary" onClick={ onSelectItem } type="submit">
+				<Button variant="primary" type="submit">
 					{ __( 'Save' ) }
 				</Button>
 			</form>

--- a/src/blocks/remote-data-container/components/modals/InputModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/InputModal.tsx
@@ -50,7 +50,7 @@ export function InputModal( props: InputModalProps ) {
 		>
 			<form
 				style={ { marginTop: '1rem' } }
-				onSubmit={ ( event: React.FormEvent ) => {
+				onSubmit={ event => {
 					event.preventDefault();
 					onSelectItem();
 				} }


### PR DESCRIPTION
When hitting enter to submit a manual input, there was a redirect to the posts page and the submission in the field wasn't saved. 

https://github.com/user-attachments/assets/f3e25896-6beb-4ca2-8f83-d2a13451dcfe

Adding `type="submit"` should fix this