### PR TITLE
'Fix' Actions column in editor

### DIFF
--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -79,6 +79,7 @@ export function ItemList( props: ItemListProps ) {
 				id: field,
 				label: field ?? '',
 				enableGlobalSearch: true,
+				getValue: ( { item }: { item: RemoteDataResult } ) => item[ field ] as string,
 				render:
 					field === media
 						? ( { item }: { item: RemoteDataResult } ) => {

--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -21,15 +21,21 @@ export function ItemList( props: ItemListProps ) {
 	const instanceId = useInstanceId( ItemList, blockName );
 
 	const data = useMemo( () => {
-		// remove null values from the data to prevent errors in filterSortAndPaginate
-		const removeNullValues = ( obj: Record< string, unknown > ): Record< string, unknown > => {
-			return Object.fromEntries(
-				Object.entries( obj ).filter( ( [ _, value ] ) => value !== null )
-			);
-		};
-
 		return ( results ?? [] ).map( ( item: Record< string, unknown > ) => {
-			const parsedItem = removeNullValues( item );
+			// Remove null values and dots to prevent errors in DataViewsd
+			const sanitizeAndRemoveNullValues = (
+				obj: Record< string, unknown >
+			): Record< string, unknown > => {
+				return Object.fromEntries(
+					Object.entries( obj )
+						.filter( ( [ _, value ] ) => value !== null ) // Remove null values
+						.map( ( [ key, value ] ) => {
+							const sanitizedKey = key.replace( /\./g, '' ); // Remove dots
+							return [ sanitizedKey, value ];
+						} )
+				);
+			};
+			const parsedItem = sanitizeAndRemoveNullValues( item );
 
 			if ( parsedItem.id ) {
 				return parsedItem;

--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -21,21 +21,15 @@ export function ItemList( props: ItemListProps ) {
 	const instanceId = useInstanceId( ItemList, blockName );
 
 	const data = useMemo( () => {
+		// remove null values from the data to prevent errors in filterSortAndPaginate
+		const removeNullValues = ( obj: Record< string, unknown > ): Record< string, unknown > => {
+			return Object.fromEntries(
+				Object.entries( obj ).filter( ( [ _, value ] ) => value !== null )
+			);
+		};
+
 		return ( results ?? [] ).map( ( item: Record< string, unknown > ) => {
-			// Remove null values and dots to prevent errors in DataViewsd
-			const sanitizeAndRemoveNullValues = (
-				obj: Record< string, unknown >
-			): Record< string, unknown > => {
-				return Object.fromEntries(
-					Object.entries( obj )
-						.filter( ( [ _, value ] ) => value !== null ) // Remove null values
-						.map( ( [ key, value ] ) => {
-							const sanitizedKey = key.replace( /\./g, '' ); // Remove dots
-							return [ sanitizedKey, value ];
-						} )
-				);
-			};
-			const parsedItem = sanitizeAndRemoveNullValues( item );
+			const parsedItem = removeNullValues( item );
 
 			if ( parsedItem.id ) {
 				return parsedItem;

--- a/src/blocks/remote-data-container/editor.scss
+++ b/src/blocks/remote-data-container/editor.scss
@@ -84,10 +84,10 @@ remote-data-blocks-inline-field {
 
 .dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper {
 	white-space: normal;
-	width: 300px;
+	width: 250px;
 	max-width: 100%;
 	min-width: 150px;
-	overflow-wrap: break-word;
+	overflow-wrap: anywhere;
 }
 
 .dataviews-view-table__row .dataviews-view-table__actions-column .components-button.is-compact.has-icon:not(.has-text) {
@@ -112,11 +112,6 @@ remote-data-blocks-inline-field {
 	vertical-align: middle;
 }
 
-.dataviews-view-table tr td:last-child,
-.dataviews-view-table tr th:last-child {
-	padding-left: 48px;
-}
-
 .rdb-editor_data-views-modal .components-modal__content {
 	padding: 0;
 
@@ -127,4 +122,27 @@ remote-data-blocks-inline-field {
 	.dataviews-view-table {
 		padding: 4px 32px 32px;
 	}
+}
+
+
+.dataviews-view-table tr th.dataviews-view-table__actions-column,
+.dataviews-view-table tr td.dataviews-view-table__actions-column {
+	position: sticky;
+	right: 0;
+	background: #fff;
+	z-index: 1;
+	padding-left: 24px;
+	padding-right: 24px;
+	text-align: center;
+}
+
+td.dataviews-view-table__actions-column::before {
+	content: "";
+	position: absolute;
+	top: 0;
+	left: -1px;
+	width: 1px;
+	height: 100%;
+	background-color: #f0f0f0;
+	z-index: 2;
 }


### PR DESCRIPTION
Due to the possibility of having many fields/columns, there was a request to make the Actions button visible without having to scroll. This may change once we implement bulk select, but for now, we can have it fixed to the right: 

<img width="1191" alt="Screenshot 2025-01-17 at 1 57 58 PM" src="https://github.com/user-attachments/assets/87370f0f-181e-4aa7-89e0-31ef3532a538" />

~I also added additional filtering to remove dots from field names~ Added `getValue` to fields to prevent the block from breaking due to `getValueFromId` from  `normalize-fields`: 
https://github.com/WordPress/gutenberg/blob/a900e036b33cab143bef3aee883a568394620023/packages/dataviews/src/normalize-fields.ts#L11

https://github.com/user-attachments/assets/39f3184f-f701-4b6a-a2c9-27991b9deebf
