### PR TITLE
Fix issue where queries with no input still show block placeholder

### DIFF
--- a/src/blocks/remote-data-container/edit.tsx
+++ b/src/blocks/remote-data-container/edit.tsx
@@ -72,12 +72,21 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 		}
 	}
 
+	const hasInputVariables = Boolean(
+		blockConfig.selectors.find( selector => selector.query_key === DISPLAY_QUERY_KEY )?.inputs
+			?.length
+	);
+
 	function refreshRemoteData() {
 		if ( ! props.attributes.remoteData?.queryInput ) {
-			return;
-		}
+			if ( hasInputVariables ) {
+				return;
+			}
 
-		fetchRemoteData( props.attributes.remoteData.queryInput, false );
+			fetchRemoteData( {}, true );
+		} else {
+			fetchRemoteData( props.attributes.remoteData.queryInput, false );
+		}
 	}
 
 	function resetRemoteData() {
@@ -92,6 +101,10 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 
 	// No remote data has been selected yet, show a placeholder.
 	if ( ! props.attributes.remoteData ) {
+		if ( ! hasInputVariables ) {
+			return null;
+		}
+
 		return (
 			<div { ...blockProps }>
 				<Placeholder blockConfig={ blockConfig } fetchRemoteData={ fetchRemoteData } />


### PR DESCRIPTION
When a block is registered for a query that doesn't have any inputs, it still shows the placeholder and requires you to provide "empty" input before it will run the query and render the block.
https://github.com/user-attachments/assets/556d5a30-cb8a-4e27-b27e-74b55bf3672a

**Steps to test**
Use the following plugin code and add a "Joke" block to a page.

```php
<?php declare(strict_types = 1);

/**
* Plugin Name: Joke RDB Example
* Description: Displays a joke.
 * Author: WPVIP
 * Author URI: https://remotedatablocks.com/
 * Text Domain: remote-data-blocks
 * Version: 1.0.0
 * Requires Plugins: remote-data-blocks
*/

namespace RemoteDataBlocks\Example\Joke;

use RemoteDataBlocks\Config\DataSource\HttpDataSource;
use RemoteDataBlocks\Config\Query\HttpQuery;
use function add_query_arg;

function register_joke_block(): void {
	$joke_data_source = HttpDataSource::from_array( [
		'service_config' => [
			'__version' => 1,
			'display_name' => 'Jokes',
			'endpoint' => 'https://official-joke-api.appspot.com/random_joke',
			'request_headers' => [
				'Content-Type' => 'application/json',
			],
		],
	] );

	$get_joke_query = HttpQuery::from_array( [
		'data_source' => $joke_data_source,
		'endpoint' => $joke_data_source->get_endpoint(),
		'input_schema' => [ ],
		'output_schema' => [
			'is_collection' => false,
			'type' => [
        'id' => [
					'name' => 'Joke ID',
          'path' => '$["id"]',
					'type' => 'id',
				],
				'setup' => [
					'name' => 'Setup',
          'path' => '$["setup"]',
					'type' => 'string',
				],
				'punchline' => [
					'name' => 'Punchline',
          'path' => '$["punchline"]',
					'type' => 'string',
				],
			],
		],
    'cache_ttl' => -1,
	] );

	register_remote_data_block( [
		'title' => 'Joke',
		'render_query' => [
			'query' => $get_joke_query,
		],
	] );
}
add_action( 'init', __NAMESPACE__ . '\\register_joke_block' );
```