### PR TITLE
Fix currency formatting in Playground

### DIFF
--- a/inc/Formatting/FieldFormatter.php
+++ b/inc/Formatting/FieldFormatter.php
@@ -19,7 +19,7 @@ final class FieldFormatter {
 	public static function format_currency( mixed $value, ?string $iso_4127_currency_code = null, ?string $locale = null ): string {
 		// The PHP 'intl' extension is not available in WordPress Playground.
 		if ( ! class_exists( 'NumberFormatter' ) || ! function_exists( 'numfmt_create' ) ) {
-			return strval($value);
+			return strval( $value );
 		}
 
 		$format = numfmt_create( $locale ?? get_locale(), NumberFormatter::CURRENCY );

--- a/inc/Formatting/FieldFormatter.php
+++ b/inc/Formatting/FieldFormatter.php
@@ -17,6 +17,11 @@ final class FieldFormatter {
 	 * @psalm-suppress UndefinedClass
 	 */
 	public static function format_currency( mixed $value, ?string $iso_4127_currency_code = null, ?string $locale = null ): string {
+		// The PHP 'intl' extension is not available in WordPress Playground.
+		if ( ! class_exists( 'NumberFormatter' ) || ! function_exists( 'numfmt_create' ) ) {
+			return strval($value);
+		}
+
 		$format = numfmt_create( $locale ?? get_locale(), NumberFormatter::CURRENCY );
 		$currency_code = $iso_4127_currency_code ?? $format->getTextAttribute( NumberFormatter::CURRENCY_CODE );
 		return numfmt_format_currency( $format, (float) $value, $currency_code );


### PR DESCRIPTION
This prevents currency formatting from throwing errors when the `intl` extension isn't included. This was an issue found when using an Airtable table with currency values through Playground which doesn't include the `intl` extension.

There is an [open issue](https://github.com/WordPress/wordpress-playground/issues/1295) about it in the Playground repository.

The downside to this fix is that currency values just won't be formatted in Playground.

## Testing
1. `npm run playground`
2. Add an Airtable source with a currency column (or use anything that has a currency mapping)
3. Use that data and see that it errors out before this fix.