### PR TITLE
Fix Sheets array alignment when a row has blank elements at the end

### DIFF
--- a/inc/Integrations/Google/Sheets/GoogleSheetsDataSource.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsDataSource.php
@@ -76,7 +76,11 @@ class GoogleSheetsDataSource extends HttpDataSource {
 
 			$response_data['values'] = array_map(
 				function ( $row, $index ) use ( $columns ) {
-					$combined = array_combine( $columns, $row );
+					// If a sheets row has blank elements at the end of the row, it will
+					// return a shorter array and cause array_combine() to throw an error.
+					$row_padded = array_pad( $row, count( $columns ), '' );
+
+					$combined = array_combine( $columns, $row_padded );
 					$combined['RowId'] = $index + 1; // Add row_id field, starting from 1
 					return $combined;
 				},
@@ -91,7 +95,7 @@ class GoogleSheetsDataSource extends HttpDataSource {
 	public static function preprocess_get_response( array $response_data, array $input_variables ): array {
 		$selected_row = null;
 		$row_id = $input_variables['row_id'];
-		
+
 		if ( isset( $response_data['values'] ) && is_array( $response_data['values'] ) ) {
 			$values = $response_data['values'];
 			$columns = array_shift( $values ); // Get column names from first row


### PR DESCRIPTION
This fixes an error when a Sheets row has missing elements at the end:

![Screenshot 2025-01-23 at 11 45 35 AM](https://github.com/user-attachments/assets/a61403da-64b0-4e80-a0f9-80063be4b0f9)

This was causing an error from `array_combine()`, because the data in the 3rd row was returning only two elements:

```
Uncaught Error: array_combine(): Argument #1($keys)and argument #2($values)must have the same number of elements
```

This PR pads rows with empty strings in order to prevent this error.

---

Note that mid-row empty columns work as expected, e.g.

![Screenshot 2025-01-23 at 11 47 44 AM](https://github.com/user-attachments/assets/f1bcbfd2-3d39-4a9f-a113-2787ad8c552a)

was returning this for the 2nd row:

```php
['A', '', 'C']
```

so no fix is needed in that case.