### PR TITLE
Correctly apply default input variable values

### DIFF
--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -197,6 +197,14 @@ class QueryRunner implements QueryRunnerInterface {
 	 * @inheritDoc
 	 */
 	public function execute( HttpQueryInterface $query, array $input_variables ): array|WP_Error {
+		// Set default input variables.
+		$input_schema = $query->get_input_schema();
+		foreach ( $input_schema as $key => $schema ) {
+			if ( ! array_key_exists( $key, $input_variables ) && isset( $schema['default_value'] ) ) {
+				$input_variables[ $key ] = $schema['default_value'];
+			}
+		}
+
 		$raw_response_data = $this->get_raw_response_data( $query, $input_variables );
 
 		if ( is_wp_error( $raw_response_data ) ) {
@@ -207,14 +215,14 @@ class QueryRunner implements QueryRunnerInterface {
 		$response_data = $this->preprocess_response( $query, $raw_response_data['response_data'], $input_variables );
 
 		// Determine if the response data is expected to be a collection.
-		$schema = $query->get_output_schema();
-		$is_collection = $schema['is_collection'] ?? false;
+		$output_schema = $query->get_output_schema();
+		$is_collection = $output_schema['is_collection'] ?? false;
 
 		// The parser always returns an array, even if it's a single item. This
 		// ensures a consistent response shape. The requestor is expected to inspect
 		// is_collection and unwrap if necessary.
 		$parser = new QueryResponseParser();
-		$results = $parser->parse( $response_data, $schema );
+		$results = $parser->parse( $response_data, $output_schema );
 		$results = $is_collection ? $results : [ $results ];
 		$metadata = $this->get_response_metadata( $query, $raw_response_data['metadata'], $results );
 

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -347,4 +347,46 @@ class QueryRunnerTest extends TestCase {
 		$this->assertCount( 1, $result['results'] );
 		$this->assertSame( $expected_result, $result['results'][0] );
 	}
+
+	public function testQueryRunnerAppliesDefaultInputVariables(): void {
+		$query = MockQuery::from_array( [
+			'data_source' => $this->http_data_source,
+			'endpoint' => function ( array $input_variables ): string {
+				return sprintf(
+					'https://example.com/api?foo=%s&baz=%s',
+					$input_variables['foo'] ?? 'MISSING',
+					$input_variables['baz'] ?? 'MISSING',
+				);
+			},
+			'input_schema' => [
+				'baz' => [
+					'name' => 'Baz',
+					'type' => 'string',
+				],
+				'foo' => [
+					'default_value' => 'bar',
+					'name' => 'Foo',
+					'type' => 'string',
+				],
+			],
+			'query_runner' => new QueryRunner( $this->http_client ),
+		] );
+
+		$response_body = $this->createMock( \Psr\Http\Message\StreamInterface::class );
+		$response = new Response( 200, [], $response_body );
+
+		$this
+			->http_client
+			->expects( $this->exactly( 1 ) )
+			->method( 'request' )
+			->willReturn( $response )
+			->with( 'GET', '/api?foo=bar&baz=MISSING' );
+
+		$result = $query->execute( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'is_collection', $result );
+		$this->assertArrayHasKey( 'metadata', $result );
+		$this->assertArrayHasKey( 'results', $result );
+	}
 }

--- a/tests/inc/Mocks/MockQuery.php
+++ b/tests/inc/Mocks/MockQuery.php
@@ -15,6 +15,7 @@ class MockQuery extends HttpQuery {
 		return parent::from_array( [
 			'data_source' => $config['data_source'] ?? MockDataSource::from_array(),
 			'display_name' => 'Mock Query',
+			'endpoint' => $config['endpoint'] ?? null,
 			'input_schema' => $config['input_schema'] ?? [],
 			'output_schema' => $config['output_schema'] ?? [ 'type' => 'string' ],
 			'query_runner' => $config['query_runner'] ?? new MockQueryRunner(),


### PR DESCRIPTION
Our schema allows users to supply a `default_value` for input variables, but it isn't respected. It's useful, so we should.