### PR TITLE
Fix SFCC output schema

### DIFF
--- a/inc/Integrations/SalesforceB2C/SalesforceB2CIntegration.php
+++ b/inc/Integrations/SalesforceB2C/SalesforceB2CIntegration.php
@@ -116,18 +116,18 @@ class SalesforceB2CIntegration {
 					'type' => [
 						'product_id' => [
 							'name' => 'product id',
-							'path' => '$.productid',
+							'path' => '$.productId',
 							'type' => 'id',
 						],
 						'name' => [
 							'name' => 'product name',
-							'path' => '$.productname',
+							'path' => '$.productName',
 							'type' => 'string',
 						],
 						'price' => [
 							'name' => 'item price',
 							'path' => '$.price',
-							'type' => 'price',
+							'type' => 'string',
 						],
 						'image_url' => [
 							'name' => 'item image url',


### PR DESCRIPTION
Noticed two errors when trying a Salesforce connection today, fixed in this PR:

1. The `price` output incorrectly used `price` instead of `string` as an output type, which threw an error.
2. The `productId` and `productName` mappings were using incorrectly capitalized parameter names.
