### PR TITLE
Register pattern only with a valid script handle

### DIFF
--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -101,12 +101,17 @@ class BlockRegistration {
 
 		$block_type = register_block_type( $block_path, $block_options );
 
-		$script_handle = $block_type->editor_script_handles[0];
+		$script_handle = $block_type->editor_script_handles[0] ?? '';
 
-		// Register a default pattern that simply displays the available data.
-		$default_pattern_name = BlockPatterns::register_default_block_pattern( $block_name, $config['title'], $config['queries'][ ConfigRegistry::DISPLAY_QUERY_KEY ] );
-		$block_config['patterns']['default'] = $default_pattern_name;
+		// Only proceed with pattern registration and config if we have a valid script handle.
+		if ( ! empty( $script_handle ) ) {
+			// Register a default pattern that simply displays the available data.
+			$default_pattern_name = BlockPatterns::register_default_block_pattern( $block_name, $config['title'], $config['queries'][ ConfigRegistry::DISPLAY_QUERY_KEY ] );
+			$block_config['patterns']['default'] = $default_pattern_name;
 
-		return [ $block_config, $script_handle ];
+			return [ $block_config, $script_handle ];
+		}
+
+		return [ $block_config, '' ];
 	}
 }

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -103,15 +103,10 @@ class BlockRegistration {
 
 		$script_handle = $block_type->editor_script_handles[0] ?? '';
 
-		// Only proceed with pattern registration and config if we have a valid script handle.
-		if ( ! empty( $script_handle ) ) {
-			// Register a default pattern that simply displays the available data.
-			$default_pattern_name = BlockPatterns::register_default_block_pattern( $block_name, $config['title'], $config['queries'][ ConfigRegistry::DISPLAY_QUERY_KEY ] );
-			$block_config['patterns']['default'] = $default_pattern_name;
+		// Register a default pattern that simply displays the available data.
+		$default_pattern_name = BlockPatterns::register_default_block_pattern( $block_name, $config['title'], $config['queries'][ ConfigRegistry::DISPLAY_QUERY_KEY ] );
+		$block_config['patterns']['default'] = $default_pattern_name;
 
-			return [ $block_config, $script_handle ];
-		}
-
-		return [ $block_config, '' ];
+		return [ $block_config, $script_handle ];
 	}
 }


### PR DESCRIPTION
## Issue

Not having an editor script handle is causing a WSOD (white screen of death) when trying to log in `/wp-admin`.

Screenshot:

![Screenshot 2025-01-30 at 12 34 28](https://github.com/user-attachments/assets/3f8cb818-d9fa-4267-8198-050ce5961d31)

## Fix:

Add a default string as a default to prevent this error.
