### PR TITLE
Update schema to allow nested serialized config

### DIFF
--- a/inc/Config/ArraySerializable.php
+++ b/inc/Config/ArraySerializable.php
@@ -28,7 +28,17 @@ abstract class ArraySerializable implements ArraySerializableInterface {
 	/**
 	 * @inheritDoc
 	 */
-	public static function from_array( array $config, ?ValidatorInterface $validator = null ): self|WP_Error {
+	public static function from_array( array $config, ?ValidatorInterface $validator = null ): static|WP_Error {
+		$subclass = static::get_subclass( $config );
+		if ( null !== $subclass ) {
+			return $subclass::from_array( $config, $validator );
+		}
+
+		$config = static::preprocess_config( $config );
+		if ( is_wp_error( $config ) ) {
+			return $config;
+		}
+
 		$schema = static::get_config_schema();
 
 		$validator = $validator ?? new Validator( $schema, static::class );
@@ -51,5 +61,29 @@ abstract class ArraySerializable implements ArraySerializableInterface {
 		return $this->config;
 	}
 
-	abstract protected static function get_config_schema(): array;
+	/**
+	 * @inheritDoc
+	 */
+	public static function preprocess_config( array $config ): array|WP_Error {
+		return $config;
+	}
+
+	/**
+	 * The config can provide a `__subclass` property that indicates that we should
+	 * inflate using a subclass of this class.
+	 */
+	protected static function get_subclass( array $config ): ?string {
+		$subclass = $config['__subclass'] ?? null;
+
+		if ( null !== $subclass && static::class !== $subclass && is_subclass_of( $subclass, static::class, true ) ) {
+			return $subclass;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	abstract public static function get_config_schema(): array;
 }

--- a/inc/Config/ArraySerializableInterface.php
+++ b/inc/Config/ArraySerializableInterface.php
@@ -3,6 +3,7 @@
 namespace RemoteDataBlocks\Config;
 
 use RemoteDataBlocks\Validation\ValidatorInterface;
+use WP_Error;
 
 interface ArraySerializableInterface {
 	/**
@@ -16,7 +17,25 @@ interface ArraySerializableInterface {
 	 * @param ValidatorInterface|null $validator An optional validator instance to use for validating the configuration.
 	 * @return mixed Returns a new instance of the implementing class.
 	 */
-	public static function from_array( array $config, ?ValidatorInterface $validator ): mixed;
+	public static function from_array( array $config, ?ValidatorInterface $validator ): static|WP_Error;
+
+	/**
+	 * This method will be called by ::from_array() to prior to validating the
+	 * config. This allows you to modify the config before it's validated, perhaps
+	 * because you want to inflate it with additional or computed values.
+	 *
+	 * @param array<string, mixed> $config The configuration to process.
+	 * @return array<string, mixed> The processed configuration.
+	 */
+	public static function preprocess_config( array $config ): array|WP_Error;
+
+	/**
+	 * Provides the schema that will be use the validate the config passed to
+	 * from_array().
+	 *
+	 * @return array An associative array representing the configuration schema.
+	 */
+	public static function get_config_schema(): array;
 
 	/**
 	 * Converts the current object to an array representation.

--- a/inc/Config/DataSource/HttpDataSource.php
+++ b/inc/Config/DataSource/HttpDataSource.php
@@ -5,7 +5,6 @@ namespace RemoteDataBlocks\Config\DataSource;
 use RemoteDataBlocks\Config\ArraySerializable;
 use RemoteDataBlocks\Validation\ConfigSchemas;
 use RemoteDataBlocks\Validation\Validator;
-use RemoteDataBlocks\Validation\ValidatorInterface;
 use RemoteDataBlocks\WpdbStorage\DataSourceCrud;
 use WP_Error;
 
@@ -44,25 +43,23 @@ class HttpDataSource extends ArraySerializable implements HttpDataSourceInterfac
 	 * NOTE: This method uses late static bindings to allow child classes to
 	 * define their own validation schema.
 	 */
-	public static function from_array( array $config, ?ValidatorInterface $validator = null ): self|WP_Error {
+	public static function preprocess_config( array $config ): array|WP_Error {
 		$service_config = $config['service_config'] ?? [];
-		$validator = $validator ?? new Validator( static::get_service_config_schema() );
+		$validator = new Validator( static::get_service_config_schema() );
 		$validated = $validator->validate( $service_config );
 
 		if ( is_wp_error( $validated ) ) {
 			return $validated;
 		}
 
-		return parent::from_array(
-			array_merge(
-				static::map_service_config( $service_config ),
-				[
-					// Store the exact data used to create the instance to preserve determinism.
-					'service' => static::SERVICE_NAME,
-					'service_config' => $service_config,
-					'uuid' => $config['uuid'] ?? null,
-				]
-			)
+		return array_merge(
+			static::map_service_config( $service_config ),
+			[
+				// Store the exact data used to create the instance to preserve determinism.
+				'service' => static::SERVICE_NAME,
+				'service_config' => $service_config,
+				'uuid' => $config['uuid'] ?? null,
+			]
 		);
 	}
 
@@ -92,7 +89,7 @@ class HttpDataSource extends ArraySerializable implements HttpDataSourceInterfac
 	/**
 	 * @inheritDoc
 	 */
-	protected static function get_config_schema(): array {
+	public static function get_config_schema(): array {
 		return ConfigSchemas::get_http_data_source_config_schema();
 	}
 

--- a/inc/Config/Query/GraphqlQuery.php
+++ b/inc/Config/Query/GraphqlQuery.php
@@ -31,7 +31,7 @@ class GraphqlQuery extends HttpQuery {
 	/**
 	 * @inheritDoc
 	 */
-	protected static function get_config_schema(): array {
+	public static function get_config_schema(): array {
 		return ConfigSchemas::get_graphql_query_config_schema();
 	}
 }

--- a/inc/Config/Query/HttpQuery.php
+++ b/inc/Config/Query/HttpQuery.php
@@ -3,6 +3,7 @@
 namespace RemoteDataBlocks\Config\Query;
 
 use RemoteDataBlocks\Config\ArraySerializable;
+use RemoteDataBlocks\Config\DataSource\HttpDataSource;
 use RemoteDataBlocks\Config\DataSource\HttpDataSourceInterface;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
 use RemoteDataBlocks\Validation\ConfigSchemas;
@@ -54,6 +55,10 @@ class HttpQuery extends ArraySerializable implements HttpQueryInterface {
 	 * Get the data source associated with this query.
 	 */
 	public function get_data_source(): HttpDataSourceInterface {
+		if ( is_array( $this->config['data_source'] ) ) {
+			$this->config['data_source'] = HttpDataSource::from_array( $this->config['data_source'] );
+		}
+
 		return $this->config['data_source'];
 	}
 
@@ -123,7 +128,7 @@ class HttpQuery extends ArraySerializable implements HttpQueryInterface {
 	/**
 	 * @inheritDoc
 	 */
-	protected static function get_config_schema(): array {
+	public static function get_config_schema(): array {
 		return ConfigSchemas::get_http_query_config_schema();
 	}
 

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -6,6 +6,8 @@ defined( 'ABSPATH' ) || exit();
 
 use RemoteDataBlocks\Logging\LoggerManager;
 use Psr\Log\LoggerInterface;
+use RemoteDataBlocks\Config\Query\HttpQuery;
+use RemoteDataBlocks\Config\Query\QueryInterface;
 use RemoteDataBlocks\Editor\BlockPatterns\BlockPatterns;
 use RemoteDataBlocks\Validation\ConfigSchemas;
 use RemoteDataBlocks\Validation\Validator;
@@ -46,7 +48,7 @@ class ConfigRegistry {
 			return self::create_error( $block_title, sprintf( 'Block %s has already been registered', $block_name ) );
 		}
 
-		$display_query = $user_config[ self::RENDER_QUERY_KEY ]['query'];
+		$display_query = self::inflate_query( $user_config[ self::RENDER_QUERY_KEY ]['query'] );
 		$input_schema = $display_query->get_input_schema();
 
 		// Build the base configuration for the block. This is our own internal
@@ -83,7 +85,7 @@ class ConfigRegistry {
 		// Register "selectors" which allow the user to use a query to assist in
 		// selecting data for display by the block.
 		foreach ( $user_config[ self::SELECTION_QUERIES_KEY ] ?? [] as $selection_query ) {
-			$from_query = $selection_query['query'];
+			$from_query = self::inflate_query( $selection_query['query'] );
 			$from_query_type = $selection_query['type'];
 			$to_query = $display_query;
 
@@ -172,5 +174,13 @@ class ConfigRegistry {
 		$error_message = sprintf( 'Error registering block %s: %s', esc_html( $block_title ), esc_html( $message ) );
 		self::$logger->error( $error_message );
 		return new WP_Error( 'block_registration_error', $error_message );
+	}
+
+	private static function inflate_query( array|QueryInterface $config ): QueryInterface {
+		if ( is_array( $config ) ) {
+			return HttpQuery::from_array( $config );
+		}
+
+		return $config;
 	}
 }

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -4,6 +4,7 @@ namespace RemoteDataBlocks\Validation;
 
 use RemoteDataBlocks\Validation\Types;
 use RemoteDataBlocks\Config\DataSource\HttpDataSourceInterface;
+use RemoteDataBlocks\Config\Query\HttpQueryInterface;
 use RemoteDataBlocks\Config\Query\QueryInterface;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
 use RemoteDataBlocks\Editor\BlockManagement\ConfigRegistry;
@@ -74,14 +75,20 @@ final class ConfigSchemas {
 				)
 			),
 			'render_query' => Types::object( [
-				'query' => Types::instance_of( QueryInterface::class ),
+				'query' => Types::one_of(
+					Types::instance_of( QueryInterface::class ),
+					Types::serialized_config_for( HttpQueryInterface::class ),
+				),
 				'loop' => Types::nullable( Types::boolean() ),
 			] ),
 			'selection_queries' => Types::nullable(
 				Types::list_of(
 					Types::object( [
 						'display_name' => Types::nullable( Types::string() ),
-						'query' => Types::instance_of( QueryInterface::class ),
+						'query' => Types::one_of(
+							Types::instance_of( QueryInterface::class ),
+							Types::serialized_config_for( HttpQueryInterface::class ),
+						),
 						'type' => Types::enum(
 							ConfigRegistry::LIST_QUERY_KEY,
 							ConfigRegistry::SEARCH_QUERY_KEY
@@ -148,7 +155,10 @@ final class ConfigSchemas {
 	private static function generate_http_query_config_schema(): array {
 		return Types::object( [
 			'cache_ttl' => Types::nullable( Types::one_of( Types::callable(), Types::integer(), Types::null() ) ),
-			'data_source' => Types::instance_of( HttpDataSourceInterface::class ),
+			'data_source' => Types::one_of(
+				Types::instance_of( HttpDataSourceInterface::class ),
+				Types::serialized_config_for( HttpDataSourceInterface::class ),
+			),
 			'endpoint' => Types::nullable( Types::one_of( Types::callable(), Types::url() ) ),
 			'image_url' => Types::nullable( Types::image_url() ),
 			// NOTE: The "input schema" for a query is not a formal schema like the

--- a/inc/Validation/Types.php
+++ b/inc/Validation/Types.php
@@ -184,6 +184,7 @@ final class Types {
 				'object',
 				'record',
 				'ref',
+				'serialized_config_for',
 				'string_matching',
 			];
 			$is_primitive = self::is_primitive( $member_type );
@@ -208,6 +209,12 @@ final class Types {
 		}
 
 		return self::generate_non_primitive_type( 'record', [ $key_type, $value_type ] );
+	}
+
+	// This type indicates that the value is a serialized array that can be used
+	// to inflate a class instance, e.g., HttpQuery::from_array( $value ).
+	public static function serialized_config_for( string $class_ref ): array {
+		return self::generate_non_primitive_type( 'serialized_config_for', $class_ref );
 	}
 
 	public static function string_matching( string $regex ): array {

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -2,6 +2,7 @@
 
 namespace RemoteDataBlocks\Validation;
 
+use RemoteDataBlocks\Config\ArraySerializableInterface;
 use RemoteDataBlocks\Validation\Types;
 use RemoteDataBlocks\Logging\LoggerManager;
 use WP_Error;
@@ -161,6 +162,40 @@ final class Validator implements ValidatorInterface {
 			case 'ref':
 				return $this->check_type( Types::load_ref_type( $type ), $value );
 
+			case 'serialized_config_for':
+				if ( ! self::check_iterable_object( $value ) ) {
+					return $this->create_error( 'Value must be an associative array', $value );
+				}
+
+				$class_ref = Types::get_type_args( $type );
+
+				if ( ! class_exists( $class_ref ) && ! interface_exists( $class_ref ) ) {
+					return $this->create_error( 'Class does not exist', $class_ref );
+				}
+
+				$implements = class_implements( $class_ref );
+				if ( ! in_array( ArraySerializableInterface::class, $implements, true ) ) {
+					return $this->create_error( 'Class does not implement ArraySerializableInterface', $class_ref );
+				}
+
+				// The config can provide a `__subclass` property that indicates that we
+				// should inflate using a subclass of the specified class.
+				$subclass = $value['__subclass'] ?? null;
+				if ( null !== $subclass ) {
+					if ( ! is_subclass_of( $subclass, $class_ref, true ) ) {
+						return $this->create_error( 'Class specified by __subclass must be a subclass of the specified class', $subclass );
+					}
+
+					$class_ref = $subclass;
+				}
+
+				// Validate the schema for the class we want to instantiate. Call the
+				// config prepocessor since some classes inflate their own config.
+				$config_validator = new Validator( $class_ref::get_config_schema(), $class_ref );
+				$config = $class_ref::preprocess_config( $value );
+
+				return $config_validator->validate( $config );
+
 			case 'string_matching':
 				$regex = Types::get_type_args( $type );
 
@@ -236,7 +271,7 @@ final class Validator implements ValidatorInterface {
 		return new WP_Error( 'invalid_type', $message, [ 'child' => $child_error ] );
 	}
 
-	private function get_object_key( mixed $data, string $key ): mixed {
+	private function get_object_key( mixed $data, string|int $key ): mixed {
 		return is_array( $data ) && array_key_exists( $key, $data ) ? $data[ $key ] : null;
 	}
 }

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -113,13 +113,23 @@ final class Validator implements ValidatorInterface {
 				return true;
 
 			case 'one_of':
+				// Keep track of all failed validations. Since one_of is a union type,
+				// if none of the types match, we will return all of the errors so that
+				// the caller can inspect each of them.
+				$errors = [];
+
 				foreach ( Types::get_type_args( $type ) as $member_type ) {
-					if ( true === $this->check_type( $member_type, $value ) ) {
+					$validated = $this->check_type( $member_type, $value );
+					if ( true === $validated ) {
 						return true;
 					}
+
+					$errors[] = $validated;
 				}
 
-				return $this->create_error( 'Value must be one of the specified types', $value );
+				$error = new WP_Error( 'invalid_one_of_type', 'Validation errors for each of the specified types', [ 'errors' => $errors ] );
+
+				return $this->create_error( 'Value must be one of the specified types', $value, $error );
 
 			case 'object':
 				if ( ! self::check_iterable_object( $value ) ) {

--- a/tests/inc/Config/HttpDataSourceTest.php
+++ b/tests/inc/Config/HttpDataSourceTest.php
@@ -10,8 +10,9 @@ class HttpDataSourceTest extends TestCase {
 
 	public function testGetServiceMethodCannotBeOverriddenl(): void {
 		$config = [
-			'service' => 'mock',
 			'service_config' => [
+				'__version' => 1,
+				'display_name' => 'Mock Data Source',
 				'endpoint' => 'http://example.com',
 			],
 		];

--- a/tests/inc/Functions/FunctionsTest.php
+++ b/tests/inc/Functions/FunctionsTest.php
@@ -70,6 +70,37 @@ class FunctionsTest extends TestCase {
 		$this->assertTrue( $config['loop'] );
 	}
 
+	public function testRegisterBlockWithNestedConfig(): void {
+		register_remote_data_block( [
+			'title' => 'Test Block with Nested Config',
+			'render_query' => [
+				'query' => [
+					'__subclass' => 'RemoteDataBlocks\Tests\Mocks\MockQuery',
+					'data_source' => [
+						'__subclass' => 'RemoteDataBlocks\Tests\Mocks\MockDataSource',
+						'service_config' => [
+							'__version' => 1,
+							'display_name' => 'Mock Data Source',
+							'endpoint' => 'https://example.com/api',
+						],
+					],
+					'display_name' => 'Mock Query',
+					'input_schema' => [],
+					'output_schema' => [ 'type' => 'string' ],
+				],
+			],
+		] );
+
+		$block_name = 'remote-data-blocks/test-block-with-nested-config';
+		$this->assertTrue( ConfigStore::is_registered_block( $block_name ) );
+
+		$config = ConfigStore::get_block_configuration( $block_name );
+		$this->assertIsArray( $config );
+		$this->assertSame( $block_name, $config['name'] );
+		$this->assertSame( 'Test Block with Nested Config', $config['title'] );
+		$this->assertFalse( $config['loop'] );
+	}
+
 	public function testRegisterListQuery(): void {
 		register_remote_data_block( [
 			'title' => 'Test Block with List Query',

--- a/tests/inc/Mocks/MockDataSource.php
+++ b/tests/inc/Mocks/MockDataSource.php
@@ -20,7 +20,7 @@ class MockDataSource extends HttpDataSource {
 		],
 	];
 
-	public static function from_array( ?array $config = self::MOCK_CONFIG, ?ValidatorInterface $validator = null ): self|WP_Error {
+	public static function from_array( ?array $config = self::MOCK_CONFIG, ?ValidatorInterface $validator = null ): static|WP_Error {
 		return parent::from_array( $config, $validator ?? new MockValidator() );
 	}
 

--- a/tests/inc/Mocks/MockQuery.php
+++ b/tests/inc/Mocks/MockQuery.php
@@ -11,7 +11,7 @@ use WP_Error;
 class MockQuery extends HttpQuery {
 	private mixed $response_data = null;
 
-	public static function from_array( array $config = [], ?ValidatorInterface $validator = null ): self|WP_Error {
+	public static function from_array( array $config = [], ?ValidatorInterface $validator = null ): static|WP_Error {
 		return parent::from_array( [
 			'data_source' => $config['data_source'] ?? MockDataSource::from_array(),
 			'display_name' => 'Mock Query',

--- a/tests/inc/Mocks/MockSerializableClass.php
+++ b/tests/inc/Mocks/MockSerializableClass.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Tests\Mocks;
+
+use RemoteDataBlocks\Config\ArraySerializable;
+use RemoteDataBlocks\Validation\Types;
+
+class MockSerializableClass extends ArraySerializable {
+	public static function get_config_schema(): array {
+		return Types::object( [
+			'boolean_value' => Types::boolean(),
+			'enum_value' => Types::enum( 'foo', 'bar' ),
+			'string_value' => Types::string(),
+		] );
+	}
+}

--- a/tests/inc/Mocks/MockSerializableSubclass.php
+++ b/tests/inc/Mocks/MockSerializableSubclass.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Tests\Mocks;
+
+use RemoteDataBlocks\Validation\Types;
+
+class MockSerializableSubclass extends MockSerializableClass {
+	public static function get_config_schema(): array {
+		return Types::object( [
+			'boolean_value' => Types::boolean(),
+			'enum_value' => Types::enum( 'foo', 'bar' ),
+			'string_value' => Types::string(),
+			'extra_value' => Types::string(),
+		] );
+	}
+}

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -3,6 +3,8 @@
 namespace RemoteDataBlocks\Tests\Validation;
 
 use PHPUnit\Framework\TestCase;
+use RemoteDataBlocks\Tests\Mocks\MockSerializableClass;
+use RemoteDataBlocks\Tests\Mocks\MockSerializableSubclass;
 use RemoteDataBlocks\Validation\Types;
 use RemoteDataBlocks\Validation\Validator;
 use stdClass;
@@ -581,6 +583,89 @@ class ValidatorTest extends TestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'Object must have valid property: bar', $result->get_error_message() );
+	}
+
+	public function testSerializedConfigFor(): void {
+		$schema = Types::object( [
+			'config' => Types::serialized_config_for( MockSerializableClass::class ),
+		] );
+
+		$validator = new Validator( $schema );
+
+		$this->assertTrue( $validator->validate( [
+			'config' => [
+				'boolean_value' => true,
+				'enum_value' => 'foo',
+				'string_value' => 'hello, world!',
+			],
+		] ) );
+
+		$result = $validator->validate( [
+			'config' => [
+				'boolean_value' => 'NOT A BOOLEAN',
+				'enum_value' => 'foo',
+				'string_value' => 'hello, world!',
+			],
+		] );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'Object must have valid property: config', $result->get_error_message() );
+		$this->assertSame( 'Object must have valid property: boolean_value', $result->get_error_data()['child']->get_error_message() );
+
+		$result = $validator->validate( [
+			'config' => null,
+		] );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'Object must have valid property: config', $result->get_error_message() );
+		$this->assertSame( 'Value must be an associative array: null', $result->get_error_data()['child']->get_error_message() );
+
+		$result = $validator->validate( [
+			'config' => new stdClass(),
+		] );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'Object must have valid property: config', $result->get_error_message() );
+		$this->assertSame( 'Value must be an associative array: {}', $result->get_error_data()['child']->get_error_message() );
+
+		$result = $validator->validate( [
+			'config' => [],
+		] );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'Object must have valid property: config', $result->get_error_message() );
+		$this->assertSame( 'Object must have valid property: boolean_value', $result->get_error_data()['child']->get_error_message() );
+	}
+
+	public function testSerializedConfigForSubclass(): void {
+		$schema = Types::object( [
+			'config' => Types::serialized_config_for( MockSerializableClass::class ),
+		] );
+
+		$validator = new Validator( $schema );
+
+		$this->assertTrue( $validator->validate( [
+			'config' => [
+				'__subclass' => MockSerializableSubclass::class,
+				'boolean_value' => true,
+				'enum_value' => 'foo',
+				'string_value' => 'hello, world!',
+				'extra_value' => 'required for subclass',
+			],
+		] ) );
+
+		$result = $validator->validate( [
+			'config' => [
+				'__subclass' => MockSerializableSubclass::class,
+				'boolean_value' => true,
+				'enum_value' => 'foo',
+				'string_value' => 'hello, world!',
+			],
+		] );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'Object must have valid property: config', $result->get_error_message() );
+		$this->assertSame( 'Object must have valid property: extra_value', $result->get_error_data()['child']->get_error_message() );
 	}
 
 	public function testStringMatching(): void {


### PR DESCRIPTION
This PR updates the core schema to allow nested serialized config. We can now represent remote data config as a single serialized array or object, which would allow loading config via JSON or any other serialization format:

```php
register_remote_data_block( [
  'title' => 'My block',
  'render_query' => [
    'query' => [
      'data_source' => [
        'service_config' => [
          '__version' => 1,
          'display_name' => 'My Data Source',
          'endpoint' => 'https://example.com/api',
        ],
      ],
      'display_name' => 'Mock Query',
      'input_schema' => [ /* ... */ ],
      'output_schema' => [ /* ... */ ],
    ],
  ],
] );
```

You can target any class that extends `HttpQuery` or `HttpDataSource`—for example, our integrations like `ShopifyDataSource` by referencing your desired class names:

```php
register_remote_data_block( [
  'title' => 'My block',
  'render_query' => [
    'query' => [
      '__subclass' => 'RemoteDataBlocks\\Integrations\\Shopify\\GetProductQuery',
      'data_source' => [
        '__subclass' => 'RemoteDataBlocks\\Integrations\\Shopify\\ShopifyDataSource',
        'service_config' => [
          '__version' => 1,
          'access_token' => 'token',
          'store_name' => 'My Shopify Store',
          /* etc */
        ],
      ],
    ],
  ],
] );
```

IMO, this is a much more durable target for "generated" code and is less likely to break with minor code updates. It can also participate in "config migrations" that Gopal is working on.

The changes in this PR are relatively light and mainly deal with updated interfaces, type annotations, validation, and test cases. The main addition is a new type: `Types::serialized_config_for()`, which allows you to provide config for a class that implements `ArraySerializableInterface`. This config will be validated and used to inflate the class instance on startup.