### PR TITLE
Fix design mistake in nested config implementation

### DIFF
--- a/inc/Config/ArraySerializable.php
+++ b/inc/Config/ArraySerializable.php
@@ -28,7 +28,7 @@ abstract class ArraySerializable implements ArraySerializableInterface {
 	/**
 	 * @inheritDoc
 	 */
-	public static function from_array( array $config, ?ValidatorInterface $validator = null ): static|WP_Error {
+	final public static function from_array( array $config, ?ValidatorInterface $validator = null ): static|WP_Error {
 		$subclass = static::get_implementor( $config );
 		if ( null !== $subclass ) {
 			return $subclass::from_array( $config, $validator );

--- a/inc/Config/ArraySerializable.php
+++ b/inc/Config/ArraySerializable.php
@@ -29,7 +29,7 @@ abstract class ArraySerializable implements ArraySerializableInterface {
 	 * @inheritDoc
 	 */
 	public static function from_array( array $config, ?ValidatorInterface $validator = null ): static|WP_Error {
-		$subclass = static::get_subclass( $config );
+		$subclass = static::get_implementor( $config );
 		if ( null !== $subclass ) {
 			return $subclass::from_array( $config, $validator );
 		}
@@ -58,7 +58,7 @@ abstract class ArraySerializable implements ArraySerializableInterface {
 	 * @inheritDoc
 	 */
 	public function to_array(): array {
-		return $this->config;
+		return array_merge( $this->config, [ self::CLASS_REF_ATTRIBUTE => static::class ] );
 	}
 
 	/**
@@ -69,17 +69,22 @@ abstract class ArraySerializable implements ArraySerializableInterface {
 	}
 
 	/**
-	 * The config can provide a `__subclass` property that indicates that we should
-	 * inflate using a subclass of this class.
+	 * The config can provide a `__class` property that indicates that we should
+	 * inflate using a specific implementor class.
 	 */
-	protected static function get_subclass( array $config ): ?string {
-		$subclass = $config['__subclass'] ?? null;
+	protected static function get_implementor( array $config ): ?string {
+		$subclass = $config[ self::CLASS_REF_ATTRIBUTE ] ?? null;
 
-		if ( null !== $subclass && static::class !== $subclass && is_subclass_of( $subclass, static::class, true ) ) {
-			return $subclass;
+		if (
+			null === $subclass ||
+			static::class === $subclass ||
+			! class_exists( $subclass ) ||
+			! in_array( ArraySerializableInterface::class, class_implements( $subclass ), true )
+		) {
+			return null;
 		}
 
-		return null;
+		return $subclass;
 	}
 
 	/**

--- a/inc/Config/ArraySerializableInterface.php
+++ b/inc/Config/ArraySerializableInterface.php
@@ -6,6 +6,8 @@ use RemoteDataBlocks\Validation\ValidatorInterface;
 use WP_Error;
 
 interface ArraySerializableInterface {
+	final public const CLASS_REF_ATTRIBUTE = '__class';
+
 	/**
 	 * Creates an instance of the class from an array representation.
 	 *

--- a/inc/Config/DataSource/HttpDataSource.php
+++ b/inc/Config/DataSource/HttpDataSource.php
@@ -80,6 +80,7 @@ class HttpDataSource extends ArraySerializable implements HttpDataSourceInterfac
 	 */
 	final public function to_array(): array {
 		return [
+			'__class' => static::class,
 			'service' => static::SERVICE_NAME,
 			'service_config' => $this->config['service_config'],
 			'uuid' => $this->config['uuid'],

--- a/inc/Config/Query/QueryInterface.php
+++ b/inc/Config/Query/QueryInterface.php
@@ -12,7 +12,7 @@ use WP_Error;
  */
 interface QueryInterface extends ArraySerializableInterface {
 	public function execute( array $input_variables ): array|WP_Error;
-	public function get_data_source(): DataSourceInterface;
+	public function get_data_source(): DataSourceInterface|QueryInterface;
 	public function get_image_url(): ?string;
 	public function get_input_schema(): array;
 	public function get_output_schema(): array;

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -197,12 +197,14 @@ final class Validator implements ValidatorInterface {
 					return $this->create_error( 'Value does not provide a __class property', $class_ref );
 				}
 
+				$class_description = sprintf( 'Class %s specified by %s property', $subclass, ArraySerializableInterface::CLASS_REF_ATTRIBUTE );
+
 				if ( ! class_exists( $subclass ) ) {
-					return $this->create_error( 'Class specified by __class property does not exist', $subclass );
+					return $this->create_error( $class_description . ' does not exist', $subclass );
 				}
 
 				if ( $subclass !== $class_ref && ! is_subclass_of( $subclass, $class_ref, true ) ) {
-					return $this->create_error( 'Class specified by __class property must match or be a subclass of the target class', $subclass );
+					return $this->create_error( $class_description . ' must match or be a subclass of the target class', $subclass );
 				}
 
 				// Done with type validation, update the target class so we can validate

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -188,16 +188,26 @@ final class Validator implements ValidatorInterface {
 					return $this->create_error( 'Class does not implement ArraySerializableInterface', $class_ref );
 				}
 
-				// The config can provide a `__subclass` property that indicates that we
-				// should inflate using a subclass of the specified class.
-				$subclass = $value['__subclass'] ?? null;
-				if ( null !== $subclass ) {
-					if ( ! is_subclass_of( $subclass, $class_ref, true ) ) {
-						return $this->create_error( 'Class specified by __subclass must be a subclass of the specified class', $subclass );
-					}
-
-					$class_ref = $subclass;
+				// The config must provide a `__class` property so that we know which
+				// class to inflate. This allows values to target subclasses of the
+				// specified class and also provides disambiguation when the type is
+				// used in a union type (one_of).
+				$subclass = $value[ ArraySerializableInterface::CLASS_REF_ATTRIBUTE ] ?? null;
+				if ( null === $subclass ) {
+					return $this->create_error( 'Value does not provide a __class property', $class_ref );
 				}
+
+				if ( ! class_exists( $subclass ) ) {
+					return $this->create_error( 'Class specified by __class property does not exist', $subclass );
+				}
+
+				if ( $subclass !== $class_ref && ! is_subclass_of( $subclass, $class_ref, true ) ) {
+					return $this->create_error( 'Class specified by __class property must match or be a subclass of the target class', $subclass );
+				}
+
+				// Done with type validation, update the target class so we can validate
+				// the value / config.
+				$class_ref = $subclass;
 
 				// Validate the schema for the class we want to instantiate. Call the
 				// config prepocessor since some classes inflate their own config.

--- a/tests/inc/Config/HttpDataSourceTest.php
+++ b/tests/inc/Config/HttpDataSourceTest.php
@@ -16,13 +16,13 @@ class HttpDataSourceTest extends TestCase {
 				'endpoint' => 'http://example.com',
 			],
 		];
-		$this->http_data_source = MockDataSource::from_array( $config );
+		$this->http_data_source = MockDataSource::create( $config );
 
 		$this->assertSame( 'generic-http', $this->http_data_source->get_service_name() );
 	}
 
 	public function testGetServiceMethodReturnsCorrectValue(): void {
-		$this->http_data_source = MockDataSource::from_array();
+		$this->http_data_source = MockDataSource::create();
 
 		$this->assertEquals( 'generic-http', $this->http_data_source->get_service_name() );
 	}

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -19,9 +19,9 @@ class QueryRunnerTest extends TestCase {
 		parent::setUp();
 
 		$this->http_client = $this->createMock( HttpClient::class );
-		$this->http_data_source = MockDataSource::from_array();
+		$this->http_data_source = MockDataSource::create();
 
-		$this->query = MockQuery::from_array( [
+		$this->query = MockQuery::create( [
 			'data_source' => $this->http_data_source,
 			'query_runner' => new QueryRunner( $this->http_client ),
 		] );
@@ -349,7 +349,7 @@ class QueryRunnerTest extends TestCase {
 	}
 
 	public function testQueryRunnerAppliesDefaultInputVariables(): void {
-		$query = MockQuery::from_array( [
+		$query = MockQuery::create( [
 			'data_source' => $this->http_data_source,
 			'endpoint' => function ( array $input_variables ): string {
 				return sprintf(

--- a/tests/inc/Config/QueryTest.php
+++ b/tests/inc/Config/QueryTest.php
@@ -11,7 +11,7 @@ class QueryTest extends TestCase {
 	private HttpQuery $query_context;
 
 	protected function setUp(): void {
-		$this->data_source = MockDataSource::from_array();
+		$this->data_source = MockDataSource::create();
 		$this->query_context = HttpQuery::from_array( [
 			'data_source' => $this->data_source,
 			'output_schema' => [ 'type' => 'null' ],

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -105,7 +105,7 @@ class BlockBindingsTest extends TestCase {
 
 		$mock_block_config = [
 			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::from_array( [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
 					'input_schema' => self::MOCK_INPUT_SCHEMA,
 					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
 					'query_runner' => $mock_qr,
@@ -154,7 +154,7 @@ class BlockBindingsTest extends TestCase {
 
 		$mock_block_config = [
 			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::from_array( [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
 					'input_schema' => $input_schema,
 					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
 					'query_runner' => $mock_qr,
@@ -218,7 +218,7 @@ class BlockBindingsTest extends TestCase {
 
 		$mock_block_config = [
 			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::from_array( [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
 					'input_schema' => $input_schema,
 					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
 					'query_runner' => $mock_qr,
@@ -280,7 +280,7 @@ class BlockBindingsTest extends TestCase {
 
 		$mock_block_config = [
 			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::from_array( [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
 					'input_schema' => $input_schema,
 					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
 					'query_runner' => $mock_qr,
@@ -334,7 +334,7 @@ class BlockBindingsTest extends TestCase {
 
 		$mock_block_config = [
 			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::from_array( [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
 					'input_schema' => $input_schema,
 					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
 					'query_runner' => $mock_qr,
@@ -389,7 +389,7 @@ class BlockBindingsTest extends TestCase {
 
 		$mock_block_config = [
 			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::from_array( [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
 					'input_schema' => $input_schema,
 					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
 					'query_runner' => $mock_qr,

--- a/tests/inc/Functions/FunctionsTest.php
+++ b/tests/inc/Functions/FunctionsTest.php
@@ -75,9 +75,9 @@ class FunctionsTest extends TestCase {
 			'title' => 'Test Block with Nested Config',
 			'render_query' => [
 				'query' => [
-					'__subclass' => 'RemoteDataBlocks\Tests\Mocks\MockQuery',
+					'__class' => 'RemoteDataBlocks\Tests\Mocks\MockQuery',
 					'data_source' => [
-						'__subclass' => 'RemoteDataBlocks\Tests\Mocks\MockDataSource',
+						'__class' => 'RemoteDataBlocks\Tests\Mocks\MockDataSource',
 						'service_config' => [
 							'__version' => 1,
 							'display_name' => 'Mock Data Source',

--- a/tests/inc/Functions/FunctionsTest.php
+++ b/tests/inc/Functions/FunctionsTest.php
@@ -20,13 +20,13 @@ class FunctionsTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->mock_logger = new MockLogger();
-		$this->mock_query = MockQuery::from_array();
-		$this->mock_list_query = MockQuery::from_array( [
+		$this->mock_query = MockQuery::create();
+		$this->mock_list_query = MockQuery::create( [
 			'output_schema' => [
 				'is_collection' => true,
 			],
 		] );
-		$this->mock_search_query = MockQuery::from_array( [
+		$this->mock_search_query = MockQuery::create( [
 			'input_schema' => [
 				'search' => [ 'type' => 'ui:search_input' ],
 			],

--- a/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
+++ b/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
@@ -147,7 +147,7 @@ class VipBlockDataApiTest extends TestCase {
 		$mock_qr->addResult( 'title', $expected1 );
 		$mock_qr->addResult( 'location', $expected2 );
 
-		$mock_query = MockQuery::from_array( [ 'query_runner' => $mock_qr ] );
+		$mock_query = MockQuery::create( [ 'query_runner' => $mock_qr ] );
 		register_remote_data_block( [
 			'title' => 'Events',
 			'render_query' => [
@@ -171,7 +171,7 @@ class VipBlockDataApiTest extends TestCase {
 		$mock_qr->addResult( 'title', 'Happy happy hour! No networking!' );
 		$mock_qr->addResult( 'location', new \WP_Error( 'rdb-uh-oh', 'uh-oh!' ) );
 
-		$mock_query = MockQuery::from_array( [ 'query_runner' => $mock_qr ] );
+		$mock_query = MockQuery::create( [ 'query_runner' => $mock_qr ] );
 		register_remote_data_block( [
 			'title' => 'Events',
 			'render_query' => [

--- a/tests/inc/Mocks/MockDataSource.php
+++ b/tests/inc/Mocks/MockDataSource.php
@@ -20,8 +20,8 @@ class MockDataSource extends HttpDataSource {
 		],
 	];
 
-	public static function from_array( ?array $config = self::MOCK_CONFIG, ?ValidatorInterface $validator = null ): static|WP_Error {
-		return parent::from_array( $config, $validator ?? new MockValidator() );
+	public static function create( ?array $config = self::MOCK_CONFIG, ?ValidatorInterface $validator = null ): static|WP_Error {
+		return self::from_array( $config, $validator ?? new MockValidator() );
 	}
 
 	/**

--- a/tests/inc/Mocks/MockQuery.php
+++ b/tests/inc/Mocks/MockQuery.php
@@ -11,9 +11,9 @@ use WP_Error;
 class MockQuery extends HttpQuery {
 	private mixed $response_data = null;
 
-	public static function from_array( array $config = [], ?ValidatorInterface $validator = null ): static|WP_Error {
-		return parent::from_array( [
-			'data_source' => $config['data_source'] ?? MockDataSource::from_array(),
+	public static function create( array $config = [], ?ValidatorInterface $validator = null ): static|WP_Error {
+		return self::from_array( [
+			'data_source' => $config['data_source'] ?? MockDataSource::create(),
 			'display_name' => 'Mock Query',
 			'endpoint' => $config['endpoint'] ?? null,
 			'input_schema' => $config['input_schema'] ?? [],

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -594,6 +594,7 @@ class ValidatorTest extends TestCase {
 
 		$this->assertTrue( $validator->validate( [
 			'config' => [
+				'__class' => MockSerializableClass::class,
 				'boolean_value' => true,
 				'enum_value' => 'foo',
 				'string_value' => 'hello, world!',
@@ -602,6 +603,7 @@ class ValidatorTest extends TestCase {
 
 		$result = $validator->validate( [
 			'config' => [
+				'__class' => MockSerializableClass::class,
 				'boolean_value' => 'NOT A BOOLEAN',
 				'enum_value' => 'foo',
 				'string_value' => 'hello, world!',
@@ -629,7 +631,9 @@ class ValidatorTest extends TestCase {
 		$this->assertSame( 'Value must be an associative array: {}', $result->get_error_data()['child']->get_error_message() );
 
 		$result = $validator->validate( [
-			'config' => [],
+			'config' => [
+				'__class' => MockSerializableClass::class,
+			],
 		] );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
@@ -646,7 +650,7 @@ class ValidatorTest extends TestCase {
 
 		$this->assertTrue( $validator->validate( [
 			'config' => [
-				'__subclass' => MockSerializableSubclass::class,
+				'__class' => MockSerializableSubclass::class,
 				'boolean_value' => true,
 				'enum_value' => 'foo',
 				'string_value' => 'hello, world!',
@@ -656,7 +660,7 @@ class ValidatorTest extends TestCase {
 
 		$result = $validator->validate( [
 			'config' => [
-				'__subclass' => MockSerializableSubclass::class,
+				'__class' => MockSerializableSubclass::class,
 				'boolean_value' => true,
 				'enum_value' => 'foo',
 				'string_value' => 'hello, world!',

--- a/tests/integration/RDBTestCase.php
+++ b/tests/integration/RDBTestCase.php
@@ -38,11 +38,7 @@ class RDBTestCase extends WP_UnitTestCase {
 		] );
 
 		$this->assertTrue( $registration_result );
-
-		// Register block configuration with WordPress, normally done during the 'init' filter
-		$block_config = ConfigStore::get_block_configuration( ConfigStore::get_block_name( $block_title ) );
-		$this->assertTrue( is_array( $block_config ) && [] !== $block_config );
-		BlockRegistration::register_block_configuration( $block_config );
+		$this->register_remote_data_block_from_block_title( $block_title );
 	}
 
 	protected function register_failed_query_data_block( string $block_title ): void {
@@ -86,8 +82,15 @@ class RDBTestCase extends WP_UnitTestCase {
 		] );
 
 		$this->assertTrue( $registration_result );
+		$this->register_remote_data_block_from_block_title( $block_title );
+	}
 
-		// Register block configuration with WordPress, normally done during the 'init' filter
+	/**
+	 * Register block configuration with WordPress, normally done during the 'init' filter
+	 *
+	 * @param string $block_title The block title.
+	 */
+	protected function register_remote_data_block_from_block_title( string $block_title ): void {
 		$block_config = ConfigStore::get_block_configuration( ConfigStore::get_block_name( $block_title ) );
 		$this->assertTrue( is_array( $block_config ) && [] !== $block_config );
 		BlockRegistration::register_block_configuration( $block_config );
@@ -129,17 +132,22 @@ class RDBTestCase extends WP_UnitTestCase {
 		return $dom;
 	}
 
-	public function assertDomIdHasTextContent( DOMDocument $dom, string $html_id, string $expected_content ): void {
+	protected function get_dom_element_by_html_id( DOMDocument $dom, string $html_id ): DOMNodeList|false {
 		$xpath = new DOMXPath( $dom );
-		$id_nodes = $xpath->query( sprintf( "//*[@id='%s']", $html_id ) );
+		$nodes = $xpath->query( sprintf( "//*[@id='%s']", $html_id ) );
+
+		return $nodes;
+	}
+
+	protected function assertDomIdHasTextContent( DOMDocument $dom, string $html_id, string $expected_content ): void {
+		$id_nodes = $this->get_dom_element_by_html_id( $dom, $html_id );
 
 		$this->assertCount( 1, $id_nodes, sprintf( "Should be 1 matching node with HTML ID '%s' but %d found.", $html_id, count( $id_nodes ) ) );
 		$this->assertEquals( $expected_content, $id_nodes[0]->textContent, sprintf( "Expected '%s' in node with HTML ID '%s', but found '%s' instead.", $expected_content, $html_id, $id_nodes[0]->textContent ) );
 	}
 
 	protected function assertDomIdHasHtmlContent( DOMDocument $dom, string $html_id, string $expected_content ): void {
-		$xpath = new DOMXPath( $dom );
-		$id_nodes = $xpath->query( sprintf( "//*[@id='%s']", $html_id ) );
+		$id_nodes = $this->get_dom_element_by_html_id( $dom, $html_id );
 
 		$this->assertCount( 1, $id_nodes, sprintf( "Should be 1 matching node with HTML ID '%s' but %d found.", $html_id, count( $id_nodes ) ) );
 

--- a/tests/integration/blocks/BlockWithNestedConfigTest.php
+++ b/tests/integration/blocks/BlockWithNestedConfigTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\IntegrationTests\Blocks;
+
+use RDBTestCase;
+
+class BlockWithNestedConfigTest extends RDBTestCase {
+	public function testBlockWithNestedConfigRenders(): void {
+		$test_api_response = [
+			'id' => 12345,
+			'name' => 'Test Product',
+			'price' => '19.99',
+		];
+
+		$registration_result = register_remote_data_block( [
+			'title' => 'Test Product API',
+			'render_query' => [
+				'query' => [
+					'__class' => 'RemoteDataBlocks\\Config\\Query\\HttpQuery',
+					'data_source' => [
+						'__class' => 'RemoteDataBlocks\\Config\\DataSource\\HttpDataSource',
+						'service_config' => [
+							'__version' => 1,
+							'display_name' => 'Test API',
+							// Mocked query runner will not actually make a request to the endpoint URL.
+							'endpoint' => 'https://example.com/not-a-real-api',
+						],
+					],
+					'output_schema' => [
+						'is_collection' => false,
+						'type' => [
+							'id' => [
+								'name' => 'ID',
+								'path' => '$.id',
+								'type' => 'string',
+							],
+							'name' => [
+								'name' => 'Name',
+								'path' => '$.name',
+								'type' => 'string',
+							],
+							'price' => [
+								'name' => 'Price',
+								'path' => '$.price',
+								'type' => 'currency_in_current_locale',
+							],
+						],
+					],
+					'query_runner' => $this->get_query_runner_with_response( $test_api_response ),
+				],
+			],
+		] );
+
+		$this->assertTrue( $registration_result );
+		$this->register_remote_data_block_from_block_title( 'Test Product API' );
+
+		$result_html = do_blocks('
+			<!-- wp:remote-data-blocks/test-product-api {"remoteData":{"blockName":"remote-data-blocks/test-product-api","queryInput":{}}} -->
+			<div class="wp-block-remote-data-blocks-test-product-api rdb-container">
+				<!-- wp:heading {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"block":"remote-data-blocks/test-product-api","field":"name"}}},"name":"Name"}} -->
+				<h2 id="field-name" class="wp-block-heading"></h2>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"block":"remote-data-blocks/test-product-api","field":"price"}}},"name":"Price"}} -->
+				<p id="field-price"></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:remote-data-blocks/test-product-api -->
+		');
+
+		$dom = self::load_html( $result_html );
+		$this->assertDomIdHasTextContent( $dom, 'field-name', 'Test Product' );
+		$this->assertDomIdHasTextContent( $dom, 'field-price', '$19.99' );
+	}
+}

--- a/tests/integration/blocks/RemoteHtmlBlockTest.php
+++ b/tests/integration/blocks/RemoteHtmlBlockTest.php
@@ -4,7 +4,7 @@ namespace RemoteDataBlocks\IntegrationTests\Blocks;
 
 use RDBTestCase;
 
-class RemoteHtmlTest extends RDBTestCase {
+class RemoteHtmlBlockTest extends RDBTestCase {
 	public function testRemoteHtmlBlockRenders(): void {
 		$test_title = 'My Product';
 

--- a/tests/integration/blocks/ZipCodeBlockTest.php
+++ b/tests/integration/blocks/ZipCodeBlockTest.php
@@ -1,11 +1,11 @@
 <?php declare(strict_types = 1);
 
-namespace RemoteDataBlocks\IntegrationTests\Render;
+namespace RemoteDataBlocks\IntegrationTests\Blocks;
 
 use RDBTestCase;
 
-class RenderTest extends RDBTestCase {
-	public function testRenderQueryBlockBindingsRender(): void {
+class ZipCodeBlockTest extends RDBTestCase {
+	public function testZipCodeBlockRenders(): void {
 		$test_api_response = [
 			'post code' => 12345,
 			'places' => [


### PR DESCRIPTION
This fixes a small design mistake in #367. The mistake is that it requires participants to extend `ArraySerializable` instead of to implement `ArraySerializableInterface`.

- As such, it renames the `__subclass` property to `__class` to reflect that subclass inheritance is not required.
- It also marks `ArraySerializable::from_array()` as `final` so that we can call it and have confidence that the `__class` property will be noticed and respected. If it is overridden, that promise could be broken.