### PR TITLE
pin psalm version in github actions to 6.5.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Psalm
-        uses: docker://ghcr.io/psalm/psalm-github-actions
+        uses: docker://ghcr.io/psalm/psalm-github-actions:6.5.1
         with:
           composer_require_dev: true
           php-version: '8.1'


### PR DESCRIPTION
Pins the Psalm version in github actions to same as the one in `composer.json` (6.5). The difference in versions was leading to difference in output.