### PR TITLE
Fix issue with Shopify editorial product search

### DIFF
--- a/inc/Integrations/Shopify/Queries/SearchProducts.graphql
+++ b/inc/Integrations/Shopify/Queries/SearchProducts.graphql
@@ -1,5 +1,5 @@
-query SearchProducts($search_terms: String) {
-	products(first: 10, query: $search_terms, sortKey: BEST_SELLING) {
+query SearchProducts($search: String) {
+	products(first: 10, query: $search, sortKey: BEST_SELLING) {
 		edges {
 			node {
 				id


### PR DESCRIPTION
The search was broken in #243 by creating a mismatch between the GraphQL query input parameter name and the RDB query configuration input name.

I searched and didn't see the input referenced anywhere else by `search_terms` so I don't think this change has any other side effects.

https://github.com/user-attachments/assets/1fc028f4-94e1-4cd1-abfc-6646c78b1da0

