### PR TITLE
Support Salesforce product overrides by SKU

### DIFF
--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -96,7 +96,7 @@ class ConfigRegistry {
 
 			foreach ( array_keys( $to_query->get_input_schema() ) as $to ) {
 				if ( ! isset( $from_output_schema['type'][ $to ] ) ) {
-					return self::create_error( $block_title, sprintf( 'Cannot map key "%1$s" from %2$s query. The display query requires a "%1$s" key as an input, but it is not present in the output schema for the %2$s query. Try adding "%1$s" to the output schema for the %2$s query.', esc_html( $to ), $from_query_type, $from_query_type, esc_html( $to ) ) );
+					return self::create_error( $block_title, sprintf( 'Cannot map key "%1$s" from %2$s query. The display query for this block requires a "%1$s" key as an input, but it is not present in the output schema for the %2$s query. Try adding a "%1$s" mapping to the output schema for the %2$s query.', esc_html( $to ), $from_query_type ) );
 				}
 			}
 

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -96,7 +96,7 @@ class ConfigRegistry {
 
 			foreach ( array_keys( $to_query->get_input_schema() ) as $to ) {
 				if ( ! isset( $from_output_schema['type'][ $to ] ) ) {
-					return self::create_error( $block_title, sprintf( 'Cannot map key "%s" from %s query', esc_html( $to ), $from_query_type ) );
+					return self::create_error( $block_title, sprintf( 'Cannot map key "%1$s" from %2$s query. The display query requires a "%1$s" key as an input, but it is not present in the output schema for the %2$s query. Try adding "%1$s" to the output schema for the %2$s query.', esc_html( $to ), $from_query_type, $from_query_type, esc_html( $to ) ) );
 				}
 			}
 

--- a/inc/Integrations/SalesforceD2C/SalesforceD2CIntegration.php
+++ b/inc/Integrations/SalesforceD2C/SalesforceD2CIntegration.php
@@ -50,21 +50,22 @@ class SalesforceD2CIntegration {
 				'data_source' => $data_source,
 				'endpoint' => function ( array $input_variables ) use ( $base_endpoint, $service_config ): string {
 					return sprintf(
-						'%s/services/data/v63.0/commerce/webstores/%s/products/%s',
+						'%s/services/data/v63.0/commerce/webstores/%s/products?skus=%s',
 						$base_endpoint,
 						$service_config['store_id'],
-						$input_variables['product_id']
+						$input_variables['product_sku']
 					);
 				},
 				'input_schema' => [
-					'product_id' => [
-						'name' => 'Product ID',
+					'product_sku' => [
+						'name' => 'Product SKU',
 						'type' => 'id',
 						'required' => true,
 					],
 				],
 				'output_schema' => [
-					'is_collection' => false,
+					'is_collection' => true,
+					'path' => '$.products[*]',
 					'type' => [
 						'id' => [
 							'name' => 'Product ID',
@@ -73,7 +74,12 @@ class SalesforceD2CIntegration {
 						],
 						'name' => [
 							'name' => 'Name',
-							'path' => '$.fields.Name',
+							'path' => '$.name',
+							'type' => 'string',
+						],
+						'sku' => [
+							'name' => 'SKU',
+							'path' => '$.sku',
 							'type' => 'string',
 						],
 						'description' => [
@@ -120,6 +126,11 @@ class SalesforceD2CIntegration {
 							'path' => '$.id',
 							'type' => 'id',
 						],
+						'product_sku' => [
+							'name' => 'Product SKU',
+							'path' => '$.fields.StockKeepingUnit.value',
+							'type' => 'string',
+						],
 						'name' => [
 							'name' => 'Name',
 							'path' => '$.name',
@@ -155,23 +166,23 @@ class SalesforceD2CIntegration {
 				'overrides' => [
 					[
 						'display_name' => 'Use Salesforce product from URL',
-						'name' => 'salesforce_product_id',
+						'name' => 'salesforce_sku',
 					],
 				],
 			]
 		);
 
 		add_filter( 'query_vars', function ( array $query_vars ): array {
-			$query_vars[] = 'utm_content';
+			$query_vars[] = 'sku';
 			return $query_vars;
 		}, 10, 1 );
 
 		add_filter( 'remote_data_blocks_query_input_variables', function ( array $input_variables, array $enabled_overrides ): array {
-			if ( true === in_array( 'salesforce_product_id', $enabled_overrides, true ) ) {
-				$product_id = get_query_var( 'utm_content' );
+			if ( true === in_array( 'salesforce_sku', $enabled_overrides, true ) ) {
+				$product_sku = get_query_var( 'sku' );
 
-				if ( ! empty( $product_id ) ) {
-					$input_variables['product_id'] = $product_id;
+				if ( ! empty( $product_sku ) ) {
+					$input_variables['product_sku'] = $product_sku;
 				}
 			}
 

--- a/src/blocks/remote-data-container/hooks/useRemoteData.ts
+++ b/src/blocks/remote-data-container/hooks/useRemoteData.ts
@@ -73,7 +73,6 @@ interface UseRemoteData {
 
 interface UseRemoteDataInput {
 	blockName: string;
-	enabledOverrides?: string[];
 	externallyManagedRemoteData?: RemoteData;
 	externallyManagedUpdateRemoteData?: ( remoteData?: RemoteData ) => void;
 	fetchOnMount?: boolean;

--- a/src/blocks/remote-data-container/hooks/useRemoteData.ts
+++ b/src/blocks/remote-data-container/hooks/useRemoteData.ts
@@ -94,7 +94,6 @@ interface UseRemoteDataInput {
 // don't need an intermediate state update / re-render.
 export function useRemoteData( {
 	blockName,
-	enabledOverrides = [],
 	externallyManagedRemoteData,
 	externallyManagedUpdateRemoteData,
 	fetchOnMount = false,
@@ -121,6 +120,9 @@ export function useRemoteData( {
 		// query error.
 		throw new Error( `Query not found for block "${ blockName }" and key "${ queryKey }".` );
 	}
+
+	// Overrides must be provided via externallyManagedRemoteData
+	const enabledOverrides = externallyManagedRemoteData?.enabledOverrides ?? [];
 
 	const inputVariables = query.inputs;
 


### PR DESCRIPTION
This PR does three things:

1. Fixes an issue with overrides in `useRemoteData()` that caused the UI checkbox for overrides to un-check itself when a block was modified. This was due to the `enabledOverrides` property always defaulting to an empty array. It's now been modified to pull overrides from `externallyManagedRemoteData`.
2. Modify the Salesforce connection to use product SKUs (e.g. `12345-1`) over internal Salesforce product IDs (e.g. `01tWs000005ccuWIAQ`). SKUs are also unique values, but should be more easy for customers to understand during use.
3. Improve an error message related to query output parameters not matching query input parameters. I encountered this error during the Salesforce SKU changes. Previously, the error was:

    ```
     Error registering block scom: Cannot map key "product_sku" from search query.
    ```

    This took me a while to understand and debug. I've expanded it, which hopefully explains the problem in more depth:

    ```
    Error registering block scom: Cannot map key "product_sku" from search query. The display query for this block requires a "product_sku" key as an input, but it is not present in the output schema for the search query. Try adding a "product_sku" mapping to the output schema for the search query.
    ```

## Testing

1. Register a Salesforce D2C data source with products

2. Create a new post and add a product using the auto-generated block. You will need to search for a product first, "drink" is a good term to use:

    ![salesforce-product-block](https://github.com/user-attachments/assets/c200a5fc-a550-46c4-adce-93852b0ff2a6)

4. Next, enable data override for the block in the sidebar:

    ![data-override-checkbox](https://github.com/user-attachments/assets/09602644-95b5-4679-80c7-79a20da9136d)

    Then save and publish the post.

5. On the front-end version of the post, pass in a `?sku=` parameter. Some available SKUs from our internal `d2cstore1` store include: `6010020`, `6010049`, `6010053`.
6. Verify the data on the page changes:

    ![SKU override example on frontend page](https://github.com/user-attachments/assets/7c2638ed-d079-4b1a-a355-58878b69635a)



