### PR TITLE
Run docs generation on PR closed event to avoid `trunk` branch protections

### DIFF
--- a/.github/workflows/ai-docs.yml
+++ b/.github/workflows/ai-docs.yml
@@ -1,12 +1,13 @@
 name: Generate AI Documentation
 
 on:
-  push:
-    branches:
-      - 'trunk'
+  pull_request:
+    types:
+      - closed
 
 jobs:
   generate-ai-docs:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -24,7 +25,7 @@ jobs:
           node-version: '20'
 
       - name: Install repomix
-        run: npm install -g repomix
+        run: npm install -g repomix@v0.2
 
       - name: Generate AI documentation
         run: repomix --style=markdown docs/ example/ -o docs/ai.md


### PR DESCRIPTION
Immediate follow-up to https://github.com/Automattic/remote-data-blocks/pull/384, which didn't work because the GitHub Actions Bot [was not allowed to commit to `trunk`](https://github.com/Automattic/remote-data-blocks/actions/runs/13488140974/job/37682013753) due to branch restrictions.

For this PR, I'm trying the instructions from [Running your `pull_request` workflow when a pull request merges](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges) to attempt to make the commit on the PR branch right before merge.