### PR TITLE
Add pagination to Shopify integration

### DIFF
--- a/inc/Integrations/Shopify/Queries/SearchProducts.graphql
+++ b/inc/Integrations/Shopify/Queries/SearchProducts.graphql
@@ -1,5 +1,16 @@
-query SearchProducts($search: String) {
-	products(first: 10, query: $search, sortKey: BEST_SELLING) {
+query SearchProducts($search: String!, $limit: Int!, $cursor_next: String) {
+	products(
+		first: $limit
+		after: $cursor_next
+		query: $search
+		sortKey: BEST_SELLING
+	) {
+		pageInfo {
+			hasNextPage
+			hasPreviousPage
+			startCursor
+			endCursor
+		}
 		edges {
 			node {
 				id

--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -86,6 +86,19 @@ class ShopifyIntegration {
 					'search' => [
 						'type' => 'ui:search_input',
 					],
+					'limit' => [
+						'default_value' => 8,
+						'name' => 'Items per page',
+						'type' => 'ui:pagination_per_page',
+					],
+					'cursor_next' => [
+						'name' => 'Next page cursor',
+						'type' => 'ui:pagination_cursor_next',
+					],
+					'cursor_previous' => [
+						'name' => 'Previous page cursor',
+						'type' => 'ui:pagination_cursor_previous',
+					],
 				],
 				'output_schema' => [
 					'path' => '$.data.products.edges[*]',
@@ -111,6 +124,18 @@ class ShopifyIntegration {
 							'path' => '$.node.title',
 							'type' => 'string',
 						],
+					],
+				],
+				'pagination_schema' => [
+					'cursor_next' => [
+						'name' => 'Next page cursor',
+						'path' => '$.data.products.pageInfo.endCursor',
+						'type' => 'string',
+					],
+					'cursor_previous' => [
+						'name' => 'Previous page cursor',
+						'path' => '$.data.products.pageInfo.startCursor',
+						'type' => 'string',
 					],
 				],
 				'graphql_query' => file_get_contents( __DIR__ . '/Queries/SearchProducts.graphql' ),

--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -137,6 +137,11 @@ class ShopifyIntegration {
 						'path' => '$.data.products.pageInfo.startCursor',
 						'type' => 'string',
 					],
+					'has_next_page' => [
+						'name' => 'Has next page',
+						'path' => '$.data.products.pageInfo.hasNextPage',
+						'type' => 'boolean',
+					],
 				],
 				'graphql_query' => file_get_contents( __DIR__ . '/Queries/SearchProducts.graphql' ),
 			] ),

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -288,9 +288,8 @@ final class ConfigSchemas {
 			'pagination_schema' => Types::nullable(
 				Types::object( [
 					// This field provides an integer representing the total number of
-					// items available in paginated results. This field must be defined
-					// in order present to enable pagination support of any type,
-					// including cursor-based pagination.
+					// items available in paginated results. Either this field or
+					// `has_next_page` must be defined in order to enable
 					'total_items' => Types::nullable(
 						Types::object( [
 							'name' => Types::nullable( Types::string() ),

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -291,11 +291,13 @@ final class ConfigSchemas {
 					// items available in paginated results. This field must be defined
 					// in order present to enable pagination support of any type,
 					// including cursor-based pagination.
-					'total_items' => Types::object( [
+					'total_items' => Types::nullable(
+						Types::object( [
 						'name' => Types::nullable( Types::string() ),
 						'path' => Types::json_path(),
 						'type' => Types::enum( 'integer' ),
 					] ),
+					),
 					// This field provides a pagination cursor for the next page of
 					// paginated results, or a null value if there is no next page. This
 					// field must be defined in order to enable cursor-based pagination.

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -289,7 +289,7 @@ final class ConfigSchemas {
 				Types::object( [
 					// This field provides an integer representing the total number of
 					// items available in paginated results. Either this field or
-					// `has_next_page` must be defined in order to enable
+					// `has_next_page` must be defined in order to enable pagination.
 					'total_items' => Types::nullable(
 						Types::object( [
 							'name' => Types::nullable( Types::string() ),

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -293,10 +293,10 @@ final class ConfigSchemas {
 					// including cursor-based pagination.
 					'total_items' => Types::nullable(
 						Types::object( [
-						'name' => Types::nullable( Types::string() ),
-						'path' => Types::json_path(),
-						'type' => Types::enum( 'integer' ),
-					] ),
+							'name' => Types::nullable( Types::string() ),
+							'path' => Types::json_path(),
+							'type' => Types::enum( 'integer' ),
+						] ),
 					),
 					// This field provides a pagination cursor for the next page of
 					// paginated results, or a null value if there is no next page. This
@@ -317,6 +317,16 @@ final class ConfigSchemas {
 							'path' => Types::json_path(),
 							'type' => Types::enum( 'string' ),
 						] ),
+					),
+					// This field provides a boolean indicating if there is a next page of
+					// paginated results. This is helpful if the API does not provide a
+					// total number of items. 
+					'has_next_page' => Types::nullable(
+						Types::object( [
+							'name' => Types::nullable( Types::string() ),
+							'path' => Types::json_path(),
+							'type' => Types::enum( 'boolean' ),
+						] )
 					),
 				] )
 			),

--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -187,7 +187,7 @@ export function ItemList( props: ItemListProps ) {
 				onChangeView={ onChangeView }
 				paginationInfo={ {
 					totalItems: totalItems ?? data.length,
-					totalPages: totalPages ?? ( hasNextPage ? page + 1 : page - 1 ) ?? 1,
+					totalPages: totalPages ?? ( hasNextPage ? page + 1 : Math.max( 1, page ) ),
 				} }
 				search={ supportsSearch }
 				selection={ selectedItems }

--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -162,7 +162,7 @@ export function ItemList( props: ItemListProps ) {
 			onChangeView={ onChangeView }
 			paginationInfo={ {
 				totalItems: totalItems ?? data.length,
-				totalPages: totalPages ?? ( hasNextPage ? page + 1 : page - 1 ),
+				totalPages: totalPages ?? ( hasNextPage ? page + 1 : page - 1 ) ?? 1,
 			} }
 			search={ supportsSearch }
 			view={ view }

--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -27,6 +27,7 @@ function getResultsWithId( results: RemoteDataResult[], instanceId: string ): Re
 interface ItemListProps {
 	availableBindings: Record< string, RemoteDataBinding >;
 	blockName: string;
+	hasNextPage: boolean;
 	loading: boolean;
 	onSelect: ( data: RemoteDataQueryInput ) => void;
 	onSelectField?: ( data: FieldSelection, fieldValue: string ) => void;
@@ -35,6 +36,7 @@ interface ItemListProps {
 	remoteData?: RemoteData;
 	searchInput: string;
 	setPage: ( newPage: number ) => void;
+	setPerPage: ( newPerPage: number ) => void;
 	setSearchInput: ( newValue: string ) => void;
 	supportsSearch: boolean;
 	totalItems?: number;
@@ -45,6 +47,7 @@ export function ItemList( props: ItemListProps ) {
 	const {
 		availableBindings,
 		blockName,
+		hasNextPage,
 		loading,
 		onSelect,
 		onSelectField,
@@ -53,6 +56,7 @@ export function ItemList( props: ItemListProps ) {
 		remoteData,
 		searchInput,
 		setPage,
+		setPerPage,
 		setSearchInput,
 		supportsSearch,
 		totalItems,
@@ -121,6 +125,7 @@ export function ItemList( props: ItemListProps ) {
 
 	function onChangeView( newView: View ) {
 		setPage( newView.page ?? 1 );
+		setPerPage( newView.perPage ?? perPage ?? data.length );
 		setSearchInput( newView.search ?? '' );
 		setView( newView );
 	}
@@ -157,7 +162,7 @@ export function ItemList( props: ItemListProps ) {
 			onChangeView={ onChangeView }
 			paginationInfo={ {
 				totalItems: totalItems ?? data.length,
-				totalPages: totalPages ?? 1,
+				totalPages: totalPages ?? ( hasNextPage ? page + 1 : page - 1 ),
 			} }
 			search={ supportsSearch }
 			view={ view }

--- a/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
@@ -88,7 +88,7 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 					<ItemList
 						availableBindings={ availableBindings }
 						blockName={ blockName }
-						hasNextPage={ hasNextPage }
+						hasNextPage={ hasNextPage ?? false }
 						idField={ idField }
 						loading={ loading }
 						onSelect={ onSelect ? onSelectItem : close }

--- a/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
@@ -31,10 +31,12 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 	const { close, isOpen, open } = useModalState();
 	const {
 		data,
+		hasNextPage,
 		loading,
 		page,
 		searchInput,
 		setPage,
+		setPerPage,
 		setSearchInput,
 		supportsSearch,
 		totalItems,
@@ -72,6 +74,7 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 					<ItemList
 						availableBindings={ availableBindings }
 						blockName={ blockName }
+						hasNextPage={ hasNextPage }
 						loading={ loading }
 						onSelect={ onSelect ? onSelectItem : close }
 						onSelectField={ onSelectField }
@@ -79,6 +82,7 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 						remoteData={ data }
 						searchInput={ searchInput }
 						setPage={ setPage }
+						setPerPage={ setPerPage }
 						setSearchInput={ setSearchInput }
 						supportsSearch={ supportsSearch }
 						totalItems={ totalItems }

--- a/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
+++ b/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
@@ -9,6 +9,7 @@ import {
 } from '@/blocks/remote-data-container/config/constants';
 
 interface UsePaginationVariables {
+	hasNextPage?: boolean;
 	onFetch: ( remoteData: RemoteData ) => void;
 	page: number;
 	paginationQueryInput: RemoteDataQueryInput;
@@ -35,7 +36,7 @@ export function usePaginationVariables( {
 	initialPerPage,
 	inputVariables,
 }: UsePaginationVariablesInput ): UsePaginationVariables {
-	const [ paginationData, setPaginationData ] = useState< RemoteDataPagination >();
+	const [ paginationData, setPaginationData ] = useState< RemoteDataPagination >( {} );
 	const [ page, setPage ] = useState< number >( initialPage );
 	const [ perPage, setPerPage ] = useState< number | null >( initialPerPage ?? null );
 
@@ -88,6 +89,7 @@ export function usePaginationVariables( {
 		supportsCursorPagination || supportsPagePagination || supportsOffsetPagination;
 	const totalItems = paginationData?.totalItems;
 	const totalPages = totalItems && perPage ? Math.ceil( totalItems / perPage ) : undefined;
+	const hasNextPage = paginationData?.hasNextPage;
 
 	function onFetch( remoteData: RemoteData ): void {
 		if ( ! supportsPagination ) {
@@ -120,6 +122,7 @@ export function usePaginationVariables( {
 	}
 
 	return {
+		hasNextPage,
 		onFetch,
 		page,
 		paginationQueryInput,

--- a/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
+++ b/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
@@ -36,7 +36,7 @@ export function usePaginationVariables( {
 	initialPerPage,
 	inputVariables,
 }: UsePaginationVariablesInput ): UsePaginationVariables {
-	const [ paginationData, setPaginationData ] = useState< RemoteDataPagination >( {} );
+	const [ paginationData, setPaginationData ] = useState< RemoteDataPagination >();
 	const [ page, setPage ] = useState< number >( initialPage );
 	const [ perPage, setPerPage ] = useState< number | null >( initialPerPage ?? null );
 

--- a/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
+++ b/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
@@ -92,8 +92,8 @@ export function usePaginationVariables( {
 		supportsCursorPagination ||
 		supportsPagePagination ||
 		supportsOffsetPagination ||
-		totalItems ||
-		hasNextPage;
+		hasNextPage ||
+		Boolean( totalItems );
 
 	function onFetch( remoteData: RemoteData ): void {
 		if ( ! supportsPagination ) {

--- a/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
+++ b/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
@@ -85,11 +85,15 @@ export function usePaginationVariables( {
 		Object.assign( paginationQueryInput, { [ perPageVariable.slug ]: perPage } );
 	}
 
-	const supportsPagination =
-		supportsCursorPagination || supportsPagePagination || supportsOffsetPagination;
 	const totalItems = paginationData?.totalItems;
 	const totalPages = totalItems && perPage ? Math.ceil( totalItems / perPage ) : undefined;
 	const hasNextPage = paginationData?.hasNextPage;
+	const supportsPagination =
+		supportsCursorPagination ||
+		supportsPagePagination ||
+		supportsOffsetPagination ||
+		totalItems ||
+		hasNextPage;
 
 	function onFetch( remoteData: RemoteData ): void {
 		if ( ! supportsPagination ) {

--- a/src/blocks/remote-data-container/hooks/useRemoteData.ts
+++ b/src/blocks/remote-data-container/hooks/useRemoteData.ts
@@ -31,6 +31,7 @@ async function fetchRemoteData( requestData: RemoteDataApiRequest ): Promise< Re
 		pagination: body.pagination && {
 			cursorNext: body.pagination.cursor_next,
 			cursorPrevious: body.pagination.cursor_previous,
+			hasNextPage: body.pagination.has_next_page,
 			totalItems: body.pagination.total_items,
 		},
 		queryInput: body.query_input,
@@ -51,8 +52,7 @@ interface UseRemoteData {
 	data?: RemoteData;
 	error?: Error;
 	fetch: ( queryInput: RemoteDataQueryInput ) => Promise< void >;
-	hasNextPage: boolean;
-	hasPreviousPage: boolean;
+	hasNextPage?: boolean;
 	loading: boolean;
 	page: number;
 	perPage?: number;
@@ -126,6 +126,7 @@ export function useRemoteData( {
 	const inputVariables = query.inputs;
 
 	const {
+		hasNextPage,
 		onFetch: onFetchForPagination,
 		page,
 		perPage,
@@ -237,7 +238,7 @@ export function useRemoteData( {
 		data: resolvedData,
 		error,
 		fetch,
-		hasNextPage: totalPages ? page < totalPages : supportsPagination,
+		hasNextPage: hasNextPage ?? ( totalPages ? page < totalPages : supportsPagination ),
 		hasPreviousPage: page > 1,
 		loading,
 		page,

--- a/src/blocks/remote-data-container/hooks/useRemoteData.ts
+++ b/src/blocks/remote-data-container/hooks/useRemoteData.ts
@@ -53,6 +53,7 @@ interface UseRemoteData {
 	error?: Error;
 	fetch: ( queryInput: RemoteDataQueryInput ) => Promise< void >;
 	hasNextPage?: boolean;
+	hasPreviousPage: boolean;
 	loading: boolean;
 	page: number;
 	perPage?: number;

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -3,9 +3,10 @@ interface InnerBlockContext {
 }
 
 interface RemoteDataPagination {
-	cursorNext?: string;
-	cursorPrevious?: string;
-	totalItems: number;
+    hasNextPage?: boolean;
+    cursorNext?: string;
+    cursorPrevious?: string;
+	totalItems?: number;
 }
 
 interface RemoteDataResultFields {
@@ -87,7 +88,8 @@ interface RemoteDataApiResponseBody {
 	pagination?: {
 		cursor_next?: string;
 		cursor_previous?: string;
-		total_items: number;
+		has_next_page?: boolean;
+		total_items?: number;
 	};
 	query_input: RemoteDataQueryInput;
 	result_id: string;

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -3,9 +3,9 @@ interface InnerBlockContext {
 }
 
 interface RemoteDataPagination {
-    hasNextPage?: boolean;
     cursorNext?: string;
     cursorPrevious?: string;
+	hasNextPage?: boolean;
 	totalItems?: number;
 }
 

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -3,8 +3,8 @@ interface InnerBlockContext {
 }
 
 interface RemoteDataPagination {
-    cursorNext?: string;
-    cursorPrevious?: string;
+	cursorNext?: string;
+	cursorPrevious?: string;
 	hasNextPage?: boolean;
 	totalItems?: number;
 }


### PR DESCRIPTION
This implements the pagination feature (@chriszarate added in #338) to our Shopify integration.

To get the total product count, we'd need access to `read_products` which requires authenticating with OAuth. To avoid this, I've made `total_items` optional and added `has_next_page`, so we can paginate through products one page at a time: 

https://github.com/user-attachments/assets/954d9fac-4d5a-4c23-9971-825bbb37fdc6

I also exposed `setPerPage` so the items per page can be updated, which makes going through the products a lot faster. This will also update for any sources with pagination set up (e.g. the art institute). 