### PR TITLE
Show the salesforce-d2c icon on the data sources page

### DIFF
--- a/src/data-sources/DataSourceList.tsx
+++ b/src/data-sources/DataSourceList.tsx
@@ -21,9 +21,9 @@ import { BaseModal } from '@/blocks/remote-data-container/components/modals/Base
 import { useModalState } from '@/blocks/remote-data-container/hooks/useModalState';
 import DataSourceMetaTags from '@/data-sources/DataSourceMetaTags';
 import {
+	ConfigSource,
 	SUPPORTED_SERVICES,
 	SUPPORTED_SERVICES_LABELS,
-	ConfigSource,
 } from '@/data-sources/constants';
 import { useDataSources } from '@/data-sources/hooks/useDataSources';
 import { DataSourceConfig } from '@/data-sources/types';
@@ -31,6 +31,7 @@ import { useSettingsContext } from '@/settings/hooks/useSettingsNav';
 import { AirtableIcon } from '@/settings/icons/AirtableIcon';
 import { GoogleSheetsIcon } from '@/settings/icons/GoogleSheetsIcon';
 import HttpIcon from '@/settings/icons/HttpIcon';
+import SalesforceCommerceD2CIcon from '@/settings/icons/SalesforceCommerceD2CIcon';
 import { ShopifyIcon } from '@/settings/icons/ShopifyIcon';
 
 import './DataSourceList.scss';
@@ -97,6 +98,8 @@ const DataSourceList = () => {
 				return ShopifyIcon;
 			case 'google-sheets':
 				return GoogleSheetsIcon;
+			case 'salesforce-d2c':
+				return SalesforceCommerceD2CIcon;
 			default:
 				return HttpIcon;
 		}


### PR DESCRIPTION
### Description

Currently, if the data source is Salesforce the HTTP datasource icon is shown. The purpose os this PR is to fix that, and ensure the salesforce icon is correctly shown.

### Testing

- Setup salesforce as a source before you pull this branch down. Ensure that the icon is the HTTP one.
- Now pull this branch down and see that the icon is updated to  the salesforce one.