### PR TITLE
fix Google Sheets API URL encoding for sheet cell ranges

### DIFF
--- a/src/data-sources/api-clients/google.ts
+++ b/src/data-sources/api-clients/google.ts
@@ -72,7 +72,8 @@ export class GoogleApi {
 		sheetTitle: string,
 		cellRange: string
 	): Promise< GoogleSheetsValueRange > {
-		const url = `${ GoogleApi.SHEETS_BASE_URL }/spreadsheets/${ spreadsheetId }/values/${ sheetTitle }!${ cellRange }`;
+		const range = encodeURIComponent( `${ sheetTitle }!${ cellRange }` );
+		const url = `${ GoogleApi.SHEETS_BASE_URL }/spreadsheets/${ spreadsheetId }/values/${ range }`;
 		const result = await this.fetchApi< GoogleSheetsValueRange >( url );
 		return result;
 	}


### PR DESCRIPTION
URL encode the sheet title and cell range parameters when constructing the Google Sheets API URL to handle special characters in sheet names or ranges which together construct the cell range which is the appended to URL.This prevents API errors when working with sheets that contain spaces or other special characters in their titles.