### PR TITLE
Fix caching for GraphQL queries

### DIFF
--- a/inc/Config/Query/GraphqlQuery.php
+++ b/inc/Config/Query/GraphqlQuery.php
@@ -34,4 +34,16 @@ class GraphqlQuery extends HttpQuery {
 	public static function get_config_schema(): array {
 		return ConfigSchemas::get_graphql_query_config_schema();
 	}
+
+	/**
+	 * GraphQL queries are typically made with POST requests, however, we do
+	 * want to cache the response to queries. Override the default HTTP behavior
+	 * for POST requests and allow caching.
+	 *
+	 * Caching policy for GraphQL mutations is separately handled and disabled.
+	 */
+	public function get_cache_ttl( array $input_variables ): int|null {
+		// Return null for default cache TTL.
+		return null;
+	}
 }


### PR DESCRIPTION
We currently use this HTTP caching strategy on trunk:

https://github.com/Automattic/remote-data-blocks/blob/4f6e62acc93e5218eb2417ffabd90be6812c1db0/inc/Config/Query/HttpQuery.php#L43-L48

The comment is incorrect. We inherit the same strategy in `GraphqlQuery`, and this has some issues. GraphQL queries are typically implemented as `POST` requests, which means that we're skipping the cache each time we make a GraphQL query. For large pages of items or a lot of properties, this results in a huge number of cache misses and slow page loads for our GraphQL data sources like Shopify.

This PR adjusts GraphQL queries to use the default caching strategy, ignoring the fact that it's a `POST` request. GraphQL mutations are still uncached.

## Testing

1. On the `trunk` branch, set up a Shopify connection.
2. Create a new post and add a product with the default template.
3. Publish the page and view the page on the frontend as a logged-in user (e.g. as `admin` on a local `wp-env` instance).
4. View the Query Monitor logs by clicking on the query monitor bar (top arrow) and clicking the "Logs" tab on the lower left:

    ![Screenshot 2025-02-26 at 12 38 38 PM](https://github.com/user-attachments/assets/95b2afe8-610b-4715-b2d4-11df85760458)

5. Note the several logs related to cache misses. Refresh the page and confirm that caching is not working.
6. Switch to this branch `fix/graphql-caching`.
7. Refresh the page. You should see one cache miss follow by several cache hits:

    ![image](https://github.com/user-attachments/assets/6da1f79d-3eee-4756-bf22-e144e67c8b79)

8. Refresh again. All requests should hit the cache now, and the page should load very quickly.
9. Wait 60 seconds and refresh. You should see a fresh uncached request followed by cached result, the same as step 7.