### PR TITLE
ItemList: Add check for empty fields

### DIFF
--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -130,7 +130,7 @@ export function ItemList( props: ItemListProps ) {
 
 	// Only update if tableFields has content and view.fields is empty
 	useEffect( () => {
-		if ( tableFields.length > 0 && view.fields.length === 0 ) {
+		if ( tableFields.length > 0 && view.fields?.length === 0 ) {
 			setView( currentView => ( {
 				...currentView,
 				fields: tableFields,

--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -1,6 +1,6 @@
 import { useInstanceId } from '@wordpress/compose';
 import { Action, DataViews, View } from '@wordpress/dataviews/wp';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { ItemListField } from '@/blocks/remote-data-container/components/item-list/ItemListField';
@@ -128,10 +128,24 @@ export function ItemList( props: ItemListProps ) {
 		selection: selectedItems,
 	} );
 
+	// Only update if tableFields has content and view.fields is empty
+	useEffect( () => {
+		if ( tableFields.length > 0 && view.fields.length === 0 ) {
+			setView( currentView => ( {
+				...currentView,
+				fields: tableFields,
+			} ) );
+		}
+	}, [ tableFields ] );
+
 	function onChangeView( newView: View ) {
 		setPage( newView.page ?? 1 );
 		setSearchInput( newView.search ?? '' );
-		setView( { ...newView, selection: selectedItems } );
+		setView( {
+			...newView,
+			fields: newView.fields ?? tableFields,
+			selection: selectedItems,
+		} );
 	}
 
 	const defaultLayouts = mediaField


### PR DESCRIPTION
@alecgeatches found that fields weren't showing for Salesforce after initiating a search.

This is because there are no results on the initial render for Salesforce. So the field value was remaining as an empty array even after searching/updating the view. 

This adds a `useEffect` to make sure that fields are updated if there are changes.

| Before  | After |
| ------------- | ------------- |
|  ![Screenshot 2025-02-27 at 12 24 37 PM](https://github.com/user-attachments/assets/79534d48-1684-4e9f-9ef2-a4a04389f6eb) | <img width="1092" alt="Screenshot 2025-02-27 at 12 35 44 PM" src="https://github.com/user-attachments/assets/c38516c6-e03a-487c-999b-12173ac6a8f3" />  |


