### PR TITLE
Add title type

### DIFF
--- a/docs/extending/query-output_schema.md
+++ b/docs/extending/query-output_schema.md
@@ -16,6 +16,7 @@ Unless your API returns a single value, `type` will be constructed of an associa
 - `null`
 - `number`
 - `string`
+- `title`
 - `url`
 - `uuid`
 

--- a/example/rest-api/art-institute/art-institute.php
+++ b/example/rest-api/art-institute/art-institute.php
@@ -71,7 +71,7 @@ function register_aic_block(): void {
 				],
 				'title' => [
 					'name' => 'Title',
-					'type' => 'string',
+					'type' => 'title',
 					'path' => '$.title',
 				],
 				'image_id' => [
@@ -136,7 +136,7 @@ function register_aic_block(): void {
 				],
 				'title' => [
 					'name' => 'Title',
-					'type' => 'string',
+					'type' => 'title',
 					'path' => '$.title',
 				],
 				'image_url' => [

--- a/inc/Editor/BlockPatterns/BlockPatterns.php
+++ b/inc/Editor/BlockPatterns/BlockPatterns.php
@@ -112,10 +112,14 @@ class BlockPatterns {
 						$bindings['heading']['content'] = [ $field, $name ];
 						break;
 					}
-
+					
 					$bindings['paragraphs'][] = [
 						'content' => [ $field, $name ],
 					];
+					break;
+
+				case 'title':
+					$bindings['heading']['content'] = [ $field, $name ];
 					break;
 
 				case 'image_alt':

--- a/inc/Integrations/SalesforceD2C/SalesforceD2CIntegration.php
+++ b/inc/Integrations/SalesforceD2C/SalesforceD2CIntegration.php
@@ -75,7 +75,7 @@ class SalesforceD2CIntegration {
 						'name' => [
 							'name' => 'Name',
 							'path' => '$.name',
-							'type' => 'string',
+							'type' => 'title',
 						],
 						'sku' => [
 							'name' => 'SKU',
@@ -134,7 +134,7 @@ class SalesforceD2CIntegration {
 						'name' => [
 							'name' => 'Name',
 							'path' => '$.name',
-							'type' => 'string',
+							'type' => 'title',
 						],
 						'image_url' => [
 							'name' => 'Image URL',

--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -69,7 +69,7 @@ class ShopifyIntegration {
 						'title' => [
 							'name' => 'Title',
 							'path' => '$.data.product.title',
-							'type' => 'string',
+							'type' => 'title',
 						],
 						'variant_id' => [
 							'name' => 'Variant ID',
@@ -109,7 +109,7 @@ class ShopifyIntegration {
 						'title' => [
 							'name' => 'Product title',
 							'path' => '$.node.title',
-							'type' => 'string',
+							'type' => 'title',
 						],
 					],
 				],

--- a/inc/Sanitization/Sanitizer.php
+++ b/inc/Sanitization/Sanitizer.php
@@ -119,6 +119,9 @@ class Sanitizer implements SanitizerInterface {
 			case 'string':
 				return sanitize_text_field( strval( $value ) );
 
+			case 'title':
+				return sanitize_text_field( strval( $value ) );
+
 			case 'button_text':
 			case 'html':
 			case 'id':

--- a/inc/Sanitization/Sanitizer.php
+++ b/inc/Sanitization/Sanitizer.php
@@ -117,8 +117,6 @@ class Sanitizer implements SanitizerInterface {
 				return null;
 
 			case 'string':
-				return sanitize_text_field( strval( $value ) );
-
 			case 'title':
 				return sanitize_text_field( strval( $value ) );
 

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -275,6 +275,7 @@ final class ConfigSchemas {
 							'image_alt',
 							'image_url',
 							'markdown',
+							'title',
 							// 'json_path' is omitted since it likely has no user utility.
 							'url',
 							'uuid',

--- a/inc/Validation/Types.php
+++ b/inc/Validation/Types.php
@@ -104,6 +104,10 @@ final class Types {
 		return self::generate_primitive_type( 'url' );
 	}
 
+	public static function title(): array {
+		return self::generate_primitive_type( 'title' );
+	}
+
 	public static function uuid(): array {
 		return self::generate_primitive_type( 'uuid' );
 	}

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -47,8 +47,14 @@ final class Validator implements ValidatorInterface {
 
 		if ( Types::is_primitive( $type ) ) {
 			$type_name = Types::get_type_name( $type );
-			if ( $this->check_primitive_type( $type_name, $value ) ) {
+			$result = $this->check_primitive_type( $type_name, $value );
+
+			if ( true === $result ) {
 				return true;
+			}
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
 			}
 
 			return $this->create_error( sprintf( 'Value must be a %s', $type_name ), $value );
@@ -232,7 +238,7 @@ final class Validator implements ValidatorInterface {
 		}
 	}
 
-	private function check_primitive_type( string $type_name, mixed $value ): bool {
+	private function check_primitive_type( string $type_name, mixed $value ): bool|WP_Error {
 		switch ( $type_name ) {
 			case 'any':
 				return true;
@@ -256,6 +262,7 @@ final class Validator implements ValidatorInterface {
 			case 'html':
 			case 'image_alt':
 			case 'markdown':
+			case 'title':
 				return is_string( $value );
 
 			case 'button_text':
@@ -274,7 +281,7 @@ final class Validator implements ValidatorInterface {
 				return wp_is_uuid( $value );
 
 			default:
-				return false;
+				return $this->create_error( 'Unknown type', $type_name );
 		}
 	}
 

--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -85,7 +85,7 @@ export function ItemList( props: ItemListProps ) {
 
 	// Find title field from availableBindings by checking type
 	const titleField = Object.entries( availableBindings ).find(
-		( [ _, binding ] ) => binding.type === 'string' && binding.name.toLowerCase() === 'title'
+		( [ _, binding ] ) => binding.type === 'title'
 	)?.[ 0 ];
 
 	// Find media field from availableBindings by checking type

--- a/src/blocks/remote-data-container/config/constants.ts
+++ b/src/blocks/remote-data-container/config/constants.ts
@@ -33,4 +33,5 @@ export const TEXT_FIELD_TYPES = [
 	'markdown',
 	'number',
 	'string',
+	'title',
 ];

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -52,6 +52,7 @@ class ValidatorTest extends TestCase {
 			'image_url' => 'https://example.com/image.jpg',
 			'json_path' => '$.foo.bar',
 			'markdown' => '# Hello, world!',
+			'title' => 'A Title',
 			'url' => 'https://example.com/foo',
 			'uuid' => '123e4567-e89b-12d3-a456-426614174000',
 		] ) );

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -29,6 +29,7 @@ class ValidatorTest extends TestCase {
 			'image_url' => Types::image_url(),
 			'json_path' => Types::json_path(),
 			'markdown' => Types::markdown(),
+			'title' => Types::title(),
 			'url' => Types::url(),
 			'uuid' => Types::uuid(),
 		] );
@@ -351,6 +352,31 @@ class ValidatorTest extends TestCase {
 		$result = $validator->validate( $invalid_value );
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertStringStartsWith( 'Value must be a id:', $result->get_error_message() );
+	}
+
+	public function testInvalidNonPrimitiveType(): void {
+		$schema = [ '@type' => 'invented' ];
+
+		$validator = new Validator( $schema );
+
+		$result = $validator->validate( 'hello, world!' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'Unknown type: invented', $result->get_error_message() );
+	}
+
+	public function testInvalidPrimitiveType(): void {
+		$schema = [
+			'@primitive' => true,
+			'@type' => 'invented',
+		];
+
+		$validator = new Validator( $schema );
+
+		$result = $validator->validate( 'hello, world!' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'Unknown type: invented', $result->get_error_message() );
 	}
 
 	public function testCallable(): void {


### PR DESCRIPTION
After seeing the missing name field in #396, I thought it might make sense to add a 'title' type to the schema to set explicit titles. In DataViews, there are three special fields: 

> titleField: The id of the field representing the title of the record.
> mediaField: The id of the field representing the media of the record.
> descriptionField: The id of the field representing the description of the record.

When these are set, they get unique styling, which we are utilizing for `image_url` in the `mediaField`, which can be seen in the screenshots below. 

This way, we don't have to guess like we do for block patterns. However, I left the check under `string` for sources like Airtable and Google Sheets, where we aren't explicitly defining each field and its type. 

| Before  | After |
| ------------- | ------------- |
| <img width="1091" alt="Screenshot 2025-02-27 at 12 52 37 PM" src="https://github.com/user-attachments/assets/dfa10610-f384-4757-bcfc-bccafa8ffc29" /> |  <img width="1084" alt="Screenshot 2025-02-27 at 12 54 31 PM" src="https://github.com/user-attachments/assets/b97ca6d7-fcbd-4adf-9bac-77dc4076fc4e" /> | 

| Before  | After |
| ------------- | ------------- |
| <img width="1088" alt="Screenshot 2025-02-27 at 12 55 01 PM" src="https://github.com/user-attachments/assets/a23b6719-303b-4be4-b098-7238e3bc290c" />  | <img width="1085" alt="Screenshot 2025-02-27 at 12 54 39 PM" src="https://github.com/user-attachments/assets/35a52827-2d77-4402-860c-9e7f33272ae5" /> |


