### PR TITLE
Apply default pattern generation from first image instead of last

### DIFF
--- a/inc/Editor/BlockPatterns/BlockPatterns.php
+++ b/inc/Editor/BlockPatterns/BlockPatterns.php
@@ -119,11 +119,11 @@ class BlockPatterns {
 					break;
 
 				case 'image_alt':
-					$bindings['image']['alt'] = [ $field, $name ];
+					$bindings['images']['alt'][] = [ $field, $name ];
 					break;
 
 				case 'image_url':
-					$bindings['image']['url'] = [ $field, $name ];
+					$bindings['images']['url'][] = [ $field, $name ];
 					break;
 
 				case 'html':
@@ -152,9 +152,17 @@ class BlockPatterns {
 			$content .= self::populate_template( 'html', self::generate_attribute_bindings( $block_name, $html ) );
 		}
 
-		// If there is an image URL, create two-column layout with left-aligned image.
-		if ( ! empty( $bindings['image']['url'] ) ) {
-			$image_bindings = self::generate_attribute_bindings( $block_name, $bindings['image'] );
+		// If there is an image URL, create two-column layout with left-aligned image of the first image provided.
+		if ( ! empty( $bindings['images']['url'] ) ) {
+			$first_image_bindings = [
+				'url' => $bindings['images']['url'][0],
+			];
+
+			if ( ! empty( $bindings['images']['alt'] ) ) {
+				$first_image_bindings['alt'] = $bindings['images']['alt'][0];
+			}
+
+			$image_bindings = self::generate_attribute_bindings( $block_name, $first_image_bindings );
 			$image_content = self::populate_template( 'image', $image_bindings );
 			$content = sprintf( self::$templates['columns'], $image_content, $content );
 		}


### PR DESCRIPTION
With our current default pattern generation, we overwrite `$bindings['image']['url']` and `$bindings['image']['alt']` each time we encounter a new one. I'm working with a data source that returns several images, with some of them being optional. The configuration output mapping looks like this:

```php
'type' => [
	'id' => [
		'name' => 'Product ID',
		'path' => '$.id',
		'type' => 'id',
	],
	'name' => [
		'name' => 'Name',
		'path' => '$.name',
		'type' => 'string',
	],
	'sku' => [
		'name' => 'SKU',
		'path' => '$.sku',
		'type' => 'string',
	],
	'description' => [
		'name' => 'Description',
		'path' => '$.fields.Description',
		'type' => 'string',
	],
	'image_url' => [
		'name' => 'Image URL',
		'path' => '$.defaultImage.url',
		'type' => 'image_url',
	],
	'image_alt_text' => [
		'name' => 'Image Alt Text',
		'path' => '$.defaultImage.alternateText',
		'type' => 'image_alt',
	],
	'Variant1Image__c' => [
		'name' => 'Variant1Image',
		'path' => '$.fields.Variant1Image__c',
		'type' => 'image_url',
	],
	'Variant2Image__c' => [
		'name' => 'Variant2Image',
		'path' => '$.fields.Variant2Image__c',
		'type' => 'image_url',
	],
	'Variant3Image__c' => [
		'name' => 'Variant3Image',
		'path' => '$.fields.Variant3Image__c',
		'type' => 'image_url',
	],
	/* ... */
];
```

I have the primary image URL and alt text at the top of the configuration, and some optional variant possibilities below. Prior to this PR, the auto-generated image that's selected by the default pattern would be `Variant3Image__c` (the least likely to have a value in my case) and `image_url` is never used.

This PR changes pattern generation to keep data about all images and instead construct the default pattern from the first encountered image and alt text. Note that this may cause the primary image's alt text to match an unrelated alt text from another part of the config, because bindings are evaluated individually. However, this is the same behavior as the current pattern generation so this is not a regression.