### PR TITLE
updating to work with WP Playground CLI

### DIFF
--- a/blueprint.local.json
+++ b/blueprint.local.json
@@ -4,7 +4,9 @@
     "title": "Remote Data Blocks local playground",
     "description": "Runs Remote Data Blocks plugin in a local WordPress Playground",
     "author": "WordPress VIP",
-    "categories": [ "Content" ]
+    "categories": [
+      "Content"
+    ]
   },
   "features": {
     "networking": true
@@ -27,16 +29,6 @@
       "step": "defineWpConfigConsts",
       "consts": {
         "USE_PLAYGROUND_CORS_PROXY": false
-      }
-    },
-    {
-      "step": "installPlugin",
-      "options": {
-        "activate": true
-      },
-      "pluginZipFile": {
-        "resource": "wordpress.org/plugins",
-        "slug": "query-monitor"
       }
     },
     {

--- a/blueprint.local.json
+++ b/blueprint.local.json
@@ -4,9 +4,7 @@
     "title": "Remote Data Blocks local playground",
     "description": "Runs Remote Data Blocks plugin in a local WordPress Playground",
     "author": "WordPress VIP",
-    "categories": [
-      "Content"
-    ]
+    "categories": [ "Content" ]
   },
   "features": {
     "networking": true

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint:phpcs:fix": "vendor/bin/phpcbf",
     "lint:psalm": "vendor/bin/psalm.phar",
     "packages-update": "wp-scripts packages-update",
-    "playground": "npx @wp-now/wp-now start --php=8.2 --blueprint=blueprint.local.json",
+    "playground": "npx @wp-playground/cli server --mount=.:/wordpress/wp-content/plugins/remote-data-blocks --php=8.2 --blueprint=blueprint.local.json",
     "playground:reset": "npm run playground -- --reset",
     "plugin-zip": "npm run build && composer install --prefer-dist --optimize-autoloader --no-dev && wp-scripts plugin-zip",
     "postinstall": "composer install",


### PR DESCRIPTION
This will work, but we lose query monitor, so we may not want to go this way.