### PR TITLE
Add option for custom block icon 

### DIFF
--- a/example/rest-api/art-institute/art-institute.php
+++ b/example/rest-api/art-institute/art-institute.php
@@ -159,6 +159,7 @@ function register_aic_block(): void {
 
 	register_remote_data_block([
 		'title' => 'Art Institute of Chicago',
+		'icon' => 'art',
 		'render_query' => [
 			'query' => $get_art_query,
 		],

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -84,6 +84,7 @@ class BlockRegistration {
 			'selectors' => $config['selectors'],
 			'settings' => [
 				'category' => self::$block_category['slug'],
+				'icon' => $config['icon'] ?? 'cloud',
 				'title' => $config['title'],
 			],
 		];

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -76,6 +76,7 @@ class ConfigRegistry {
 		// @see BlockRegistration::register_block_type::register_blocks.
 		$config = [
 			'description' => '',
+			'icon' => $user_config['icon'] ?? 'cloud',
 			'name' => $block_name,
 			'loop' => $user_config[ self::RENDER_QUERY_KEY ]['loop'] ?? false,
 			'overrides' => $user_config['overrides'] ?? [],

--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -41,6 +41,7 @@ class AirtableIntegration {
 					array_merge(
 						[
 							'title' => $data_source->get_display_name() . '/' . $table['name'],
+							'icon' => 'editor-table',
 							'render_query' => [
 								'query' => $query,
 							],

--- a/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
@@ -41,6 +41,7 @@ class GoogleSheetsIntegration {
 				array_merge(
 					[
 						'title' => $data_source->get_display_name() . '/' . $sheet['name'],
+						'icon' => 'media-spreadsheet',
 						'render_query' => [
 							'query' => $query,
 						],

--- a/inc/Integrations/SalesforceD2C/SalesforceD2CIntegration.php
+++ b/inc/Integrations/SalesforceD2C/SalesforceD2CIntegration.php
@@ -154,6 +154,7 @@ class SalesforceD2CIntegration {
 		register_remote_data_block(
 			[
 				'title' => $data_source->get_display_name(),
+				'icon' => 'money-alt',
 				'render_query' => [
 					'query' => $queries['display'],
 				],

--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -124,6 +124,7 @@ class ShopifyIntegration {
 
 		register_remote_data_block( [
 			'title' => $block_title,
+			'icon' => 'cart',
 			'render_query' => [
 				'query' => $queries['shopify_get_product'],
 			],

--- a/inc/PluginSettings/PluginSettings.php
+++ b/inc/PluginSettings/PluginSettings.php
@@ -20,6 +20,11 @@ class PluginSettings {
 		add_action( 'pre_update_option_' . DataSourceCrud::CONFIG_OPTION_NAME, [ __CLASS__, 'encrypt_option' ], 10, 2 );
 		add_action( 'option_' . DataSourceCrud::CONFIG_OPTION_NAME, [ __CLASS__, 'decrypt_option' ], 10, 1 );
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_routes' ] );
+		// fix for dashicons not being enqueued in the editor:
+		// https://github.com/WordPress/gutenberg/issues/53528#issuecomment-1692717292
+		add_action( 'enqueue_block_assets', function (): void {
+			wp_enqueue_style( 'dashicons' );
+		} );
 	}
 
 	public static function add_options_page(): void {

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -65,6 +65,7 @@ final class ConfigSchemas {
 
 	private static function generate_remote_data_block_config_schema(): array {
 		return Types::object( [
+			'icon' => Types::nullable( Types::string() ),
 			'patterns' => Types::nullable(
 				Types::list_of(
 					Types::object( [

--- a/src/blocks/remote-data-container/block.json
+++ b/src/blocks/remote-data-container/block.json
@@ -5,7 +5,6 @@
   "version": "0.1.0",
   "title": "Remote Data Container",
   "category": "widgets",
-  "icon": "cloud",
   "description": "A container and context provider for Remote Data Blocks",
   "example": {},
   "providesContext": {

--- a/src/blocks/remote-data-container/components/placeholders/PlaceholderSingle.tsx
+++ b/src/blocks/remote-data-container/components/placeholders/PlaceholderSingle.tsx
@@ -14,8 +14,7 @@ export function PlaceholderSingle( props: PlaceholderSingleProps ) {
 
 	const supportsBulk = blockConfig?.selectors?.some( selector => selector.supports_bulk ) ?? false;
 
-	const { icon } = blockConfig.settings;
-	const iconElement = icon && typeof icon === 'string' ? ( icon as IconType ) : cloud;
+	const iconElement: IconType = ( blockConfig.settings.icon as IconType ) ?? cloud;
 
 	return (
 		<Placeholder

--- a/src/blocks/remote-data-container/components/placeholders/PlaceholderSingle.tsx
+++ b/src/blocks/remote-data-container/components/placeholders/PlaceholderSingle.tsx
@@ -1,4 +1,4 @@
-import { Placeholder } from '@wordpress/components';
+import { IconType, Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { cloud } from '@wordpress/icons';
 
@@ -14,9 +14,12 @@ export function PlaceholderSingle( props: PlaceholderSingleProps ) {
 
 	const supportsBulk = blockConfig?.selectors?.some( selector => selector.supports_bulk ) ?? false;
 
+	const { icon } = blockConfig.settings;
+	const iconElement = icon && typeof icon === 'string' ? ( icon as IconType ) : cloud;
+
 	return (
 		<Placeholder
-			icon={ cloud }
+			icon={ iconElement }
 			label={ blockConfig.settings.title }
 			instructions={
 				supportsBulk

--- a/types/localized-block-data.d.ts
+++ b/types/localized-block-data.d.ts
@@ -42,6 +42,7 @@ interface BlockConfig {
 	settings: {
 		category: string;
 		description?: string;
+		icon?: string;
 		title: string;
 	};
 }

--- a/types/localized-block-data.d.ts
+++ b/types/localized-block-data.d.ts
@@ -42,7 +42,7 @@ interface BlockConfig {
 	settings: {
 		category: string;
 		description?: string;
-		icon?: string;
+		icon?: ReactElement | IconType | ComponentType;
 		title: string;
 	};
 }


### PR DESCRIPTION
This exposes the `icon` property in the `block.json`, which can be added to the block config when registering a block. Currently, this only allows for Dashicons.

<img width="625" alt="Screenshot 2025-03-04 at 5 23 57 PM" src="https://github.com/user-attachments/assets/b2edd96e-bb53-4d00-8f5e-6d22ea8cf2c3" />
