### PR TITLE
Use string as effect dependency instead of array with indeterminate length

### DIFF
--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -110,7 +110,7 @@ export function ItemList( props: ItemListProps ) {
 			mediaField,
 			titleField,
 		} ) );
-	}, [ mediaField, titleField, ...tableFields ] );
+	}, [ [ mediaField, titleField, ...tableFields ].join( ';' ) ] );
 
 	function onChangeView( newView: View ) {
 		setPage( newView.page ?? 1 );


### PR DESCRIPTION
Fixes the React warning noted in [this comment](https://github.com/Automattic/remote-data-blocks/pull/406#issuecomment-2711909636).