### PR TITLE
Bugfix: Don't cache error results

### DIFF
--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -25,11 +25,13 @@ export function memoizeFn< T extends ( ...args: Parameters< T > ) => ReturnType<
 
 		const result = func( ...args );
 
-		// If the result is a Promise, only cache the resolved value.
+		// If the result is a Promise, ensure that it does not reject so that we
+		// do not cache a bad result. Wrap the resolved value in a Promise to ensure
+		// that it remains then-able.
 		if ( result instanceof Promise ) {
-			return result.then( ( resolvedResult: ReturnType< T > ) => {
-				cache.set( key, resolvedResult );
-				return resolvedResult;
+			return result.then( () => {
+				cache.set( key, result );
+				return result;
 			} ) as ReturnType< T >;
 		}
 

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -24,6 +24,15 @@ export function memoizeFn< T extends ( ...args: Parameters< T > ) => ReturnType<
 		}
 
 		const result = func( ...args );
+
+		// If the result is a Promise, only cache the resolved value.
+		if ( result instanceof Promise ) {
+			return result.then( ( resolvedResult: ReturnType< T > ) => {
+				cache.set( key, resolvedResult );
+				return resolvedResult;
+			} ) as ReturnType< T >;
+		}
+
 		cache.set( key, result );
 		return result;
 	};

--- a/tests/src/utils/function.test.ts
+++ b/tests/src/utils/function.test.ts
@@ -37,6 +37,25 @@ describe( 'function utils', () => {
 			expect( fn ).toHaveBeenCalledTimes( 3 );
 		} );
 
+		it( 'should cache a then-able promise if that is returned by the function', async () => {
+			const fn = vi.fn().mockImplementation( async ( arg: number ): Promise< string > => {
+				await Promise.resolve();
+				return `called with: ${ arg }`;
+			} );
+			const memoized = memoizeFn< ( arg: number ) => Promise< string > >( fn );
+
+			expect( await memoized( 1 ) ).toEqual( 'called with: 1' );
+			expect( await memoized( 1 ) ).toEqual( 'called with: 1' );
+
+			const thenPromise = new Promise< string >( ( resolve, reject ) => {
+				memoized( 1 ).then( resolve ).catch( reject );
+			} );
+
+			expect( await thenPromise ).toEqual( 'called with: 1' );
+
+			expect( fn ).toHaveBeenCalledTimes( 1 );
+		} );
+
 		it( 'should not cache promise rejections', async () => {
 			const fn = vi
 				.fn()

--- a/tests/src/utils/function.test.ts
+++ b/tests/src/utils/function.test.ts
@@ -18,5 +18,78 @@ describe( 'function utils', () => {
 
 			expect( fn ).toHaveBeenCalledTimes( 3 );
 		} );
+
+		it( 'should cache repeated calls of async function', async () => {
+			const fn = vi.fn().mockImplementation( async ( arg: number ): Promise< string > => {
+				await Promise.resolve();
+				return `called with: ${ arg }`;
+			} );
+			const memoized = memoizeFn( fn );
+
+			expect( await memoized( 1 ) ).toEqual( 'called with: 1' );
+			expect( await memoized( 1 ) ).toEqual( 'called with: 1' );
+			expect( await memoized( 2 ) ).toEqual( 'called with: 2' );
+			expect( await memoized( 2 ) ).toEqual( 'called with: 2' );
+			expect( await memoized( 2 ) ).toEqual( 'called with: 2' );
+			expect( await memoized( 3 ) ).toEqual( 'called with: 3' );
+			expect( await memoized( 3 ) ).toEqual( 'called with: 3' );
+
+			expect( fn ).toHaveBeenCalledTimes( 3 );
+		} );
+
+		it( 'should not cache promise rejections', async () => {
+			const fn = vi
+				.fn()
+				.mockImplementation(
+					async ( arg: number ): Promise< string > =>
+						Promise.reject( new Error( `rejected with: ${ arg }` ) )
+				);
+			const memoized = memoizeFn( fn );
+
+			await expect( memoized( 1 ) ).rejects.toThrowError( 'rejected with: 1' );
+			await expect( memoized( 1 ) ).rejects.toThrowError( 'rejected with: 1' );
+			await expect( memoized( 2 ) ).rejects.toThrowError( 'rejected with: 2' );
+			await expect( memoized( 2 ) ).rejects.toThrowError( 'rejected with: 2' );
+			await expect( memoized( 2 ) ).rejects.toThrowError( 'rejected with: 2' );
+			await expect( memoized( 3 ) ).rejects.toThrowError( 'rejected with: 3' );
+			await expect( memoized( 3 ) ).rejects.toThrowError( 'rejected with: 3' );
+
+			expect( fn ).toHaveBeenCalledTimes( 7 );
+		} );
+
+		it( 'should not cache promise rejections via thrown errors', async () => {
+			const fn = vi.fn().mockImplementation( async ( arg: number ): Promise< string > => {
+				await Promise.resolve();
+				throw new Error( `rejected with: ${ arg }` );
+			} );
+			const memoized = memoizeFn( fn );
+
+			await expect( memoized( 1 ) ).rejects.toThrowError( 'rejected with: 1' );
+			await expect( memoized( 1 ) ).rejects.toThrowError( 'rejected with: 1' );
+			await expect( memoized( 2 ) ).rejects.toThrowError( 'rejected with: 2' );
+			await expect( memoized( 2 ) ).rejects.toThrowError( 'rejected with: 2' );
+			await expect( memoized( 2 ) ).rejects.toThrowError( 'rejected with: 2' );
+			await expect( memoized( 3 ) ).rejects.toThrowError( 'rejected with: 3' );
+			await expect( memoized( 3 ) ).rejects.toThrowError( 'rejected with: 3' );
+
+			expect( fn ).toHaveBeenCalledTimes( 7 );
+		} );
+
+		it( 'should not cache thrown errors', () => {
+			const fn = vi.fn< ( arg: number ) => never >().mockImplementation( ( arg: number ): never => {
+				throw new Error( `thrown with: ${ arg }` );
+			} );
+			const memoized = memoizeFn( fn );
+
+			expect( () => memoized( 1 ) ).toThrowError( 'thrown with: 1' );
+			expect( () => memoized( 1 ) ).toThrowError( 'thrown with: 1' );
+			expect( () => memoized( 2 ) ).toThrowError( 'thrown with: 2' );
+			expect( () => memoized( 2 ) ).toThrowError( 'thrown with: 2' );
+			expect( () => memoized( 2 ) ).toThrowError( 'thrown with: 2' );
+			expect( () => memoized( 3 ) ).toThrowError( 'thrown with: 3' );
+			expect( () => memoized( 3 ) ).toThrowError( 'thrown with: 3' );
+
+			expect( fn ).toHaveBeenCalledTimes( 7 );
+		} );
 	} );
 } );


### PR DESCRIPTION
Bugfix to prevent memoizeFn from caching Promise rejections.