### PR TITLE
Airtable pagination support

### DIFF
--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -78,7 +78,7 @@ class AirtableIntegration {
 		}
 	}
 
-	private static function get_item_query( AirtableDataSource $data_source, array $table ): array {
+	public static function get_item_query( AirtableDataSource $data_source, array $table ): array {
 		return [
 			'__class' => HttpQuery::class,
 			'data_source' => $data_source,
@@ -127,7 +127,7 @@ class AirtableIntegration {
 		return $output_schema;
 	}
 
-	private static function get_list_query( AirtableDataSource $data_source, array $table ): array {
+	public static function get_list_query( AirtableDataSource $data_source, array $table ): array {
 		return [
 			'__class' => HttpQuery::class,
 			'data_source' => $data_source,

--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -6,7 +6,6 @@ use RemoteDataBlocks\Store\DataSource\DataSourceConfigManager;
 use RemoteDataBlocks\Config\Query\HttpQuery;
 use RemoteDataBlocks\Formatting\StringFormatter;
 use RemoteDataBlocks\Snippet\Snippet;
-use WP_Error;
 
 class AirtableIntegration {
 	public static function init(): void {
@@ -34,20 +33,17 @@ class AirtableIntegration {
 		$tables = $data_source->to_array()['service_config']['tables'];
 
 		foreach ( $tables as $table ) {
-				$query = self::get_query( $data_source, $table );
-				$list_query = self::get_list_query( $data_source, $table );
-
 				register_remote_data_block(
 					array_merge(
 						[
 							'title' => $data_source->get_display_name() . '/' . $table['name'],
 							'icon' => 'editor-table',
 							'render_query' => [
-								'query' => $query,
+								'query' => self::get_item_query( $data_source, $table ),
 							],
 							'selection_queries' => [
 								[
-									'query' => $list_query,
+									'query' => self::get_list_query( $data_source, $table ),
 									'type' => 'list',
 								],
 							],
@@ -82,21 +78,9 @@ class AirtableIntegration {
 		}
 	}
 
-	public static function get_query( AirtableDataSource $data_source, array $table ): HttpQuery|WP_Error {
-		$input_schema = [
-			'record_id' => [
-				'name' => 'Record ID',
-				'type' => 'id:list',
-			],
-		];
-
-		$output_schema = [
-			'is_collection' => true,
-			'path' => '$.records[*]',
-			'type' => self::get_airtable_output_schema_mappings( $table ),
-		];
-
-		return HttpQuery::from_array( [
+	private static function get_item_query( AirtableDataSource $data_source, array $table ): array {
+		return [
+			'__class' => HttpQuery::class,
 			'data_source' => $data_source,
 			'endpoint' => function ( array $input_variables ) use ( $data_source, $table ): string {
 				// Build the formula
@@ -108,9 +92,18 @@ class AirtableIntegration {
 
 				return $data_source->get_endpoint() . '/' . $table['id'] . '?filterByFormula=' . urlencode( $formula );
 			},
-			'input_schema' => $input_schema,
-			'output_schema' => $output_schema,
-		] );
+			'input_schema' => [
+				'record_id' => [
+					'name' => 'Record ID',
+					'type' => 'id:list',
+				],
+			],
+			'output_schema' => [
+				'is_collection' => true,
+				'path' => '$.records[*]',
+				'type' => self::get_airtable_output_schema_mappings( $table ),
+			],
+		];
 	}
 
 	private static function get_airtable_output_schema_mappings( array $table ): array {
@@ -134,19 +127,50 @@ class AirtableIntegration {
 		return $output_schema;
 	}
 
-	public static function get_list_query( AirtableDataSource $data_source, array $table ): HttpQuery|WP_Error {
-		$output_schema = [
-			'is_collection' => true,
-			'path' => '$.records[*]',
-			'type' => self::get_airtable_output_schema_mappings( $table ),
-		];
-
-		return HttpQuery::from_array( [
+	private static function get_list_query( AirtableDataSource $data_source, array $table ): array {
+		return [
+			'__class' => HttpQuery::class,
 			'data_source' => $data_source,
-			'endpoint' => $data_source->get_endpoint() . '/' . $table['id'],
-			'input_schema' => [],
-			'output_schema' => $output_schema,
-		] );
+			'endpoint' => function ( array $input_variables ) use ( $data_source, $table ): string {
+				$endpoint = $data_source->get_endpoint() . '/' . $table['id'];
+
+				if ( isset( $input_variables['cursor'] ) ) {
+					// While named as "offset", this is implemented as a string cursor.
+					$endpoint = add_query_arg( 'offset', $input_variables['cursor'], $endpoint );
+				}
+
+				if ( isset( $input_variables['page_size'] ) ) {
+					$endpoint = add_query_arg( 'pageSize', $input_variables['page_size'], $endpoint );
+				}
+
+				return $endpoint;
+			},
+			'input_schema' => [
+				'cursor' => [
+					'name' => 'Pagination cursor',
+					'required' => false,
+					'type' => 'ui:pagination_cursor',
+				],
+				'page_size' => [
+					'default_value' => 20,
+					'name' => 'Page Size',
+					'required' => false,
+					'type' => 'ui:pagination_per_page',
+				],
+			],
+			'output_schema' => [
+				'is_collection' => true,
+				'path' => '$.records[*]',
+				'type' => self::get_airtable_output_schema_mappings( $table ),
+			],
+			'pagination_schema' => [
+				'cursor_next' => [
+					'name' => 'Next page cursor',
+					'path' => '$.offset', // named "offset" but functions as cursor
+					'type' => 'string',
+				],
+			],
+		];
 	}
 
 	private static function get_output_schema_mappings_snippet( array $table ): string {

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -241,6 +241,11 @@ final class ConfigSchemas {
 							// and offset-based pagination variables.
 							'ui:pagination_cursor_next',
 							'ui:pagination_cursor_previous',
+							//
+							// Some APIs provide a single pagination cursor that is used for
+							// both previous and next pages. If specified, this variable
+							// takes precedence over next and previous cursor variables.
+							'ui:pagination_cursor',
 						),
 						'required' => Types::nullable( Types::boolean() ),
 					] ),

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -308,8 +308,9 @@ final class ConfigSchemas {
 					// `has_next_page` must be defined in order to enable pagination.
 					'total_items' => Types::nullable(
 						Types::object( [
+							'generate' => Types::nullable( Types::callable() ),
 							'name' => Types::nullable( Types::string() ),
-							'path' => Types::json_path(),
+							'path' => Types::nullable( Types::json_path() ),
 							'type' => Types::enum( 'integer' ),
 						] ),
 					),
@@ -318,8 +319,9 @@ final class ConfigSchemas {
 					// field must be defined in order to enable cursor-based pagination.
 					'cursor_next' => Types::nullable(
 						Types::object( [
+							'generate' => Types::nullable( Types::callable() ),
 							'name' => Types::nullable( Types::string() ),
-							'path' => Types::json_path(),
+							'path' => Types::nullable( Types::json_path() ),
 							'type' => Types::enum( 'string' ),
 						] ),
 					),
@@ -328,8 +330,9 @@ final class ConfigSchemas {
 					// field must be defined in order to enable cursor-based pagination.
 					'cursor_previous' => Types::nullable(
 						Types::object( [
+							'generate' => Types::nullable( Types::callable() ),
 							'name' => Types::nullable( Types::string() ),
-							'path' => Types::json_path(),
+							'path' => Types::nullable( Types::json_path() ),
 							'type' => Types::enum( 'string' ),
 						] ),
 					),
@@ -338,8 +341,9 @@ final class ConfigSchemas {
 					// total number of items.
 					'has_next_page' => Types::nullable(
 						Types::object( [
+							'generate' => Types::nullable( Types::callable() ),
 							'name' => Types::nullable( Types::string() ),
-							'path' => Types::json_path(),
+							'path' => Types::nullable( Types::json_path() ),
 							'type' => Types::enum( 'boolean' ),
 						] )
 					),

--- a/src/blocks/remote-data-container/config/constants.ts
+++ b/src/blocks/remote-data-container/config/constants.ts
@@ -14,6 +14,7 @@ export const REMOTE_DATA_REST_API_URL = getRestUrl();
 
 export const CONTAINER_CLASS_NAME = getClassName( 'container' );
 
+export const PAGINATION_CURSOR_VARIABLE_TYPE = 'ui:pagination_cursor';
 export const PAGINATION_CURSOR_NEXT_VARIABLE_TYPE = 'ui:pagination_cursor_next';
 export const PAGINATION_CURSOR_PREVIOUS_VARIABLE_TYPE = 'ui:pagination_cursor_previous';
 export const PAGINATION_OFFSET_VARIABLE_TYPE = 'ui:pagination_offset';

--- a/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
+++ b/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
@@ -3,6 +3,7 @@ import { useState } from '@wordpress/element';
 import {
 	PAGINATION_CURSOR_NEXT_VARIABLE_TYPE,
 	PAGINATION_CURSOR_PREVIOUS_VARIABLE_TYPE,
+	PAGINATION_CURSOR_VARIABLE_TYPE,
 	PAGINATION_OFFSET_VARIABLE_TYPE,
 	PAGINATION_PAGE_VARIABLE_TYPE,
 	PAGINATION_PER_PAGE_VARIABLE_TYPE,
@@ -16,9 +17,6 @@ interface UsePaginationVariables {
 	perPage?: number;
 	setPage: ( page: number ) => void;
 	setPerPage: ( perPage: number ) => void;
-	supportsCursorPagination: boolean;
-	supportsOffsetPagination: boolean;
-	supportsPagePagination: boolean;
 	supportsPagination: boolean;
 	supportsPerPage: boolean;
 	totalItems?: number;
@@ -31,6 +29,19 @@ interface UsePaginationVariablesInput {
 	inputVariables: InputVariable[];
 }
 
+interface PaginationCursors {
+	next?: string;
+	previous?: string;
+}
+
+export enum PaginationType {
+	CURSOR_SIMPLE = 'cursor_simple',
+	CURSOR = 'cursor',
+	OFFSET = 'offset',
+	NONE = 'none',
+	PAGE = 'page',
+}
+
 export function usePaginationVariables( {
 	initialPage = 1,
 	initialPerPage,
@@ -39,7 +50,11 @@ export function usePaginationVariables( {
 	const [ paginationData, setPaginationData ] = useState< RemoteDataPagination >();
 	const [ page, setPage ] = useState< number >( initialPage );
 	const [ perPage, setPerPage ] = useState< number | null >( initialPerPage ?? null );
+	const [ cursors, setCursors ] = useState< PaginationCursors >( {} );
 
+	const cursorVariable = inputVariables?.find(
+		input => input.type === PAGINATION_CURSOR_VARIABLE_TYPE
+	);
 	const cursorNextVariable = inputVariables?.find(
 		input => input.type === PAGINATION_CURSOR_NEXT_VARIABLE_TYPE
 	);
@@ -57,27 +72,38 @@ export function usePaginationVariables( {
 	);
 
 	const paginationQueryInput: RemoteDataQueryInput = {};
+	const nonFirstPage = page > 1;
+	const calculatedPerPage = perPage ?? paginationData?.perPage ?? 10;
 
 	// These will be amended below.
-	let supportsCursorPagination = false;
-	let supportsOffsetPagination = false;
-	let supportsPagePagination = false;
+	let hasNextPage = Boolean( paginationData?.hasNextPage ?? paginationData?.cursorNext );
+	let paginationType = PaginationType.NONE;
 	let setPageFn: ( page: number ) => void = () => {};
 
-	if ( cursorNextVariable && cursorPreviousVariable ) {
+	if ( cursorVariable ) {
+		paginationType = PaginationType.CURSOR_SIMPLE;
 		setPageFn = setPageForCursorPagination;
-		supportsCursorPagination = true;
 		Object.assign( paginationQueryInput, {
-			[ cursorNextVariable.slug ]: paginationData?.cursorNext,
-			[ cursorPreviousVariable.slug ]: paginationData?.cursorPrevious,
+			[ cursorVariable.slug ]: cursors.next ?? cursors.previous,
 		} );
-	} else if ( offsetVariable && perPage ) {
+	} else if ( cursorNextVariable && cursorPreviousVariable ) {
+		paginationType = PaginationType.CURSOR;
+		setPageFn = setPageForCursorPagination;
+		Object.assign( paginationQueryInput, {
+			[ cursorNextVariable.slug ]: cursors.next,
+			[ cursorPreviousVariable.slug ]: cursors.previous,
+		} );
+	} else if ( offsetVariable ) {
+		paginationType = PaginationType.OFFSET;
 		setPageFn = setPage;
-		supportsOffsetPagination = true;
-		Object.assign( paginationQueryInput, { [ offsetVariable.slug ]: page * perPage } );
+		if ( nonFirstPage ) {
+			Object.assign( paginationQueryInput, {
+				[ offsetVariable.slug ]: ( page - 1 ) * calculatedPerPage,
+			} );
+		}
 	} else if ( pageVariable ) {
+		paginationType = PaginationType.PAGE;
 		setPageFn = setPage;
-		supportsPagePagination = true;
 		Object.assign( paginationQueryInput, { [ pageVariable.slug ]: page } );
 	}
 
@@ -85,43 +111,44 @@ export function usePaginationVariables( {
 		Object.assign( paginationQueryInput, { [ perPageVariable.slug ]: perPage } );
 	}
 
+	const supportsPagination = paginationType !== PaginationType.NONE;
 	const totalItems = paginationData?.totalItems;
-	const totalPages = totalItems && perPage ? Math.ceil( totalItems / perPage ) : undefined;
-	const hasNextPage = paginationData?.hasNextPage;
-	const supportsPagination =
-		supportsCursorPagination ||
-		supportsPagePagination ||
-		supportsOffsetPagination ||
-		hasNextPage ||
-		Boolean( totalItems );
+	const totalPages = totalItems ? Math.ceil( totalItems / calculatedPerPage ) : undefined;
+
+	if ( totalPages && page < totalPages ) {
+		hasNextPage = true;
+	}
 
 	function onFetch( remoteData: RemoteData ): void {
 		if ( ! supportsPagination ) {
 			return;
 		}
 
-		setPaginationData( remoteData.pagination );
-
-		// We need a perPage value to calculate the total pages, so inpsect the results.
-		if ( ! perPage && remoteData.results.length ) {
-			setPerPage( remoteData.results.length );
-		}
+		setPaginationData( {
+			perPage: perPage ?? remoteData.results.length,
+			...remoteData.pagination,
+		} );
 	}
 
 	// With cursor pagination, we can only go one page at a time.
 	function setPageForCursorPagination( newPage: number ): void {
+		// if page has gone up, we want to use nextCursor and set aside the current cursor as the previous one
+		// if the page has gone down, we want to use previousCursor and set aside the current cursor as the next one
 		if ( newPage > page ) {
-			if ( totalPages ) {
-				setPage( Math.min( totalPages, page + 1 ) );
-				return;
-			}
-
-			setPage( page + 1 );
+			setPage( Math.min( totalPages ?? page + 1, page + 1 ) );
+			setCursors( {
+				next: paginationData?.cursorNext ?? cursors.next,
+				previous: undefined,
+			} );
 			return;
 		}
 
 		if ( newPage < page ) {
 			setPage( Math.max( 1, page - 1 ) );
+			setCursors( {
+				next: undefined,
+				previous: paginationData?.cursorPrevious ?? cursors.previous,
+			} );
 		}
 	}
 
@@ -130,12 +157,9 @@ export function usePaginationVariables( {
 		onFetch,
 		page,
 		paginationQueryInput,
-		perPage: perPage ?? undefined,
+		perPage: perPage ?? paginationData?.perPage,
 		setPage: setPageFn,
 		setPerPage: supportsPagination ? setPerPage : () => {},
-		supportsCursorPagination,
-		supportsOffsetPagination,
-		supportsPagePagination,
 		supportsPagination,
 		supportsPerPage: Boolean( perPageVariable ),
 		totalItems,

--- a/src/blocks/remote-data-container/hooks/useRemoteData.ts
+++ b/src/blocks/remote-data-container/hooks/useRemoteData.ts
@@ -59,9 +59,6 @@ interface UseRemoteData {
 	setPage: ( page: number ) => void;
 	setPerPage: ( perPage: number ) => void;
 	setSearchInput: ( searchInput: string ) => void;
-	supportsCursorPagination: boolean;
-	supportsOffsetPagination: boolean;
-	supportsPagePagination: boolean;
 	supportsPagination: boolean;
 	supportsPerPage: boolean;
 	supportsSearch: boolean;

--- a/tests/src/blocks/remote-data-container/hooks/usePaginationVariables.test.ts
+++ b/tests/src/blocks/remote-data-container/hooks/usePaginationVariables.test.ts
@@ -1,0 +1,332 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+	PAGINATION_CURSOR_NEXT_VARIABLE_TYPE,
+	PAGINATION_CURSOR_PREVIOUS_VARIABLE_TYPE,
+	PAGINATION_CURSOR_VARIABLE_TYPE,
+	PAGINATION_OFFSET_VARIABLE_TYPE,
+	PAGINATION_PAGE_VARIABLE_TYPE,
+	PAGINATION_PER_PAGE_VARIABLE_TYPE,
+} from '@/blocks/remote-data-container/config/constants';
+import { usePaginationVariables } from '@/blocks/remote-data-container/hooks/usePaginationVariables';
+
+function generateRemoteData(
+	resultCount: number,
+	paginationData: RemoteDataPagination
+): RemoteData {
+	return {
+		blockName: 'test/block',
+		queryKey: 'test-query',
+		queryInputs: [],
+		metadata: {},
+		resultId: 'result-id',
+		results: Array.from( { length: resultCount }, () => ( {
+			result: {},
+			uuid: 'uuid',
+		} ) ),
+		pagination: paginationData,
+	};
+}
+
+describe( 'usePaginationVariables', () => {
+	it( 'provides static variables when pagination is not supported', () => {
+		const inputVariables: InputVariable[] = [];
+
+		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBeUndefined();
+		expect( result.current.supportsPagination ).toBe( false );
+
+		// Simulate remote data fetch
+		act( () => {
+			result.current.onFetch(
+				generateRemoteData( 5, {
+					cursorNext: 'cursor-next',
+					totalItems: 100,
+				} )
+			);
+		} );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBeUndefined();
+		expect( result.current.supportsPagination ).toBe( false );
+		expect( result.current.totalItems ).toBeUndefined();
+		expect( result.current.totalPages ).toBeUndefined();
+
+		// Update page and per-page
+		act( () => result.current.setPage( 2 ) );
+		act( () => result.current.setPerPage( 50 ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBeUndefined();
+		expect( result.current.supportsPagination ).toBe( false );
+		expect( result.current.totalItems ).toBeUndefined();
+		expect( result.current.totalPages ).toBeUndefined();
+	} );
+
+	it( 'supports initial page and per-page input', () => {
+		const inputVariables: InputVariable[] = [];
+
+		const { result } = renderHook( () =>
+			usePaginationVariables( { initialPage: 11, initialPerPage: 27, inputVariables } )
+		);
+
+		expect( result.current.page ).toBe( 11 );
+		expect( result.current.perPage ).toBe( 27 );
+		expect( result.current.supportsPagination ).toBe( false );
+	} );
+
+	it( 'supports page-based pagination', () => {
+		const inputVariables = [
+			{
+				required: false,
+				slug: 'page',
+				type: PAGINATION_PAGE_VARIABLE_TYPE,
+			},
+			{
+				required: false,
+				slug: 'perPage',
+				type: PAGINATION_PER_PAGE_VARIABLE_TYPE,
+			},
+		];
+
+		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBeUndefined();
+		expect( result.current.supportsPagination ).toBe( true );
+
+		// Simulate remote data fetch
+		act( () => {
+			result.current.onFetch(
+				generateRemoteData( 5, {
+					totalItems: 100,
+				} )
+			);
+		} );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBe( 5 );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 100 );
+		expect( result.current.totalPages ).toBe( 20 );
+
+		// Update page
+		act( () => result.current.setPage( 3 ) );
+
+		expect( result.current.page ).toBe( 3 );
+		expect( result.current.perPage ).toBe( 5 );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 100 );
+		expect( result.current.totalPages ).toBe( 20 );
+
+		// Update per-page
+		act( () => result.current.setPerPage( 25 ) );
+
+		expect( result.current.page ).toBe( 3 );
+		expect( result.current.perPage ).toBe( 25 );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 100 );
+		expect( result.current.totalPages ).toBe( 4 );
+	} );
+
+	it( 'should support cursor pagination', () => {
+		const inputVariables = [
+			{
+				required: false,
+				slug: 'next',
+				type: PAGINATION_CURSOR_NEXT_VARIABLE_TYPE,
+			},
+			{
+				required: false,
+				slug: 'previous',
+				type: PAGINATION_CURSOR_PREVIOUS_VARIABLE_TYPE,
+			},
+		];
+
+		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBeUndefined();
+		expect( result.current.supportsPagination ).toBe( true );
+
+		// Simulate remote data fetch
+		act( () => {
+			result.current.onFetch(
+				generateRemoteData( 10, {
+					cursorNext: 'test-next-cursor',
+					totalItems: 115,
+				} )
+			);
+		} );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBe( 10 );
+		expect( result.current.paginationQueryInput ).toEqual( {} );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 115 );
+		expect( result.current.totalPages ).toBe( 12 );
+
+		// Update page + 2
+		act( () => result.current.setPage( 3 ) );
+
+		expect( result.current.page ).toBe( 2 ); // can only go one at a time
+		expect( result.current.perPage ).toBe( 10 );
+		expect( result.current.paginationQueryInput ).toEqual( { next: 'test-next-cursor' } );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 115 );
+		expect( result.current.totalPages ).toBe( 12 );
+
+		// Simulate remote data fetch
+		act( () => {
+			result.current.onFetch(
+				generateRemoteData( 15, {
+					cursorNext: 'test-next-cursor-2',
+					cursorPrevious: 'test-previous-cursor',
+					totalItems: 105,
+				} )
+			);
+		} );
+
+		// Update page - 1
+		act( () => result.current.setPage( 1 ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBe( 15 );
+		expect( result.current.paginationQueryInput ).toEqual( { previous: 'test-previous-cursor' } );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 105 );
+		expect( result.current.totalPages ).toBe( 7 );
+	} );
+
+	it( 'should support "simple" cursor pagination', () => {
+		const inputVariables = [
+			{
+				required: false,
+				slug: 'cursor',
+				type: PAGINATION_CURSOR_VARIABLE_TYPE,
+			},
+		];
+
+		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBeUndefined();
+		expect( result.current.supportsPagination ).toBe( true );
+
+		// Simulate remote data fetch
+		act( () => {
+			result.current.onFetch(
+				generateRemoteData( 10, {
+					cursorNext: 'test-next-cursor',
+					totalItems: 115,
+				} )
+			);
+		} );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBe( 10 );
+		expect( result.current.paginationQueryInput ).toEqual( {} );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 115 );
+		expect( result.current.totalPages ).toBe( 12 );
+
+		// Update page + 2
+		act( () => result.current.setPage( 3 ) );
+
+		expect( result.current.page ).toBe( 2 ); // can only go one at a time
+		expect( result.current.perPage ).toBe( 10 );
+		expect( result.current.paginationQueryInput ).toEqual( { cursor: 'test-next-cursor' } );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 115 );
+		expect( result.current.totalPages ).toBe( 12 );
+
+		// Simulate remote data fetch
+		act( () => {
+			result.current.onFetch(
+				generateRemoteData( 15, {
+					cursorNext: 'test-next-cursor-2',
+					totalItems: 105,
+				} )
+			);
+		} );
+
+		// Update page - 1
+		act( () => result.current.setPage( 1 ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBe( 15 );
+		expect( result.current.paginationQueryInput ).toEqual( {} );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 105 );
+		expect( result.current.totalPages ).toBe( 7 );
+	} );
+
+	it( 'should support offset pagination', () => {
+		const inputVariables = [
+			{
+				required: false,
+				slug: 'offset',
+				type: PAGINATION_OFFSET_VARIABLE_TYPE,
+			},
+			{
+				required: false,
+				slug: 'perPage',
+				type: PAGINATION_PER_PAGE_VARIABLE_TYPE,
+			},
+		];
+
+		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBeUndefined();
+		expect( result.current.supportsPagination ).toBe( true );
+
+		// Simulate remote data fetch
+		act( () => {
+			result.current.onFetch(
+				generateRemoteData( 10, {
+					totalItems: 115,
+				} )
+			);
+		} );
+
+		expect( result.current.page ).toBe( 1 );
+		expect( result.current.perPage ).toBe( 10 );
+		expect( result.current.paginationQueryInput ).toEqual( {} );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 115 );
+		expect( result.current.totalPages ).toBe( 12 );
+
+		// Update page + 2
+		act( () => result.current.setPage( 3 ) );
+
+		expect( result.current.page ).toBe( 3 );
+		expect( result.current.perPage ).toBe( 10 );
+		expect( result.current.paginationQueryInput ).toEqual( { offset: 20 } );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 115 );
+		expect( result.current.totalPages ).toBe( 12 );
+
+		// Simulate remote data fetch
+		act( () => {
+			result.current.onFetch(
+				generateRemoteData( 15, {
+					totalItems: 105,
+				} )
+			);
+		} );
+
+		// Update page - 1
+		act( () => result.current.setPage( 2 ) );
+
+		expect( result.current.page ).toBe( 2 );
+		expect( result.current.perPage ).toBe( 15 );
+		expect( result.current.paginationQueryInput ).toEqual( { offset: 15 } );
+		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.totalItems ).toBe( 105 );
+		expect( result.current.totalPages ).toBe( 7 );
+	} );
+} );

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -6,6 +6,7 @@ interface RemoteDataPagination {
 	cursorNext?: string;
 	cursorPrevious?: string;
 	hasNextPage?: boolean;
+	perPage?: number;
 	totalItems?: number;
 }
 
@@ -102,4 +103,5 @@ interface RemoteDataApiResponseBody {
 
 interface RemoteDataApiResponse {
 	body?: RemoteDataApiResponseBody;
+	status?: number;
 }


### PR DESCRIPTION
Add support for pagination to Airtable queries. Airtable has a very odd [pagination scheme](https://airtable.com/developers/web/api/list-records), which it calls "offset" but is in fact a kind cursor pagination with a single cursor (instead of next and previous cursors).

Accordingly, I've added a new pagination type called "simple cursor" pagination. This required some refactoring of `usePaginationVariables`, but I took the opportunity to add tests. Thanks @brookewp for leading the way!
