### PR TITLE
Bugfix: Loading state in DataViews when paginating

### DIFF
--- a/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
@@ -111,7 +111,7 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 						onSelect={ save }
 						onSelectField={ onSelectField }
 						page={ page }
-						results={ data?.results }
+						results={ loading ? undefined : data?.results }
 						searchInput={ searchInput }
 						selectionIds={ selectionIds }
 						setPage={ setPage }


### PR DESCRIPTION
Currently when navigating through pages of results in DataViews, the user never sees a loading state. This is because the previous results continue to be passed to the component, which overrides the `loading` prop. This leads to some confusing "did it work?" UX:

https://github.com/user-attachments/assets/0f30c81c-8a8c-42ab-a4f7-a8b87a118b02

Instead we can withhold the results when the request is loading:

https://github.com/user-attachments/assets/4f5b243f-623a-41ed-90cb-f2a48fb93cd0


Also noticing some alignment issues for the pagination links, not sure if that's because of our overlay or not. cc: @brookewp 