### PR TITLE
Fix: pattern selection missing after making duplicate selection

### DIFF
--- a/src/blocks/remote-data-container/hooks/usePatterns.ts
+++ b/src/blocks/remote-data-container/hooks/usePatterns.ts
@@ -35,13 +35,27 @@ export function cloneBlockWithAttributes(
 export function usePatterns( remoteDataBlockName: string, rootClientId: string = '' ) {
 	const { patterns } = getBlockConfig( remoteDataBlockName ) ?? {};
 	const { replaceInnerBlocks } = useDispatch< BlockEditorStoreActions >( blockEditorStore );
-	const { getBlocks, getPatternsByBlockTypes, __experimentalGetAllowedPatterns } =
-		useSelect< BlockEditorStoreSelectors >( blockEditorStore, [
-			remoteDataBlockName,
-			[ remoteDataBlockName, rootClientId ],
-		] );
 
-	// Extract patterns with defined roles.
+	// Use `useSelect` and correctly type its return value
+	const { getBlocks, getPatternsByBlockTypes, allowedPatterns } = useSelect(
+		(
+			select
+		): {
+			getBlocks: BlockEditorStoreSelectors[ 'getBlocks' ];
+			getPatternsByBlockTypes: BlockEditorStoreSelectors[ 'getPatternsByBlockTypes' ];
+			allowedPatterns: BlockPattern[];
+		} => {
+			const store = select( blockEditorStore ) as BlockEditorStoreSelectors;
+			return {
+				getBlocks: store.getBlocks,
+				getPatternsByBlockTypes: store.getPatternsByBlockTypes,
+				allowedPatterns: store.__experimentalGetAllowedPatterns( rootClientId ) ?? [],
+			};
+		},
+		[ remoteDataBlockName, rootClientId ]
+	);
+
+	// Extract patterns with defined roles
 	const patternsByBlockTypes = getPatternsByBlockTypes( remoteDataBlockName );
 	const defaultPattern = patternsByBlockTypes.find( ( { name } ) => name === patterns?.default );
 	const innerBlocksPattern = patternsByBlockTypes.find(
@@ -58,11 +72,16 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 			);
 		},
 		getSupportedPatterns: ( result?: RemoteDataApiResult ): BlockPattern[] => {
-			const supportedPatterns = __experimentalGetAllowedPatterns( rootClientId ).filter(
+			const supportedPatterns = allowedPatterns.filter(
 				pattern =>
 					pattern?.blockTypes?.includes( remoteDataBlockName ) ||
 					pattern.blocks.some( block => hasBlockBinding( block, remoteDataBlockName ) )
 			);
+
+			// Return early if there are no supported patterns
+			if ( ! supportedPatterns.length ) {
+				return [];
+			}
 
 			// If no result is provided, return the supported patterns as is.
 			if ( ! result ) {
@@ -93,7 +112,7 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 			// of the collection.
 			const patternBlocks =
 				pattern.blocks.map( block => {
-					const boundAttributes = getBoundAttributeEntries( block.attributes, remoteDataBlockName );
+				const boundAttributes = getBoundAttributeEntries( block.attributes, remoteDataBlockName );
 
 					if ( ! boundAttributes.length ) {
 						return block;

--- a/src/blocks/remote-data-container/hooks/usePatterns.ts
+++ b/src/blocks/remote-data-container/hooks/usePatterns.ts
@@ -36,15 +36,14 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 	const { patterns } = getBlockConfig( remoteDataBlockName ) ?? {};
 	const { replaceInnerBlocks } = useDispatch< BlockEditorStoreActions >( blockEditorStore );
 
-	const { getBlocks, getPatternsByBlockTypes, allowedPatterns } = useSelect(
-		(
-			select
-		): {
-			getBlocks: BlockEditorStoreSelectors[ 'getBlocks' ];
-			getPatternsByBlockTypes: BlockEditorStoreSelectors[ 'getPatternsByBlockTypes' ];
+	const { getBlocks, getPatternsByBlockTypes, allowedPatterns } = useSelect<
+		BlockEditorStoreSelectors,
+		Pick< BlockEditorStoreSelectors, 'getBlocks' | 'getPatternsByBlockTypes' > & {
 			allowedPatterns: BlockPattern[];
-		} => {
-			const store = select( blockEditorStore ) as BlockEditorStoreSelectors;
+		}
+	>(
+		select => {
+			const store = select( blockEditorStore );
 			return {
 				getBlocks: store.getBlocks,
 				getPatternsByBlockTypes: store.getPatternsByBlockTypes,

--- a/src/blocks/remote-data-container/hooks/usePatterns.ts
+++ b/src/blocks/remote-data-container/hooks/usePatterns.ts
@@ -36,7 +36,6 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 	const { patterns } = getBlockConfig( remoteDataBlockName ) ?? {};
 	const { replaceInnerBlocks } = useDispatch< BlockEditorStoreActions >( blockEditorStore );
 
-	// Use `useSelect` and correctly type its return value
 	const { getBlocks, getPatternsByBlockTypes, allowedPatterns } = useSelect(
 		(
 			select
@@ -78,11 +77,6 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 					pattern.blocks.some( block => hasBlockBinding( block, remoteDataBlockName ) )
 			);
 
-			// Return early if there are no supported patterns
-			if ( ! supportedPatterns.length ) {
-				return [];
-			}
-
 			// If no result is provided, return the supported patterns as is.
 			if ( ! result ) {
 				return supportedPatterns;
@@ -112,7 +106,7 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 			// of the collection.
 			const patternBlocks =
 				pattern.blocks.map( block => {
-				const boundAttributes = getBoundAttributeEntries( block.attributes, remoteDataBlockName );
+					const boundAttributes = getBoundAttributeEntries( block.attributes, remoteDataBlockName );
 
 					if ( ! boundAttributes.length ) {
 						return block;


### PR DESCRIPTION
@alecgeatches [found an issue](https://github.com/Automattic/remote-data-blocks/pull/418#issuecomment-2741387672) after selecting the same item in succession. When doing so, no patterns are available to select in the modal: 

https://github.com/user-attachments/assets/22158ccf-fcdc-4235-92cc-365f64c42620

This appears to be due to a brief moment where `__experimentalGetAllowedPatterns` returns an empty array, and its state isn't updated. I believe this happened because `__experimentalGetAllowedPatterns` was extracted from `useSelect` as a function reference rather than tracking its return value.

## Solution

In this PR, `__experimentalGetAllowedPatterns(rootClientId)` is now inside the selector function, to ensure its result is included in `useSelect`'s state tracking. 

https://github.com/user-attachments/assets/fd78a682-7b7e-4b51-b44a-7baac154d8b4

## Testing

After selecting an item in a block (replicated in the art institute and airtable blocks), add another block and make the same selection. You should see patterns to select (ensure custom patterns are present in addition to default). 