### PR TITLE
Fix: loops with non-required inputs

### DIFF
--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -50,8 +50,14 @@ class ConfigRegistry {
 
 		$display_query = self::inflate_query( $user_config[ self::RENDER_QUERY_KEY ]['query'] );
 		$input_schema = $display_query->get_input_schema();
+		$output_schema = $display_query->get_output_schema();
 
-		$is_loop = $user_config[ self::RENDER_QUERY_KEY ]['loop'] ?? false;
+		// Check if any variables are required
+		$has_required_variables = array_reduce(
+			array_column( $input_schema, 'required' ),
+			fn( $carry, $required ) => $carry || ( $required ?? true ),
+			false
+		);
 
 		// Build the base configuration for the block. This is our own internal
 		// configuration, not what will be passed to WordPress's register_block_type.
@@ -61,7 +67,7 @@ class ConfigRegistry {
 			'icon' => $user_config['icon'] ?? 'cloud',
 			'instructions' => $user_config['instructions'] ?? null,
 			'name' => $block_name,
-			'loop' => $is_loop,
+			'loop' => $user_config[ self::RENDER_QUERY_KEY ]['loop'] ?? false,
 			'overrides' => $user_config['overrides'] ?? [],
 			'patterns' => [],
 			'queries' => [
@@ -74,13 +80,13 @@ class ConfigRegistry {
 						return [
 							'name' => $input_var['name'] ?? $slug,
 							'required' => $input_var['required'] ?? true,
-							'slug' => $slug,
+						'slug' => $slug,
 							'type' => $input_var['type'] ?? 'string',
 						];
 					}, array_keys( $input_schema ), array_values( $input_schema ) ),
-					'name' => $is_loop ? 'Collection' : 'Manual input',
+					'name' => $has_required_variables ? 'Manual input' : 'Load collection',
 					'query_key' => self::DISPLAY_QUERY_KEY,
-					'type' => $is_loop ? 'loop' : 'input',
+					'type' => $has_required_variables ? 'input' : 'collection',
 				],
 			],
 			'title' => $block_title,

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -50,7 +50,6 @@ class ConfigRegistry {
 
 		$display_query = self::inflate_query( $user_config[ self::RENDER_QUERY_KEY ]['query'] );
 		$input_schema = $display_query->get_input_schema();
-		$output_schema = $display_query->get_output_schema();
 
 		// Check if any variables are required
 		$has_required_variables = array_reduce(
@@ -80,7 +79,7 @@ class ConfigRegistry {
 						return [
 							'name' => $input_var['name'] ?? $slug,
 							'required' => $input_var['required'] ?? true,
-						'slug' => $slug,
+							'slug' => $slug,
 							'type' => $input_var['type'] ?? 'string',
 						];
 					}, array_keys( $input_schema ), array_values( $input_schema ) ),

--- a/src/blocks/remote-data-container/components/placeholders/ItemSelectQueryType.tsx
+++ b/src/blocks/remote-data-container/components/placeholders/ItemSelectQueryType.tsx
@@ -38,8 +38,13 @@ export function ItemSelectQueryType( props: ItemSelectQueryTypeProps ) {
 								{ ...selectorProps }
 							/>
 						);
+					case 'collection':
+						return (
+							<Button key={ title } onClick={ () => onSelect( [ {} ] ) } variant="primary">
+								{ selector.name }
+							</Button>
+						);
 					case 'input':
-					case 'loop':
 						if ( selector.inputs.length === 1 && selector.inputs[ 0 ] ) {
 							return (
 								<InputPopover
@@ -52,18 +57,6 @@ export function ItemSelectQueryType( props: ItemSelectQueryTypeProps ) {
 						}
 						return <InputModal key={ title } inputs={ selector.inputs } { ...selectorProps } />;
 				}
-
-				return (
-					<Button
-						key={ title }
-						onClick={ () => {
-							onSelect( [ {} ] );
-						} }
-						variant="primary"
-					>
-						Load Collection
-					</Button>
-				);
 
 				return null;
 			} ) }


### PR DESCRIPTION
After merging #418, I noticed that the Airtable loop block shows a manual input button because there are multiple inputs in the schema for paginating. To fix this, we'll need to add a check for non-required input variables like what @chriszarate is adding in #428 

Hopefully we'll have less conflicts by using the same method. The main difference is I added it as a conditional to the `render_query` as I suggested here: https://github.com/Automattic/remote-data-blocks/pull/428#discussion_r2013030205

