### PR TITLE
add hook to signal plugin loaded

### DIFF
--- a/docs/extending/hooks.md
+++ b/docs/extending/hooks.md
@@ -10,6 +10,25 @@ There are two types of hooks: Actions and Filters. To use either, you need to wr
 
 Actions allow you to add data or change how WordPress operates. Actions will run at a specific point in the execution of plugin. Callback functions for an Action do not return anything back to the calling Action hook.
 
+### remote_data_blocks_loaded
+
+This action fires when Remote Data Blocks is fully loaded and ready for use. Plugins that depend on Remote Data Blocks should use this hook to defer their initialization until Remote Data Blocks is fully loaded.
+
+```php
+function my_plugin_init() {
+	// Initialize your plugin that depends on Remote Data Blocks here
+	// All Remote Data Blocks classes and functionality are now available
+}
+
+if ( defined( 'REMOTE_DATA_BLOCKS__PLUGIN_VERSION' ) ) {
+	// Immediately init the plugin since remote data blocks is already loaded
+	my_plugin_init()
+} else {
+	// Defer the init until the remote data block is loaded
+	add_action( 'remote_data_blocks_loaded', 'my_plugin_init' );
+}
+```
+
 ### wpcomvip_log
 
 If you want to send debugging information to another source besides [Query Monitor](../troubleshooting.md#query-monitor), use the `wpcomvip_log` action.

--- a/docs/extending/hooks.md
+++ b/docs/extending/hooks.md
@@ -20,7 +20,7 @@ function my_plugin_init() {
 	// All Remote Data Blocks classes and functionality are now available
 }
 
-if ( defined( 'REMOTE_DATA_BLOCKS__PLUGIN_VERSION' ) ) {
+if ( defined( 'REMOTE_DATA_BLOCKS__LOADED' ) ) {
 	// Immediately init the plugin since remote data blocks is already loaded
 	my_plugin_init()
 } else {

--- a/remote-data-blocks.php
+++ b/remote-data-blocks.php
@@ -52,6 +52,9 @@ Integrations\VipBlockDataApi\VipBlockDataApi::init();
 // REST endpoints
 REST\RemoteDataController::init();
 
+// Fire action to indicate that the plugin is loaded
+do_action( 'remote_data_blocks_loaded' );
+
 // Plugin developers: If you need to register additional code for testing, you
 // can do so here, e.g.:
 // require_once __DIR__ . '/example/shopify/register.php';

--- a/remote-data-blocks.php
+++ b/remote-data-blocks.php
@@ -16,6 +16,12 @@ namespace RemoteDataBlocks;
 
 defined( 'ABSPATH' ) || exit();
 
+// Check if the plugin is already loaded, if so, return early to prevent duplicate plugin instances.
+if ( defined( 'REMOTE_DATA_BLOCKS__LOADED' ) ) {
+	return;
+}
+
+define( 'REMOTE_DATA_BLOCKS__LOADED', true );
 define( 'REMOTE_DATA_BLOCKS__PLUGIN_ROOT', __FILE__ );
 define( 'REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'REMOTE_DATA_BLOCKS__PLUGIN_VERSION', '0.9.1' );


### PR DESCRIPTION
### Description

This PR adds a new action hook to signal the plugin is loaded and adds an early return to prevent multiple instances of the plugin from being loaded.

- Added a check to prevent multiple instances of the Remote Data Blocks plugin from being loaded by returning early if the plugin is already defined ( [`remote-data-blocks.php`](diffhunk://#diff-5f9e69557260c9fd4c96c84baf735c2a61e39819b8c406f626c19d4ef64d71aaR19-R24) ).
- Added a `do_action` call to fire the `remote_data_blocks_loaded` action, indicating that the plugin is fully loaded and ready for use. This would be useful for plugins that need to defer their initialization until remote data blocks is ready ( [`remote-data-blocks.php`](diffhunk://#diff-5f9e69557260c9fd4c96c84baf735c2a61e39819b8c406f626c19d4ef64d71aaR60-R61) ).