### PR TITLE
Improve cache debugging and remove footguns

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -760,14 +760,6 @@ function custom_query_response_metadata( array $metadata, HttpQueryInterface $qu
 add_filter( 'remote_data_blocks_query_response_metadata', 'custom_query_response_metadata', 10, 3 );
 ```
 
-### remote_data_blocks_bypass_cache
-
-Filter to bypass the cache for a specific request (default: `false`).
-
-```php
-add_filter( 'remote_data_blocks_bypass_cache', '__return_true' );
-```
-
 ### remote_data_blocks_http_client_retry_delay
 
 Filter to change the defualt 1 second delapy after an HTTP request fails. The Remote Data Blocks Plugin uses the [Guzzle](https://github.com/guzzle/guzzle) HTTP client. You can read about the response interface in their [documentation](https://docs.guzzlephp.org/en/stable/).

--- a/docs/extending/hooks.md
+++ b/docs/extending/hooks.md
@@ -136,14 +136,6 @@ function custom_query_response_metadata( array $metadata, HttpQueryInterface $qu
 add_filter( 'remote_data_blocks_query_response_metadata', 'custom_query_response_metadata', 10, 3 );
 ```
 
-### remote_data_blocks_bypass_cache
-
-Filter to bypass the cache for a specific request (default: `false`).
-
-```php
-add_filter( 'remote_data_blocks_bypass_cache', '__return_true' );
-```
-
 ### remote_data_blocks_http_client_retry_delay
 
 Filter to change the defualt 1 second delapy after an HTTP request fails. The Remote Data Blocks Plugin uses the [Guzzle](https://github.com/guzzle/guzzle) HTTP client. You can read about the response interface in their [documentation](https://docs.guzzlephp.org/en/stable/).

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -9,9 +9,6 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\Utils;
-use Kevinrob\GuzzleCache\KeyValueHttpHeader;
-use Kevinrob\GuzzleCache\Storage\CacheStorageInterface;
-use Kevinrob\GuzzleCache\Storage\WordPressObjectCacheStorage;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -25,14 +22,12 @@ class HttpClient {
 	public Client $client;
 
 	private const MAX_RETRIES = 3;
-	private const FALLBACK_CACHE_TTL_IN_SECONDS = 60;
-	private const WP_OBJECT_CACHE_GROUP = 'remote-data-blocks';
-	private const CACHE_INVALIDATING_REQUEST_HEADERS = [ 'Authorization', 'Cache-Control' ];
 
 	public const CACHE_TTL_CLIENT_OPTION_KEY = '__default_cache_ttl';
 
 	private string $base_uri;
 	private HandlerStack $handler_stack;
+	private static RdbCacheMiddleware $cache_middleware;
 
 	/**
 	 * @var array<string, string>
@@ -58,22 +53,15 @@ class HttpClient {
 	 */
 	private array $queued_requests = [];
 
-	public static function get_cache_storage(): CacheStorageInterface {
-		return new WordPressObjectCacheStorage( self::WP_OBJECT_CACHE_GROUP );
-	}
-
 	/**
 	 * Get the cache middleware for the HTTP client.
-	 *
 	 */
-	public static function get_cache_middleware( CacheStorageInterface $cache_storage, int|null $default_ttl = null ): callable {
-		return new RdbCacheMiddleware(
-			new RdbCacheStrategy(
-				$cache_storage,
-				$default_ttl ?? self::FALLBACK_CACHE_TTL_IN_SECONDS,
-				new KeyValueHttpHeader( self::CACHE_INVALIDATING_REQUEST_HEADERS )
-			)
-		);
+	protected static function get_cache_middleware( int|null $default_ttl = null ): callable {
+		if ( ! isset( self::$cache_middleware ) ) {
+			self::$cache_middleware = new RdbCacheMiddleware( new RdbCacheStrategy( $default_ttl ) );
+		}
+
+		return self::$cache_middleware;
 	}
 
 	/**
@@ -105,7 +93,7 @@ class HttpClient {
 		} ) );
 
 		$default_ttl = $client_options[ self::CACHE_TTL_CLIENT_OPTION_KEY ] ?? null;
-		$cache_middleware = self::get_cache_middleware( self::get_cache_storage(), $default_ttl );
+		$cache_middleware = self::get_cache_middleware( $default_ttl );
 		$this->handler_stack->push( $cache_middleware, 'remote_data_blocks_cache' );
 
 		$this->handler_stack->push( Middleware::log(

--- a/inc/HttpClient/RdbCacheStrategy.php
+++ b/inc/HttpClient/RdbCacheStrategy.php
@@ -5,6 +5,7 @@ namespace RemoteDataBlocks\HttpClient;
 use Kevinrob\GuzzleCache\CacheEntry;
 use Kevinrob\GuzzleCache\KeyValueHttpHeader;
 use Kevinrob\GuzzleCache\Storage\CacheStorageInterface;
+use Kevinrob\GuzzleCache\Storage\WordPressObjectCacheStorage;
 use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -12,27 +13,46 @@ use RemoteDataBlocks\Logging\Logger;
 use RemoteDataBlocks\Logging\LoggerManager;
 
 class RdbCacheStrategy extends GreedyCacheStrategy {
+	private const CACHE_INVALIDATING_REQUEST_HEADERS = [ 'Authorization', 'Cache-Control' ];
+	private const FALLBACK_CACHE_TTL_IN_SECONDS = 60;
+	private const WP_OBJECT_CACHE_GROUP = 'remote-data-blocks';
+
 	private Logger $logger;
 
-	public function __construct( CacheStorageInterface $cache, int $default_ttl, ?KeyValueHttpHeader $vary_headers = null ) {
-		parent::__construct( $cache, $default_ttl, $vary_headers );
+	public function __construct( ?int $default_ttl = null, ?CacheStorageInterface $storage = null ) {
+		// Filter this if customization is needed.
+		$vary_headers = new KeyValueHttpHeader( self::CACHE_INVALIDATING_REQUEST_HEADERS );
+
+		parent::__construct(
+			$storage ?? new WordPressObjectCacheStorage( self::WP_OBJECT_CACHE_GROUP ),
+			$default_ttl ?? self::FALLBACK_CACHE_TTL_IN_SECONDS,
+			$vary_headers
+		);
+
 		$this->logger = LoggerManager::instance( __CLASS__ );
 	}
 
-	private static function getRequestString( RequestInterface $request ): string {
+	private function log( RequestInterface $request, string $message, ?CacheEntry $cache_entry = null ): void {
 		$uri = $request->getUri();
 		$uri_string = $uri->getScheme() . '://' . $uri->getHost() . $uri->getPath();
 		$method = $request->getMethod();
-		$body = $request->getBody()->getContents();
-		return $method . ' ' . $uri_string . ' ' . $body;
-	}
+		$has_body = (bool) $request->getBody();
 
-	private function should_bypass_cache( RequestInterface $request ): bool {
-		if ( apply_filters( 'remote_data_blocks_bypass_cache', false, $request ) ) {
-			return true;
+		$context = [
+			'method' => $method,
+			'uri' => $uri_string,
+			'has_body' => $has_body,
+			'key' => $this->getCacheKey( $request ),
+		];
+
+		if ( $cache_entry instanceof CacheEntry ) {
+			$context['age'] = $cache_entry->getAge();
+			$context['ttl'] = $cache_entry->getTtl();
 		}
 
-		return false;
+		ksort( $context );
+
+		$this->logger->debug( $message, $context );
 	}
 
 	/** @psalm-suppress ParamNameMismatch reason: parent is camelCase, but we want snake_case */
@@ -51,18 +71,14 @@ class RdbCacheStrategy extends GreedyCacheStrategy {
 	}
 
 	public function fetch( RequestInterface $request ): CacheEntry|null {
-		if ( $this->should_bypass_cache( $request ) ) {
-			$this->logger->debug( 'Cache Bypass: ' . self::getRequestString( $request ) );
-			return null;
-		}
-
 		$result = parent::fetch( $request );
 
 		if ( null === $result ) {
-			$this->logger->debug( 'Cache Miss: ' . self::getRequestString( $request ) );
+			$this->log( $request, 'cache:read:miss' );
 			return null;
 		}
-		$this->logger->debug( 'Cache Hit: ' . self::getRequestString( $request ) );
+
+		$this->log( $request, 'cache:read:hit', $result );
 		return $result;
 	}
 
@@ -72,16 +88,17 @@ class RdbCacheStrategy extends GreedyCacheStrategy {
 
 		// Negative TTL indicates disabled caching.
 		if ( $cache_ttl < 0 ) {
-			$this->logger->debug( 'Did not cache (negative TTL): ' . self::getRequestString( $request ) );
+			$this->log( $request, 'cache:write:disabled' );
 			return false;
 		}
 
 		$result = parent::cache( $request, $response );
 		if ( false === $result ) {
-			$this->logger->debug( 'Did not cache (uncacheable): ' . self::getRequestString( $request ) );
+			$this->log( $request, 'cache:write:uncacheable' );
 			return false;
 		}
-		$this->logger->debug( 'Cached (TTL=' . $cache_ttl . '): ' . self::getRequestString( $request ) );
+
+		$this->log( $request, 'cache:write:success' );
 		return $result;
 	}
 }

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Exception\RequestException;
 use Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage;
 use RemoteDataBlocks\HttpClient\RdbCacheMiddleware;
+use RemoteDataBlocks\HttpClient\RdbCacheStrategy;
 use RemoteDataBlocks\HttpClient\HttpClient;
 
 class HttpClientTest extends TestCase {
@@ -23,7 +24,7 @@ class HttpClientTest extends TestCase {
 		$this->mock_handler = new MockHandler();
 		$handler = HandlerStack::create( $this->mock_handler );
 
-		$handler->push( HttpClient::get_cache_middleware( new VolatileRuntimeStorage() ), 'phpunit_remote_data_blocks_cache' );
+		$handler->push( new RdbCacheMiddleware( new RdbCacheStrategy( null, new VolatileRuntimeStorage() ) ) );
 		$client = new Client( [ 'handler' => $handler ] );
 
 		$this->http_client = new HttpClient( 'https://api.example.com' );
@@ -126,15 +127,15 @@ class HttpClientTest extends TestCase {
 		$results = $this->http_client->execute_parallel();
 
 		$this->assertCount( 3, $results );
-		
+
 		$this->assertSame( 'fulfilled', $results[0]['state'] );
 		$this->assertSame( 200, $results[0]['value']->getStatusCode() );
 		$this->assertSame( 'Success Response', (string) $results[0]['value']->getBody() );
-		
+
 		$this->assertSame( 'rejected', $results[1]['state'] );
 		$this->assertInstanceOf( RequestException::class, $results[1]['reason'] );
 		$this->assertSame( 'Error', $results[1]['reason']->getMessage() );
-		
+
 		$this->assertSame( 'rejected', $results[2]['state'] );
 		$this->assertInstanceOf( ConnectException::class, $results[2]['reason'] );
 		$this->assertSame( 'Connection Error', $results[2]['reason']->getMessage() );


### PR DESCRIPTION
I originally set out to add some in-memory caching to our existing cache strategy. However, I realized that, since we delegate to `wp_cache_get`, this is done for us. You can confirm by reading `WP_Object_Cache` source code or by monitoring Redis `GET`s to confirm that they are not repeated within the same request lifecycle:

```sh
$ redis-cli monitor | grep -i '"GET" "wp:remote-data-blocks:'
```

Instead, this PR removes some risky configurability and improves logging:

1. Remove `remote_data_blocks_bypass_cache` filter. We have not identified a use case for this filter; caching behavior is separately controllable on queries via `ttl`. This filter can be considered a footgun since it completely disables the ability to cache _any_ request, even in-memory.
   - Currently, since block bindings are repeated for each block in a remote data block, and potentially repeated again for each item in a collection query, we often end up executing the same query many times—sometimes hundreds of times. Disabling caching globally is a bad idea. If it is needed in narrow circumstances, it can be done at the query level.
2. Simplify class instantiation by removing configurability that is unused or unneeded. We can always add filtering in the future, if requested. 
3. Fix non-static instantiation of cache middleware. This doesn't fix any known bugs, but someone who used a custom caching implementation might have been impacted.
4. Improve cache logging with consistent output and additional information like `age` and `ttl`.

Example cache logging:

<img width="1729" alt="Screenshot 2025-04-02 at 13 09 27" src="https://github.com/user-attachments/assets/8601e2dd-0cc5-4385-97f1-23127c42ac99" />
