### PR TITLE
Add more info about the block for the block bindings

### DIFF
--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -67,7 +67,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ sprintf( __( 'Remote Data Block: %s', 'remote-data-blocks' ), remoteDataName ) }>
+				<PanelBody title={ __( sprintf ( 'Remote Data Block: %s', remoteDataName ), 'remote-data-blocks' ) }>
 					<BlockBindingControls
 						attributes={ attributes }
 						availableBindings={ availableBindings }

--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -68,7 +68,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 		<>
 			<InspectorControls>
 				<PanelBody
-					title={ sprintf( __( 'Remote Data Block: %s' ), remoteDataName ), 'remote-data-blocks' ) }
+					title={ sprintf( __( 'Remote Data Block: %s', 'remote-data-blocks' ), remoteDataName ) }
 				>
 					<BlockBindingControls
 						attributes={ attributes }

--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -68,7 +68,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 		<>
 			<InspectorControls>
 				<PanelBody
-					title={ __( sprintf( 'Remote Data Block: %s', remoteDataName ), 'remote-data-blocks' ) }
+					title={ sprintf( __( 'Remote Data Block: %s' ), remoteDataName ), 'remote-data-blocks' ) }
 				>
 					<BlockBindingControls
 						attributes={ attributes }

--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -12,7 +12,7 @@ import {
 	PATTERN_OVERRIDES_CONTEXT_KEY,
 } from '@/config/constants';
 import { getBoundBlockClassName, getMismatchedAttributes } from '@/utils/block-binding';
-import { getBlockAvailableBindings } from '@/utils/localized-block-data';
+import { getBlockAvailableBindings, getBlockTitle } from '@/utils/localized-block-data';
 
 interface BoundBlockEditProps {
 	attributes: RemoteDataInnerBlockAttributes;
@@ -20,6 +20,7 @@ interface BoundBlockEditProps {
 	blockName: string;
 	children: JSX.Element;
 	remoteDataName: string;
+	remoteDataTitle: string;
 	setAttributes: ( attributes: RemoteDataInnerBlockAttributes ) => void;
 }
 
@@ -30,7 +31,14 @@ interface BlockEditWithPreviewIndex {
 }
 
 function BoundBlockEdit( props: BoundBlockEditProps ) {
-	const { attributes, availableBindings, blockName, remoteDataName, setAttributes } = props;
+	const {
+		attributes,
+		availableBindings,
+		blockName,
+		remoteDataName,
+		remoteDataTitle,
+		setAttributes,
+	} = props;
 	const existingBindings = attributes.metadata?.bindings ?? {};
 
 	function removeBinding( target: string ) {
@@ -68,10 +76,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 		<>
 			<InspectorControls>
 				<PanelBody
-					title={ sprintf(
-						__( 'Remote Data Block: %s', 'remote-data-blocks' ),
-						remoteDataName.replace( 'remote-data-blocks/', '' )
-					) }
+					title={ sprintf( __( 'Remote Data Block: %s', 'remote-data-blocks' ), remoteDataTitle ) }
 				>
 					<BlockBindingControls
 						attributes={ attributes }
@@ -135,12 +140,16 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 			return <BlockEdit { ...props } attributes={ mergedAttributes } />;
 		}
 
+		// lookup the title of the remote data block
+		const remoteBlockTitle = getBlockTitle( remoteData?.blockName );
+
 		return (
 			<BoundBlockEdit
 				attributes={ mergedAttributes }
 				availableBindings={ availableBindings }
 				blockName={ name }
 				remoteDataName={ remoteData?.blockName ?? '' }
+				remoteDataTitle={ remoteBlockTitle }
 				setAttributes={ setAttributes }
 			>
 				<BlockEdit { ...props } attributes={ mergedAttributes } />

--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -67,7 +67,9 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( sprintf ( 'Remote Data Block: %s', remoteDataName ), 'remote-data-blocks' ) }>
+				<PanelBody
+					title={ __( sprintf( 'Remote Data Block: %s', remoteDataName ), 'remote-data-blocks' ) }
+				>
 					<BlockBindingControls
 						attributes={ attributes }
 						availableBindings={ availableBindings }

--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -2,7 +2,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { BlockConfiguration, BlockEditProps } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 import { BlockBindingControls } from '@/blocks/remote-data-container/components/BlockBindingControls';
 import { useRemoteDataContext } from '@/blocks/remote-data-container/hooks/useRemoteDataContext';
@@ -67,7 +67,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Remote Data', 'remote-data-blocks' ) }>
+				<PanelBody title={ sprintf( __( 'Remote Data Block: %s', 'remote-data-blocks' ), remoteDataName ) }>
 					<BlockBindingControls
 						attributes={ attributes }
 						availableBindings={ availableBindings }

--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -68,7 +68,10 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 		<>
 			<InspectorControls>
 				<PanelBody
-					title={ sprintf( __( 'Remote Data Block: %s', 'remote-data-blocks' ), remoteDataName ) }
+					title={ sprintf(
+						__( 'Remote Data Block: %s', 'remote-data-blocks' ),
+						remoteDataName.replace( 'remote-data-blocks/', '' )
+					) }
 				>
 					<BlockBindingControls
 						attributes={ attributes }

--- a/src/utils/localized-block-data.ts
+++ b/src/utils/localized-block-data.ts
@@ -14,6 +14,14 @@ export function getBlockDataSourceType( blockName?: string ): string {
 	return getBlockConfig( blockName )?.dataSourceType ?? '';
 }
 
+export function getBlockTitle( blockName?: string ): string {
+	if ( ! blockName ) {
+		return '';
+	}
+
+	return getBlockConfig( blockName )?.settings?.title ?? '';
+}
+
 export function getBlocksConfig(): BlocksConfig {
 	return window.REMOTE_DATA_BLOCKS?.config ?? {};
 }

--- a/src/utils/localized-block-data.ts
+++ b/src/utils/localized-block-data.ts
@@ -14,12 +14,23 @@ export function getBlockDataSourceType( blockName?: string ): string {
 	return getBlockConfig( blockName )?.dataSourceType ?? '';
 }
 
+/**
+ * Get the title of a remote data block.
+ *
+ * The title could be set in the block config or it could be the block name, without the remote-data-blocks/ prefix.
+ * If the title is not found, or the block name is not found, then unknown is returned.
+ *
+ * @param blockName The name of the remote data block.
+ * @returns The title of the remote data block.
+ */
 export function getBlockTitle( blockName?: string ): string {
 	if ( ! blockName ) {
 		return '';
 	}
 
-	return getBlockConfig( blockName )?.settings?.title ?? '';
+	return (
+		getBlockConfig( blockName )?.settings?.title ?? blockName.replace( 'remote-data-blocks/', '' )
+	);
 }
 
 export function getBlocksConfig(): BlocksConfig {


### PR DESCRIPTION
### Description

The goal of this PR is to make it easier to spot when a block binding hasn't been mapped to the right remote data. Now, in the side panel under a block binding the remote data block's name will show up so as to spot any errors quickly.