### PR TITLE
Front-end pagination support

### DIFF
--- a/docs/extending/hooks.md
+++ b/docs/extending/hooks.md
@@ -72,6 +72,17 @@ function custom_allowed_url_schemes( array $allowed_url_schemes, HttpQueryInterf
 add_filter( 'remote_data_blocks_allowed_url_schemes', 'custom_allowed_url_schemes', 10, 2 );
 ```
 
+### remote_data_blocks_pagination_query_var_name
+
+Filter the query variable name used for pagination (default: `rdb-pagination`).
+
+```php
+function custom_pagination_query_var_name(): string {
+	return 'paginate';
+}
+add_filter( 'remote_data_blocks_pagination_query_var_name', 'custom_pagination_query_var_name', 10, 0 );
+```
+
 ### remote_data_blocks_request_details
 
 Filter the request details (method, options, url) before the HTTP request is dispatched.

--- a/docs/extending/query.md
+++ b/docs/extending/query.md
@@ -113,7 +113,8 @@ There are also some special input variable types:
 - `ui:pagination_offset`: A variable with this type indicates that the query supports offset pagination. It must accept an `integer` containing the requested offset. See `pagination_schema` for additional information and requirements.
 - `ui:pagination_page`: A variable with this type indicates that the query supports page-based pagination. It must accept an `integer` containing the requested results page. See `pagination_schema` for additional information and requirements.
 - `ui:pagination_per_page`: A variable with this type indicates that the query supports controlling the number of resultsper page. It must accept an `integer` containing the number of requested results.
-- `ui:pagination_cursor_next` and `ui_pagination_cursor_previous`: Variables with these types indicate that the query supports cursor pagination. They accept `strings` containing the requested cursor. See `pagination_schema` for additional information and requirements.
+- `ui:pagination_cursor_next` and `ui_pagination_cursor_previous`: Variables with these types indicate that the query supports cursor pagination. They accept `string`s containing the requested cursor. See `pagination_schema` for additional information and requirements.
+- `ui:pagination_cursor`: A variable with this type indicates support for a simple variant of cursor pagination that uses a single cursor instead of a pair of forward / backward cursors. It accepts a `string` containing the requested cursor. See `pagination_schema` for additional information and requirements.
 
 #### Example with search and pagination input variables
 
@@ -196,11 +197,14 @@ We have more in-depth [`output_schema`](./query-output_schema.md) examples.
 
 If your query supports pagination, the `pagination_schema` property defines how to extract pagination-related values from the query response. If defined, the property should be an associative array with the following structure:
 
-- `total_items` (required): A variable definition that extracts the total number of items across every page of results.
-- `cursor_next`: If your query supports cursor pagination, a variable definition that extracts the cursor for the next page of results.
+- `total_items`: A variable definition that extracts the total number of items across every page of results.
+- `has_next_page`: A variable definition that extracts a boolean indicating whether there are more pages of results. Useful for APIs that do not report the total number of items.
+- `cursor_next`: If your query supports cursor pagination, a variable definition that extracts the cursor for the next page of results. This output variable will also be mapped to `ui:pagination_cursor`, if present.
 - `cursor_previous`: If your query supports cursor pagination, a variable definition that extracts the cursor for the previous page of results.
 
-Note that the `total_items` variable is required for all types of pagination.
+Note that one of `has_next_page` or `total_items` is required for all pagination types.
+
+A pagination block will automatically be added to remote data blocks that support pagination.
 
 #### Example
 

--- a/example/rest-api/art-institute/art-institute.php
+++ b/example/rest-api/art-institute/art-institute.php
@@ -96,13 +96,19 @@ function register_aic_block(): void {
 			return add_query_arg( [
 				'limit' => $input_variables['limit'],  
 				'fields' => 'id,title,image_id,artist_title',
+				'page' => $input_variables['page'],
 			], $endpoint );
 		},
 		'input_schema' => [
 			'limit' => [
-				'name' => 'Limit',
-				'type' => 'ui:input',
 				'default_value' => 10,
+				'name' => 'Pagination limit',
+				'type' => 'ui:pagination_per_page',
+			],
+			'page' => [
+				'default_value' => 1,
+				'name' => 'Pagination page',
+				'type' => 'ui:pagination_page',
 			],
 		],
 		'output_schema' => [

--- a/inc/Config/ArraySerializable.php
+++ b/inc/Config/ArraySerializable.php
@@ -13,7 +13,15 @@ defined( 'ABSPATH' ) || exit();
  * ArraySerializable class
  */
 abstract class ArraySerializable implements ArraySerializableInterface {
-	final private function __construct( protected array $config ) {}
+	protected string $id;
+
+	final private function __construct( protected array $config ) {
+		$this->id = md5( wp_json_encode( [ get_called_class(), $config ] ) );
+	}
+
+	final public function get_id(): string {
+		return $this->id;
+	}
 
 	protected function get_or_call_from_config( string $property_name, mixed ...$callable_args ): mixed {
 		$config_value = $this->config[ $property_name ] ?? null;

--- a/inc/Config/ArraySerializableInterface.php
+++ b/inc/Config/ArraySerializableInterface.php
@@ -22,6 +22,12 @@ interface ArraySerializableInterface {
 	public static function from_array( array $config, ?ValidatorInterface $validator ): static|WP_Error;
 
 	/**
+	 * Get a deterministic identifier for the instance. Instances with the same
+	 * base class and config should have the same ID.
+	 */
+	public function get_id(): string;
+
+	/**
 	 * This method will be called by ::from_array() to prior to validating the
 	 * config. This allows you to modify the config before it's validated, perhaps
 	 * because you want to inflate it with additional or computed values.

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -5,6 +5,7 @@ namespace RemoteDataBlocks\Config\QueryRunner;
 use Exception;
 use GuzzleHttp\RequestOptions;
 use RemoteDataBlocks\Config\Query\HttpQueryInterface;
+use RemoteDataBlocks\Editor\DataBinding\Pagination;
 use RemoteDataBlocks\HttpClient\HttpClient;
 use WP_Error;
 
@@ -252,7 +253,7 @@ class QueryRunner implements QueryRunnerInterface {
 
 		return [
 			'metadata' => $metadata,
-			'pagination' => $pagination,
+			'pagination' => Pagination::format_pagination_data_for_query_response( $pagination, $input_schema, $input_variables ),
 			'results' => $results,
 			'query_inputs' => [ $input_variables ],
 		];

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -255,6 +255,7 @@ class QueryRunner implements QueryRunnerInterface {
 			'metadata' => $metadata,
 			'pagination' => Pagination::format_pagination_data_for_query_response( $pagination, $input_schema, $input_variables ),
 			'results' => $results,
+			'query_id' => $query->get_id(),
 			'query_inputs' => [ $input_variables ],
 		];
 	}
@@ -310,6 +311,7 @@ class QueryRunner implements QueryRunnerInterface {
 			'metadata' => $this->get_response_metadata( $query, [ 'batch' => true ], $merged_results ),
 			'pagination' => null, // Pagination is always disabled for batch executions.
 			'results' => $merged_results,
+			'query_id' => $query->get_id(),
 			'query_inputs' => $merged_query_inputs,
 		];
 	}

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -46,6 +46,9 @@ class BlockRegistration {
 		// Remote data HTML block - used to render HTML content in the absence of a proper binding.
 		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-html' );
 
+		// Remote data pagination block - used to render pagination links for collections.
+		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-pagination' );
+
 		// Remote data template - used to render remote data collections.
 		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-template' );
 	}

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -147,8 +147,7 @@ class BlockBindings {
 		// If there is a single array of input variables, fetch pagination variables.
 		// Pagination is disabled for batch execution.
 		if ( 1 === count( $array_of_input_variables ) ) {
-			$block_id = self::get_block_id( $block_name, $array_of_input_variables[0] );
-			$pagination_input_variables = Pagination::get_pagination_input_variables_for_current_request( $block_id );
+			$pagination_input_variables = Pagination::get_pagination_input_variables_for_current_request( $query->get_id() );
 			$array_of_input_variables[0] = array_merge( $array_of_input_variables[0] ?? [], $pagination_input_variables );
 		}
 
@@ -199,36 +198,27 @@ class BlockBindings {
 		}
 	}
 
-	/**
-	 * Create a hash of the block name and input variables as a kind of
-	 * identifier for the block. This is not a unique ID and could result in
-	 * collisions, but is unlikely to surprise the user since the hash input
-	 * contains the configured behavior (block name and input variables).
-	 */
-	private static function get_block_id( string $block_name, array $input_variables ): string {
-		return md5( wp_json_encode( [ $block_name, $input_variables ] ) );
-	}
-
 	public static function get_pagination_links( WP_Block $block ): array {
 		$block_context = $block->context[ self::$context_name ] ?? [];
 		$query_response = self::execute_queries( $block_context, [], 'remote_data_block_get_pagination_data' );
-		$pagination_data = $query_response['pagination'] ?? null;
 
-		if ( null === $pagination_data ) {
+		$pagination_data = $query_response['pagination'] ?? null;
+		$query_id = $query_response['query_id'] ?? null;
+
+		if ( null === $pagination_data || null === $query_id ) {
 			return [];
 		}
 
-		$block_id = self::get_block_id( $block_context['blockName'], $block_context['queryInputs'][0] ?? null );
 		$next_link = null;
 		$previous_link = null;
 
 		// Create pagination links.
 		if ( isset( $pagination_data['input_variables']['next_page'] ) ) {
-			$next_link = Pagination::create_query_var( $block_id, $pagination_data['input_variables']['next_page'] );
+			$next_link = Pagination::create_query_var( $query_id, $pagination_data['input_variables']['next_page'] );
 		}
 
 		if ( isset( $pagination_data['input_variables']['previous_page'] ) ) {
-			$previous_link = Pagination::create_query_var( $block_id, $pagination_data['input_variables']['previous_page'] );
+			$previous_link = Pagination::create_query_var( $query_id, $pagination_data['input_variables']['previous_page'] );
 		}
 
 		return [

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -10,6 +10,9 @@ use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;
 use RemoteDataBlocks\Logging\LoggerManager;
 use RemoteDataBlocks\Sanitization\Sanitizer;
 use WP_Block;
+use function add_action;
+use function add_filter;
+use function remove_filter;
 
 use function register_block_bindings_source;
 
@@ -130,8 +133,7 @@ class BlockBindings {
 		$enabled_overrides = $source_args['enabledOverrides'] ?? $remote_data['enabledOverrides'];
 		$query_key = $source_args['queryKey'] ?? $remote_data['queryKey'] ?? ConfigRegistry::DISPLAY_QUERY_KEY;
 
-		// Extract the input variables. Support the previous property name used
-		// before we allowed multiple query inputs.
+		// Extract the input variables. Allow the binding source args to override.
 		$array_of_input_variables = $source_args['queryInputs'] ?? $remote_data['queryInputs'];
 
 		$block_config = ConfigStore::get_block_configuration( $block_name );
@@ -140,6 +142,14 @@ class BlockBindings {
 		if ( null === $query ) {
 			self::log_error( sprintf( 'Cannot load query %s for block binding', $query_key ), $block_name, $operation_name );
 			return null;
+		}
+
+		// If there is a single array of input variables, fetch pagination variables.
+		// Pagination is disabled for batch execution.
+		if ( 1 === count( $array_of_input_variables ) ) {
+			$block_id = self::get_block_id( $block_name, $array_of_input_variables[0] );
+			$pagination_input_variables = Pagination::get_pagination_input_variables_for_current_request( $block_id );
+			$array_of_input_variables[0] = array_merge( $array_of_input_variables[0] ?? [], $pagination_input_variables );
 		}
 
 		$array_of_input_variables = array_map( function ( $input_variables ) use ( $enabled_overrides, $block_name ): array {
@@ -187,6 +197,44 @@ class BlockBindings {
 			self::log_error( 'Unexpected exception for block binding: ' . $e->getMessage(), $block_name, $operation_name );
 			return null;
 		}
+	}
+
+	/**
+	 * Create a hash of the block name and input variables as a kind of
+	 * identifier for the block. This is not a unique ID and could result in
+	 * collisions, but is unlikely to surprise the user since the hash input
+	 * contains the configured behavior (block name and input variables).
+	 */
+	private static function get_block_id( string $block_name, array $input_variables ): string {
+		return md5( wp_json_encode( [ $block_name, $input_variables ] ) );
+	}
+
+	public static function get_pagination_links( WP_Block $block ): array {
+		$block_context = $block->context[ self::$context_name ] ?? [];
+		$query_response = self::execute_queries( $block_context, [], 'remote_data_block_get_pagination_data' );
+		$pagination_data = $query_response['pagination'] ?? null;
+
+		if ( null === $pagination_data ) {
+			return [];
+		}
+
+		$block_id = self::get_block_id( $block_context['blockName'], $block_context['queryInputs'][0] ?? null );
+		$next_link = null;
+		$previous_link = null;
+
+		// Create pagination links.
+		if ( isset( $pagination_data['input_variables']['next_page'] ) ) {
+			$next_link = Pagination::create_query_var( $block_id, $pagination_data['input_variables']['next_page'] );
+		}
+
+		if ( isset( $pagination_data['input_variables']['previous_page'] ) ) {
+			$previous_link = Pagination::create_query_var( $block_id, $pagination_data['input_variables']['previous_page'] );
+		}
+
+		return [
+			'next_page' => $next_link,
+			'previous_page' => $previous_link,
+		];
 	}
 
 	public static function get_value( array $source_args, WP_Block|array $block, string $attribute_name ): ?string {

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -147,7 +147,7 @@ class BlockBindings {
 		// If there is a single array of input variables, fetch pagination variables.
 		// Pagination is disabled for batch execution.
 		if ( 1 === count( $array_of_input_variables ) ) {
-			$pagination_input_variables = Pagination::get_pagination_input_variables_for_current_request( $query->get_id() );
+			$pagination_input_variables = Pagination::get_pagination_input_variables_for_current_request( $query );
 			$array_of_input_variables[0] = array_merge( $array_of_input_variables[0] ?? [], $pagination_input_variables );
 		}
 

--- a/inc/Editor/DataBinding/Pagination.php
+++ b/inc/Editor/DataBinding/Pagination.php
@@ -11,10 +11,20 @@ use function get_query_var;
 defined( 'ABSPATH' ) || exit();
 
 class Pagination {
-	private static $variable_name = 'rdb-pagination';
+	private static string $variable_name = 'rdb-pagination';
 
 	public static function init(): void {
 		add_filter( 'query_vars', [ __CLASS__, 'register_query_var' ], 10, 1 );
+
+		/**
+		 * Filter the name of the query variable used for pagination.
+		 *
+		 * @param string $query_var_name The name of the query variable.
+		 */
+		self::$variable_name = apply_filters(
+			'remote_data_blocks_pagination_query_var_name',
+			'rdb-pagination'
+		);
 	}
 
 	public static function create_query_var( string $query_id, array $pagination_input_variables ): string {

--- a/inc/Editor/DataBinding/Pagination.php
+++ b/inc/Editor/DataBinding/Pagination.php
@@ -15,9 +15,9 @@ class Pagination {
 		add_filter( 'query_vars', [ __CLASS__, 'register_query_var' ], 10, 1 );
 	}
 
-	public static function create_query_var( string $block_id, array $pagination_input_variables ): string {
+	public static function create_query_var( string $query_id, array $pagination_input_variables ): string {
 		$value = [
-			$block_id => $pagination_input_variables,
+			$query_id => $pagination_input_variables,
 		];
 
 		return add_query_arg( self::$variable_name, self::encode_query_var( $value ) );
@@ -31,7 +31,7 @@ class Pagination {
 		return base64_encode( wp_json_encode( $query_var_value ) );
 	}
 
-	public static function get_pagination_input_variables_for_current_request( string $block_id ): array {
+	public static function get_pagination_input_variables_for_current_request( string $query_id ): array {
 		$value = self::decode_query_var( get_query_var( self::$variable_name, '' ) );
 
 		if ( empty( $value ) ) {
@@ -44,7 +44,7 @@ class Pagination {
 		// We only expect a single key => value pair, but in the future we may
 		// decide to support more than one. This would allow us to control the
 		// pagination of multiple remote data blocks independently.
-		return $value[ $block_id ] ?? [];
+		return $value[ $query_id ] ?? [];
 	}
 
 	public static function format_pagination_data_for_query_response( array|null $pagination_data, array $query_input_schema, array $input_variables ): array {

--- a/inc/Editor/DataBinding/Pagination.php
+++ b/inc/Editor/DataBinding/Pagination.php
@@ -1,0 +1,171 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Editor\DataBinding;
+
+use function add_filter;
+use function add_query_arg;
+use function get_query_var;
+
+defined( 'ABSPATH' ) || exit();
+
+class Pagination {
+	private static $variable_name = 'rdb-pagination';
+
+	public static function init(): void {
+		add_filter( 'query_vars', [ __CLASS__, 'register_query_var' ], 10, 1 );
+	}
+
+	public static function create_query_var( string $block_id, array $pagination_input_variables ): string {
+		$value = [
+			$block_id => $pagination_input_variables,
+		];
+
+		return add_query_arg( self::$variable_name, self::encode_query_var( $value ) );
+	}
+
+	private static function decode_query_var( string $query_var_string ): array {
+		return json_decode( base64_decode( $query_var_string ), true ) ?? [];
+	}
+
+	private static function encode_query_var( array $query_var_value ): string {
+		return base64_encode( wp_json_encode( $query_var_value ) );
+	}
+
+	public static function get_pagination_input_variables_for_current_request( string $block_id ): array {
+		$value = self::decode_query_var( get_query_var( self::$variable_name, '' ) );
+
+		if ( empty( $value ) ) {
+			return [];
+		}
+
+		// The query var value is an associative array with IDs as keys and
+		// values that are an associative array of input variables.
+		//
+		// We only expect a single key => value pair, but in the future we may
+		// decide to support more than one. This would allow us to control the
+		// pagination of multiple remote data blocks independently.
+		return $value[ $block_id ] ?? [];
+	}
+
+	public static function format_pagination_data_for_query_response( array|null $pagination_data, array $query_input_schema, array $input_variables ): array {
+		// If the input schema is empty, it does not support pagination.
+		if ( empty( $query_input_schema ) ) {
+			return [];
+		}
+
+		// Find the appropriate pagination variables from the input schema.
+		$cursor_variable = null;
+		$cursor_next_variable = null;
+		$cursor_previous_variable = null;
+		$offset_variable = null;
+		$page_variable = null;
+		$per_page_variable = null;
+
+		foreach ( $query_input_schema as $slug => $input ) {
+			$type = $input['type'] ?? '';
+			if ( 'ui:pagination_cursor' === $type ) {
+				$cursor_variable = $slug;
+			} elseif ( 'ui:pagination_cursor_next' === $type ) {
+				$cursor_next_variable = $slug;
+			} elseif ( 'ui:pagination_cursor_previous' === $type ) {
+				$cursor_previous_variable = $slug;
+			} elseif ( 'ui:pagination_offset' === $type ) {
+				$offset_variable = $slug;
+			} elseif ( 'ui:pagination_page' === $type ) {
+				$page_variable = $slug;
+			} elseif ( 'ui:pagination_per_page' === $type ) {
+				$per_page_variable = $slug;
+			}
+		}
+
+		// Default pagination values
+		$current_per_page = $input_variables[ $per_page_variable ] ?? 10;
+		$pagination_input_variables = [];
+		$pagination_type = 'NONE';
+		$total_items = $pagination_data['total_items'] ?? null;
+
+		$pagination_input_variable_targets = [
+			'offset' => $offset_variable,
+			'page' => $page_variable,
+			'per_page' => $per_page_variable,
+		];
+
+		if ( $cursor_variable ) {
+			$pagination_type = 'CURSOR_SIMPLE';
+
+			if ( isset( $pagination_data['cursor_next'] ) ) {
+				$pagination_input_variables['next_page'] = [
+					$cursor_variable => $pagination_data['cursor_next'],
+				];
+			}
+
+			if ( isset( $pagination_data['cursor_previous'] ) ) {
+				$pagination_input_variables['previous_page'] = [
+					$cursor_variable => $pagination_data['cursor_previous'],
+				];
+			}
+		} elseif ( $cursor_next_variable && $cursor_previous_variable ) {
+			$pagination_type = 'CURSOR';
+
+			if ( isset( $pagination_data['cursor_next'] ) ) {
+				$pagination_input_variables['next_page'] = [
+					$cursor_next_variable => $pagination_data['cursor_next'],
+				];
+			}
+
+			if ( isset( $pagination_data['cursor_previous'] ) ) {
+				$pagination_input_variables['previous_page'] = [
+					$cursor_previous_variable => $pagination_data['cursor_previous'],
+				];
+			}
+		} elseif ( $offset_variable ) {
+			$pagination_type = 'OFFSET';
+			$current_offset = $input_variables[ $offset_variable ] ?? 0;
+
+			if ( null === $total_items || $current_offset + $current_per_page < $total_items ) {
+				$pagination_input_variables['next_page'] = [
+					$offset_variable => $current_offset + $current_per_page,
+				];
+			}
+
+			if ( $current_offset >= $current_per_page ) {
+				$pagination_input_variables['previous_page'] = [
+					$offset_variable => $current_offset - $current_per_page,
+				];
+			}
+		} elseif ( $page_variable ) {
+			$pagination_type = 'PAGE';
+			$current_page = $input_variables[ $page_variable ] ?? 1;
+			$total_pages = $total_items ? ceil( $total_items / $current_per_page ) : null;
+
+			if ( null === $total_pages || $current_page < $total_pages ) {
+				$pagination_input_variables['next_page'] = [
+					$page_variable => $current_page + 1,
+				];
+			}
+
+			if ( $current_page > 1 ) {
+				$pagination_input_variables['previous_page'] = [
+					$page_variable => $current_page - 1,
+				];
+			}
+		}
+
+		if ( 'NONE' === $pagination_type ) {
+			return [];
+		}
+
+		return [
+			'input_variables' => $pagination_input_variables,
+			'input_variable_targets' => $pagination_input_variable_targets,
+			'per_page' => $current_per_page,
+			'total_items' => $total_items,
+			'type' => $pagination_type,
+		];
+	}
+
+	public static function register_query_var( array $query_vars ): array {
+		$query_vars[] = self::$variable_name;
+		return $query_vars;
+	}
+}

--- a/inc/Editor/DataBinding/Pagination.php
+++ b/inc/Editor/DataBinding/Pagination.php
@@ -2,6 +2,8 @@
 
 namespace RemoteDataBlocks\Editor\DataBinding;
 
+use RemoteDataBlocks\Config\Query\QueryInterface;
+
 use function add_filter;
 use function add_query_arg;
 use function get_query_var;
@@ -31,12 +33,14 @@ class Pagination {
 		return base64_encode( wp_json_encode( $query_var_value ) );
 	}
 
-	public static function get_pagination_input_variables_for_current_request( string $query_id ): array {
-		$value = self::decode_query_var( get_query_var( self::$variable_name, '' ) );
+	public static function get_pagination_input_variables_for_current_request( QueryInterface $query ): array {
+		$untrusted_variables = self::decode_query_var( get_query_var( self::$variable_name, '' ) );
 
-		if ( empty( $value ) ) {
+		if ( empty( $untrusted_variables ) || ! is_array( $untrusted_variables ) ) {
 			return [];
 		}
+
+		$query_id = $query->get_id();
 
 		// The query var value is an associative array with IDs as keys and
 		// values that are an associative array of input variables.
@@ -44,7 +48,44 @@ class Pagination {
 		// We only expect a single key => value pair, but in the future we may
 		// decide to support more than one. This would allow us to control the
 		// pagination of multiple remote data blocks independently.
-		return $value[ $query_id ] ?? [];
+		$untrusted_variables = $untrusted_variables[ $query_id ] ?? [];
+
+		if ( empty( $untrusted_variables ) || ! is_array( $untrusted_variables ) ) {
+			return [];
+		}
+
+		// Only accept pagination input variables that are defined in this query's
+		// input schema.
+		$input_schema = $query->get_input_schema();
+		$input_variables = [];
+		$pagination_input_variable_types = [
+			'ui:pagination_cursor',
+			'ui:pagination_cursor_next',
+			'ui:pagination_cursor_previous',
+			'ui:pagination_offset',
+			'ui:pagination_page',
+			'ui:pagination_per_page',
+		];
+
+		foreach ( $input_schema as $slug => $input ) {
+			if ( ! in_array( $input['type'] ?? null, $pagination_input_variable_types, true ) ) {
+				continue;
+			}
+
+			if ( ! array_key_exists( $slug, $untrusted_variables ) ) {
+				continue;
+			}
+
+			$value = $untrusted_variables[ $slug ];
+
+			if ( ! is_string( $value ) && ! is_int( $value ) ) {
+				continue;
+			}
+
+			$input_variables[ $slug ] = $value;
+		}
+
+		return $input_variables;
 	}
 
 	public static function format_pagination_data_for_query_response( array|null $pagination_data, array $query_input_schema, array $input_variables ): array {

--- a/inc/Editor/DataBinding/Pagination.php
+++ b/inc/Editor/DataBinding/Pagination.php
@@ -112,6 +112,7 @@ class Pagination {
 		$page_variable = null;
 		$per_page_variable = null;
 
+		// Inspect the input schema to find the pagination variables.
 		foreach ( $query_input_schema as $slug => $input ) {
 			$type = $input['type'] ?? '';
 			if ( 'ui:pagination_cursor' === $type ) {
@@ -135,12 +136,17 @@ class Pagination {
 		$pagination_type = 'NONE';
 		$total_items = $pagination_data['total_items'] ?? null;
 
+		// These are the input variables that will be targeted for basic
+		// pagination types.
 		$pagination_input_variable_targets = [
 			'offset' => $offset_variable,
 			'page' => $page_variable,
 			'per_page' => $per_page_variable,
 		];
 
+		// For each pagination type, define the input variables used to
+		// navigate to the previous or next page. This will allow the
+		// pagination helper block to provide links to those pages.
 		if ( $cursor_variable ) {
 			$pagination_type = 'CURSOR_SIMPLE';
 

--- a/remote-data-blocks.php
+++ b/remote-data-blocks.php
@@ -35,6 +35,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 Editor\AdminNotices\AdminNotices::init();
 Editor\DataBinding\BlockBindings::init();
 Editor\DataBinding\FieldShortcode::init();
+Editor\DataBinding\Pagination::init();
 Editor\BlockManagement\BlockRegistration::init();
 Editor\BlockManagement\ConfigRegistry::init();
 Editor\PatternEditor\PatternEditor::init();

--- a/src/blocks/remote-data-container/edit.tsx
+++ b/src/blocks/remote-data-container/edit.tsx
@@ -35,7 +35,7 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 	const { getSupportedPatterns, innerBlocksPattern, insertPatternBlocks, resetInnerBlocks } =
 		usePatterns( blockName, rootClientId );
 
-	const { data, fetch, loading, reset } = useRemoteData( {
+	const { data, fetch, loading, reset, supportsPagination } = useRemoteData( {
 		blockName,
 		externallyManagedRemoteData: remoteDataAttribute,
 		externallyManagedUpdateRemoteData: updateRemoteData,
@@ -59,13 +59,14 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 	}
 
 	function onSelectPattern( pattern: BlockPattern ): void {
-		insertPatternBlocks( pattern );
+		insertPatternBlocks( pattern, supportsPagination );
 		setShowPatternSelection( false );
 	}
+
 	function onSelectRemoteData( inputs: RemoteDataQueryInput[] ): void {
 		void fetch( inputs ).then( () => {
 			if ( innerBlocksPattern ) {
-				insertPatternBlocks( innerBlocksPattern );
+				insertPatternBlocks( innerBlocksPattern, supportsPagination );
 				return;
 			}
 

--- a/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
+++ b/src/blocks/remote-data-container/hooks/usePaginationVariables.ts
@@ -1,19 +1,9 @@
 import { useState } from '@wordpress/element';
 
-import {
-	PAGINATION_CURSOR_NEXT_VARIABLE_TYPE,
-	PAGINATION_CURSOR_PREVIOUS_VARIABLE_TYPE,
-	PAGINATION_CURSOR_VARIABLE_TYPE,
-	PAGINATION_OFFSET_VARIABLE_TYPE,
-	PAGINATION_PAGE_VARIABLE_TYPE,
-	PAGINATION_PER_PAGE_VARIABLE_TYPE,
-} from '@/blocks/remote-data-container/config/constants';
-
-interface UsePaginationVariables {
+export interface UsePaginationVariables {
 	hasNextPage?: boolean;
-	onFetch: ( remoteData: RemoteData ) => void;
 	page: number;
-	paginationQueryInput: RemoteDataQueryInput;
+	paginationQueryInput?: RemoteDataQueryInput;
 	perPage?: number;
 	setPage: ( page: number ) => void;
 	setPerPage: ( perPage: number ) => void;
@@ -23,143 +13,125 @@ interface UsePaginationVariables {
 	totalPages?: number;
 }
 
-interface UsePaginationVariablesInput {
+export interface UsePaginationVariablesInput {
 	initialPage?: number;
 	initialPerPage?: number;
-	inputVariables: InputVariable[];
-}
-
-interface PaginationCursors {
-	next?: string;
-	previous?: string;
-}
-
-export enum PaginationType {
-	CURSOR_SIMPLE = 'cursor_simple',
-	CURSOR = 'cursor',
-	OFFSET = 'offset',
-	NONE = 'none',
-	PAGE = 'page',
+	paginationData?: RemoteDataPagination;
 }
 
 export function usePaginationVariables( {
 	initialPage = 1,
 	initialPerPage,
-	inputVariables,
+	paginationData,
 }: UsePaginationVariablesInput ): UsePaginationVariables {
-	const [ paginationData, setPaginationData ] = useState< RemoteDataPagination >();
 	const [ page, setPage ] = useState< number >( initialPage );
 	const [ perPage, setPerPage ] = useState< number | null >( initialPerPage ?? null );
-	const [ cursors, setCursors ] = useState< PaginationCursors >( {} );
+	const [ paginationQueryInput, setPaginationQueryInput ] = useState< RemoteDataQueryInput >();
 
-	const cursorVariable = inputVariables?.find(
-		input => input.type === PAGINATION_CURSOR_VARIABLE_TYPE
-	);
-	const cursorNextVariable = inputVariables?.find(
-		input => input.type === PAGINATION_CURSOR_NEXT_VARIABLE_TYPE
-	);
-	const cursorPreviousVariable = inputVariables?.find(
-		input => input.type === PAGINATION_CURSOR_PREVIOUS_VARIABLE_TYPE
-	);
-	const offsetVariable = inputVariables?.find(
-		input => input.type === PAGINATION_OFFSET_VARIABLE_TYPE
-	);
-	const pageVariable = inputVariables?.find(
-		input => input.type === PAGINATION_PAGE_VARIABLE_TYPE
-	);
-	const perPageVariable = inputVariables?.find(
-		input => input.type === PAGINATION_PER_PAGE_VARIABLE_TYPE
-	);
+	const nextPageQueryInput = paginationData?.input_variables?.next_page;
+	const previousPageQueryInput = paginationData?.input_variables?.previous_page;
+	const offsetVariable = paginationData?.input_variable_targets?.offset;
+	const pageVariable = paginationData?.input_variable_targets?.page;
+	const perPageVariable = paginationData?.input_variable_targets?.per_page;
 
-	const paginationQueryInput: RemoteDataQueryInput = {};
-	const nonFirstPage = page > 1;
-	const calculatedPerPage = perPage ?? paginationData?.perPage ?? 10;
-
-	// These will be amended below.
-	let hasNextPage = Boolean( paginationData?.hasNextPage ?? paginationData?.cursorNext );
-	let paginationType = PaginationType.NONE;
-	let setPageFn: ( page: number ) => void = () => {};
-
-	if ( cursorVariable ) {
-		paginationType = PaginationType.CURSOR_SIMPLE;
-		setPageFn = setPageForCursorPagination;
-		Object.assign( paginationQueryInput, {
-			[ cursorVariable.slug ]: cursors.next ?? cursors.previous,
-		} );
-	} else if ( cursorNextVariable && cursorPreviousVariable ) {
-		paginationType = PaginationType.CURSOR;
-		setPageFn = setPageForCursorPagination;
-		Object.assign( paginationQueryInput, {
-			[ cursorNextVariable.slug ]: cursors.next,
-			[ cursorPreviousVariable.slug ]: cursors.previous,
-		} );
-	} else if ( offsetVariable ) {
-		paginationType = PaginationType.OFFSET;
-		setPageFn = setPage;
-		if ( nonFirstPage ) {
-			Object.assign( paginationQueryInput, {
-				[ offsetVariable.slug ]: ( page - 1 ) * calculatedPerPage,
-			} );
-		}
-	} else if ( pageVariable ) {
-		paginationType = PaginationType.PAGE;
-		setPageFn = setPage;
-		Object.assign( paginationQueryInput, { [ pageVariable.slug ]: page } );
-	}
-
-	if ( perPageVariable && perPage ) {
-		Object.assign( paginationQueryInput, { [ perPageVariable.slug ]: perPage } );
-	}
-
-	const supportsPagination = paginationType !== PaginationType.NONE;
-	const totalItems = paginationData?.totalItems;
+	const calculatedPerPage = perPage ?? paginationData?.per_page ?? 10;
+	const hasNextPage = Boolean( nextPageQueryInput );
+	const supportsPagination = Boolean( paginationData?.type && paginationData?.type !== 'NONE' );
+	const totalItems = paginationData?.total_items;
 	const totalPages = totalItems ? Math.ceil( totalItems / calculatedPerPage ) : undefined;
 
-	if ( totalPages && page < totalPages ) {
-		hasNextPage = true;
-	}
-
-	function onFetch( remoteData: RemoteData ): void {
+	function setPageForPagination( requestedNewPage: number ): void {
 		if ( ! supportsPagination ) {
 			return;
 		}
 
-		setPaginationData( {
-			perPage: perPage ?? remoteData.results.length,
-			...remoteData.pagination,
-		} );
-	}
+		const wantsNextPage = requestedNewPage > page;
+		const wantsPreviousPage = requestedNewPage < page && requestedNewPage > 0;
+		const newPage = wantsNextPage
+			? Math.min( totalPages ?? page + 1, requestedNewPage )
+			: Math.max( 1, requestedNewPage );
 
-	// With cursor pagination, we can only go one page at a time.
-	function setPageForCursorPagination( newPage: number ): void {
-		// if page has gone up, we want to use nextCursor and set aside the current cursor as the previous one
-		// if the page has gone down, we want to use previousCursor and set aside the current cursor as the next one
-		if ( newPage > page ) {
-			setPage( Math.min( totalPages ?? page + 1, page + 1 ) );
-			setCursors( {
-				next: paginationData?.cursorNext ?? cursors.next,
-				previous: undefined,
-			} );
+		if ( ! wantsNextPage && ! wantsPreviousPage ) {
 			return;
 		}
 
-		if ( newPage < page ) {
-			setPage( Math.max( 1, page - 1 ) );
-			setCursors( {
-				next: undefined,
-				previous: paginationData?.cursorPrevious ?? cursors.previous,
-			} );
+		switch ( paginationData?.type ) {
+			case 'CURSOR':
+			case 'CURSOR_SIMPLE':
+				// With cursor pagination, we can only go one page at a time.
+				if ( wantsNextPage ) {
+					setPage( page + 1 );
+					setPaginationQueryInput( nextPageQueryInput );
+					break;
+				}
+
+				setPage( page - 1 );
+				setPaginationQueryInput( previousPageQueryInput );
+				break;
+
+			case 'OFFSET':
+				if ( ! offsetVariable ) {
+					break;
+				}
+
+				setPage( newPage );
+
+				if ( wantsNextPage ) {
+					setPaginationQueryInput( {
+						...nextPageQueryInput,
+						[ offsetVariable ]: calculatedPerPage * ( newPage - 1 ),
+					} );
+					break;
+				}
+
+				setPaginationQueryInput( {
+					...previousPageQueryInput,
+					[ offsetVariable ]: calculatedPerPage * ( newPage - 1 ),
+				} );
+				break;
+
+			case 'PAGE':
+				if ( ! pageVariable ) {
+					break;
+				}
+
+				setPage( newPage );
+
+				if ( wantsNextPage ) {
+					setPaginationQueryInput( {
+						...nextPageQueryInput,
+						[ pageVariable ]: newPage,
+					} );
+					break;
+				}
+
+				setPaginationQueryInput( {
+					...previousPageQueryInput,
+					[ pageVariable ]: newPage,
+				} );
+				break;
 		}
+	}
+
+	function setPerPageForPagination( newPerPage: number ): void {
+		if ( ! perPageVariable || calculatedPerPage === newPerPage ) {
+			return;
+		}
+
+		setPerPage( newPerPage );
+		setPaginationQueryInput( {
+			...paginationQueryInput,
+			[ perPageVariable ]: newPerPage,
+		} );
 	}
 
 	return {
 		hasNextPage,
-		onFetch,
 		page,
 		paginationQueryInput,
-		perPage: perPage ?? paginationData?.perPage,
-		setPage: setPageFn,
-		setPerPage: supportsPagination ? setPerPage : () => {},
+		perPage: perPage ?? paginationData?.per_page,
+		setPage: setPageForPagination,
+		setPerPage: setPerPageForPagination,
 		supportsPagination,
 		supportsPerPage: Boolean( perPageVariable ),
 		totalItems,

--- a/src/blocks/remote-data-container/hooks/usePatterns.ts
+++ b/src/blocks/remote-data-container/hooks/usePatterns.ts
@@ -4,7 +4,7 @@ import {
 	BlockPattern,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { cloneBlock, createBlock } from '@wordpress/blocks';
+import { BlockInstance, cloneBlock, createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 import {
@@ -42,6 +42,43 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 		( { name } ) => name === patterns?.inner_blocks
 	);
 
+	function getInnerBlocks( pattern: BlockPattern ): BlockInstance[] {
+		// If the pattern is a synced pattern, insert it directly.
+		if ( isSyncedPattern( pattern ) ) {
+			const syncedPattern = createBlock( 'core/block', { ref: pattern.id } );
+			const loopTemplate = createBlock( 'remote-data-blocks/template', {}, [ syncedPattern ] );
+			return [ loopTemplate ];
+		}
+
+		// Clone the pattern blocks with bindings to allow the user to make changes.
+		// We always insert a single representation of the pattern, even if it is a
+		// collection. The InnerBlocksLoop component will handle rendering the rest
+		// of the collection.
+		const patternBlocks =
+			pattern.blocks.map( block => {
+				const boundAttributes = getBoundAttributeEntries( block.attributes, remoteDataBlockName );
+
+				if ( ! boundAttributes.length ) {
+					return block;
+				}
+
+				return cloneBlock( block );
+			} ) ?? [];
+		const loopTemplate = createBlock( 'remote-data-blocks/template', {}, patternBlocks );
+
+		return [ loopTemplate ];
+	}
+
+	function insertPatternBlocks( pattern: BlockPattern, addPaginationBlock = false ): void {
+		const innerBlocks = getInnerBlocks( pattern );
+
+		if ( addPaginationBlock ) {
+			innerBlocks.push( createBlock( 'remote-data-blocks/pagination' ) );
+		}
+
+		replaceInnerBlocks( rootClientId, innerBlocks ).catch( () => {} );
+	}
+
 	const returnValue = {
 		defaultPattern,
 		getSupportedPatterns: ( result?: RemoteDataApiResult ): BlockPattern[] => {
@@ -66,33 +103,7 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 			} ) );
 		},
 		innerBlocksPattern,
-		insertPatternBlocks: ( pattern: BlockPattern ): void => {
-			// If the pattern is a synced pattern, insert it directly.
-			if ( isSyncedPattern( pattern ) ) {
-				const syncedPattern = createBlock( 'core/block', { ref: pattern.id } );
-				const loopTemplate = createBlock( 'remote-data-blocks/template', {}, [ syncedPattern ] );
-				replaceInnerBlocks( rootClientId, [ loopTemplate ] ).catch( () => {} );
-				return;
-			}
-
-			// Clone the pattern blocks with bindings to allow the user to make changes.
-			// We always insert a single representation of the pattern, even if it is a
-			// collection. The InnerBlocksLoop component will handle rendering the rest
-			// of the collection.
-			const patternBlocks =
-				pattern.blocks.map( block => {
-					const boundAttributes = getBoundAttributeEntries( block.attributes, remoteDataBlockName );
-
-					if ( ! boundAttributes.length ) {
-						return block;
-					}
-
-					return cloneBlock( block );
-				} ) ?? [];
-			const loopTemplate = createBlock( 'remote-data-blocks/template', {}, patternBlocks );
-
-			replaceInnerBlocks( rootClientId, [ loopTemplate ] ).catch( () => {} );
-		},
+		insertPatternBlocks,
 		resetInnerBlocks: (): void => {
 			replaceInnerBlocks( rootClientId, [] ).catch( () => {} );
 		},

--- a/src/blocks/remote-data-container/hooks/useRemoteData.ts
+++ b/src/blocks/remote-data-container/hooks/useRemoteData.ts
@@ -30,12 +30,7 @@ async function unmemoizedfetchRemoteData(
 	return {
 		blockName: body.block_name,
 		metadata: body.metadata,
-		pagination: body.pagination && {
-			cursorNext: body.pagination.cursor_next,
-			cursorPrevious: body.pagination.cursor_previous,
-			hasNextPage: body.pagination.has_next_page,
-			totalItems: body.pagination.total_items,
-		},
+		pagination: body.pagination,
 		queryKey: body.query_key,
 		queryInputs: body.query_inputs,
 		resultId: body.result_id,
@@ -119,10 +114,10 @@ export function useRemoteData( {
 	const enabledOverrides = externallyManagedRemoteData?.enabledOverrides ?? [];
 
 	const inputVariables = query.inputs;
+	const paginationData = resolvedData?.pagination;
 
 	const {
 		hasNextPage,
-		onFetch: onFetchForPagination,
 		page,
 		perPage,
 		paginationQueryInput,
@@ -130,11 +125,7 @@ export function useRemoteData( {
 		totalItems,
 		totalPages,
 		...paginationVariables
-	} = usePaginationVariables( {
-		initialPage,
-		initialPerPage,
-		inputVariables,
-	} );
+	} = usePaginationVariables( { initialPage, initialPerPage, paginationData } );
 	const { hasSearchInput, searchQueryInput, searchInput, setSearchInput, supportsSearch } =
 		useSearchVariables( {
 			initialSearchInput,
@@ -228,7 +219,6 @@ export function useRemoteData( {
 			return;
 		}
 
-		onFetchForPagination( remoteData );
 		resolvedUpdater( { enabledOverrides, ...remoteData } );
 		setLoading( false );
 		onSuccess?.();
@@ -254,7 +244,6 @@ export function useRemoteData( {
 		setSearchInput,
 		supportsPagination,
 		supportsSearch,
-		totalItems: resolvedData?.pagination?.totalItems,
 		totalPages,
 		...paginationVariables,
 	};

--- a/src/blocks/remote-data-pagination/block.json
+++ b/src/blocks/remote-data-pagination/block.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "remote-data-blocks/pagination",
+  "version": "0.1.0",
+  "usesContext": [ "remote-data-blocks/remoteData" ],
+  "title": "Remote Data Pagination",
+  "category": "widgets",
+  "description": "Pagination controls for remote data blocks",
+  "example": {},
+  "attributes": {},
+  "supports": {
+    "customClassName": false,
+    "className": false,
+    "html": false
+  },
+  "textdomain": "remote-data-blocks",
+  "editorScript": "file:./index.js",
+  "editorStyle": "file:./index.css",
+  "render": "file:./render.php",
+  "style": "file:./style-index.css"
+}

--- a/src/blocks/remote-data-pagination/edit.tsx
+++ b/src/blocks/remote-data-pagination/edit.tsx
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { BlockEditProps } from '@wordpress/blocks';
+import { Placeholder } from '@wordpress/components';
+
+import { useRemoteDataContext } from '@/blocks/remote-data-container/hooks/useRemoteDataContext';
+import { __ } from '@/utils/i18n';
+
+import './editor.scss';
+
+export function Edit( props: BlockEditProps< RemoteDataPaginationBlockAttributes > ): JSX.Element {
+	const { context } = props;
+	const blockProps = useBlockProps();
+
+	const { remoteData } = useRemoteDataContext( context );
+
+	if ( ! remoteData?.pagination ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					label={ __( 'Remote Data Pagination' ) }
+					instructions={ __(
+						'This block only works when placed inside a remote data block using data that supports pagination. This block will be ignored as currently configured.'
+					) }
+				/>
+			</div>
+		);
+	}
+
+	const labelPrevious = 'Previous';
+	const labelNext = 'Next';
+
+	// Loosely follows the core query-pagination-* blocks:
+	// https://github.com/WordPress/gutenberg/blob/268409673287c1effc6ae2acda720d3015f0f6f0/packages/block-library/src/query-pagination-previous/edit.js
+	//
+	// One key difference is that we are registering a single pagination block
+	// instead of separate previous, next, and page number blocks.
+	return (
+		<div { ...blockProps }>
+			<div className="remote-data-pagination">
+				<a href="#pagination-previous-pseudo-link" onClick={ event => event.preventDefault() }>
+					<span>{ labelPrevious }</span>
+				</a>
+				<a href="#pagination-next-pseudo-link" onClick={ event => event.preventDefault() }>
+					<span>{ labelNext }</span>
+				</a>
+			</div>
+		</div>
+	);
+}

--- a/src/blocks/remote-data-pagination/editor.scss
+++ b/src/blocks/remote-data-pagination/editor.scss
@@ -1,0 +1,3 @@
+/**
+ * The following styles get applied inside the editor only.
+ */

--- a/src/blocks/remote-data-pagination/index.ts
+++ b/src/blocks/remote-data-pagination/index.ts
@@ -1,0 +1,15 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { queryPagination } from '@wordpress/icons';
+
+import metadata from './block.json';
+import { Edit } from './edit';
+import { Save } from './save';
+import './style.scss';
+
+registerBlockType< RemoteDataPaginationBlockAttributes >( metadata.name, {
+	edit: Edit,
+	icon: {
+		src: queryPagination,
+	},
+	save: Save,
+} );

--- a/src/blocks/remote-data-pagination/render.php
+++ b/src/blocks/remote-data-pagination/render.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
+
+// Global variables provided by WordPress for block rendering:
+// $attributes (array): The block attributes.
+// $content (string): The block default content.
+// $block (WP_Block): The block instance.
+
+$pagination_links = BlockBindings::get_pagination_links( $block );
+
+$next_page_link = $pagination_links['next_page'] ?? null;
+$next_page_link_label = 'Next';
+$previous_page_link = $pagination_links['previous_page'] ?? null;
+$previous_page_link_label = 'Previous';
+
+?>
+<div <?php echo get_block_wrapper_attributes(); ?>>
+	<div class="remote-data-pagination">
+		<?php if ( null === $previous_page_link ) : ?>
+			<?php echo esc_html( $previous_page_link_label ); ?>
+		<?php else : ?>
+			<a href="<?php echo esc_url( $previous_page_link ); ?>">
+				<?php echo esc_html( $previous_page_link_label ); ?>
+			</a>
+		<?php endif; ?>
+
+		<?php if ( null === $next_page_link ) : ?>
+			<?php echo esc_html( $next_page_link_label ); ?>
+		<?php else : ?>
+			<a href="<?php echo esc_url( $next_page_link ); ?>">
+				<?php echo esc_html( $next_page_link_label ); ?>
+			</a>
+		<?php endif; ?>
+	</div>
+</div>

--- a/src/blocks/remote-data-pagination/save.tsx
+++ b/src/blocks/remote-data-pagination/save.tsx
@@ -1,0 +1,5 @@
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export function Save() {
+	return <InnerBlocks.Content />;
+}

--- a/src/blocks/remote-data-pagination/style.scss
+++ b/src/blocks/remote-data-pagination/style.scss
@@ -1,0 +1,14 @@
+/*
+ * The following styles get applied both inside the editor and on the frontend.
+ */
+
+.remote-data-pagination {
+	color: var( --wp--custom--remote-data-blocks--paginatin-link-disabled, #999 );
+	display: flex;
+	justify-content: space-between;
+	margin: 1rem 0;
+
+	a {
+		color: var( --wp--custom--remote-data-blocks--pagination-link, #000 );
+	}
+}

--- a/src/blocks/remote-data-pagination/style.scss
+++ b/src/blocks/remote-data-pagination/style.scss
@@ -3,12 +3,12 @@
  */
 
 .remote-data-pagination {
-	color: var( --wp--custom--remote-data-blocks--paginatin-link-disabled, #999 );
+	color: var(--wp--custom--remote-data-blocks--paginatin-link-disabled, #999);
 	display: flex;
 	justify-content: space-between;
 	margin: 1rem 0;
 
 	a {
-		color: var( --wp--custom--remote-data-blocks--pagination-link, #000 );
+		color: var(--wp--custom--remote-data-blocks--pagination-link, #000);
 	}
 }

--- a/tests/inc/Config/ArraySerializableTest.php
+++ b/tests/inc/Config/ArraySerializableTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Tests\Config;
+
+use PHPUnit\Framework\TestCase;
+use RemoteDataBlocks\Tests\Mocks\MockSerializableClass;
+use WP_Error;
+use function wp_json_encode;
+
+class ArraySerializableTest extends TestCase {
+	private array $sample_config = [
+		'boolean_value' => true,
+		'enum_value' => 'foo',
+		'string_value' => 'test',
+	];
+
+	public function test_get_id(): void {
+		$instance = MockSerializableClass::from_array( $this->sample_config );
+		$expected_id = md5( wp_json_encode( [ MockSerializableClass::class, $this->sample_config ] ) );
+		$this->assertSame( $expected_id, $instance->get_id() );
+	}
+
+	public function test_from_array_valid_config(): void {
+		$instance = MockSerializableClass::from_array( $this->sample_config );
+		$this->assertInstanceOf( MockSerializableClass::class, $instance );
+	}
+
+	public function test_from_array_invalid_config(): void {
+		$instance = MockSerializableClass::from_array( [ 'foo' => 'bar' ] );
+		$this->assertInstanceOf( WP_Error::class, $instance );
+	}
+
+	public function test_to_array(): void {
+		$instance = MockSerializableClass::from_array( $this->sample_config );
+		$config = $instance->to_array();
+		$expected_config = array_merge( 
+			$this->sample_config,
+			[ '__class' => MockSerializableClass::class ]
+		);
+
+		$this->assertSame( $expected_config, $config );
+	}
+}

--- a/tests/inc/Editor/DataBinding/PaginationTest.php
+++ b/tests/inc/Editor/DataBinding/PaginationTest.php
@@ -4,8 +4,15 @@ namespace RemoteDataBlocks\Tests\Editor\DataBinding;
 
 use PHPUnit\Framework\TestCase;
 use RemoteDataBlocks\Editor\DataBinding\Pagination;
+use RemoteDataBlocks\Tests\Mocks\MockQuery;
+use RemoteDataBlocks\Tests\Mocks\MockWordPressFunctions;
 
 class PaginationTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		MockWordPressFunctions::reset();
+	}
+
 	public function test_decode_query_var(): void {
 		$query_var_value = [
 			'test-block' => [
@@ -133,5 +140,126 @@ class PaginationTest extends TestCase {
 		$result = Pagination::format_pagination_data_for_query_response( $pagination_data, $query_input_schema, $input_variables );
 
 		$this->assertEquals( [], $result );
+	}
+
+	public function test_get_pagination_input_variables_for_current_request_with_valid_query_var(): void {
+		$mock_query = MockQuery::create( [
+			'input_schema' => [
+				'page' => [ 'type' => 'ui:pagination_page' ],
+				'per_page' => [ 'type' => 'ui:pagination_per_page' ],
+			],
+		] );
+
+		$query_id = $mock_query->get_id();
+		$query_var_value = [
+			'page' => 2,
+			'per_page' => 10,
+		];
+
+		// Mock get_query_var to return the encoded query var.
+		MockWordPressFunctions::inject_mock_query_var(
+			'rdb-pagination',
+			base64_encode( wp_json_encode( [ $query_id => $query_var_value ] ) )
+		);
+
+		$result = Pagination::get_pagination_input_variables_for_current_request( $mock_query );
+
+		$this->assertEquals( $query_var_value, $result );
+	}
+
+	public function test_get_pagination_input_variables_for_current_request_with_empty_query_var(): void {
+		$result = Pagination::get_pagination_input_variables_for_current_request( MockQuery::create() );
+
+		$this->assertEquals( [], $result );
+	}
+
+	public function test_get_pagination_input_variables_for_current_request_with_invalid_query_var(): void {
+		$mock_query = MockQuery::create();
+		$query_id = $mock_query->get_id();
+
+		// Mock get_query_var to return the encoded query var.
+		MockWordPressFunctions::inject_mock_query_var(
+			'rdb-pagination',
+			base64_encode( wp_json_encode( [ $query_id => base64_encode( wp_json_encode( 'foo' ) ) ] ) )
+		);
+
+		$result = Pagination::get_pagination_input_variables_for_current_request( $mock_query );
+
+		$this->assertEquals( [], $result );
+	}
+
+	public function test_get_pagination_input_variables_for_current_request_with_wrong_query_id(): void {
+		$mock_query = MockQuery::create( [
+			'input_schema' => [
+				'page' => [ 'type' => 'ui:pagination_page' ],
+				'per_page' => [ 'type' => 'ui:pagination_per_page' ],
+			],
+		] );
+
+		$query_id = 'wrong_' . $mock_query->get_id();
+		$query_var_value = [
+			'page' => 2,
+			'per_page' => 10,
+		];
+
+		// Mock get_query_var to return the encoded query var.
+		MockWordPressFunctions::inject_mock_query_var(
+			'rdb-pagination',
+			base64_encode( wp_json_encode( [ $query_id => $query_var_value ] ) )
+		);
+
+		$result = Pagination::get_pagination_input_variables_for_current_request( $mock_query );
+
+		$this->assertEquals( [], $result );
+	}
+
+	public function test_get_pagination_input_variables_for_current_request_removes_non_pagination_variables(): void {
+		$mock_query = MockQuery::create( [
+			'input_schema' => [
+				'page' => [ 'type' => 'ui:pagination_page' ],
+			],
+		] );
+
+		$query_id = $mock_query->get_id();
+		$query_var_value = [
+			'all_ur_base' => 'belong2us',
+			'name' => 'bobby_tables',
+			'page' => 2,
+		];
+
+		// Mock get_query_var to return the encoded query var.
+		MockWordPressFunctions::inject_mock_query_var(
+			'rdb-pagination',
+			base64_encode( wp_json_encode( [ $query_id => $query_var_value ] ) )
+		);
+
+		$result = Pagination::get_pagination_input_variables_for_current_request( $mock_query );
+
+		$this->assertEquals( [ 'page' => 2 ], $result );
+	}
+
+	public function test_get_pagination_input_variables_for_current_request_removes_non_primitive_values(): void {
+		$mock_query = MockQuery::create( [
+			'input_schema' => [
+				'page' => [ 'type' => 'ui:pagination_page' ],
+				'per_page' => [ 'type' => 'ui:pagination_per_page' ],
+			],
+		] );
+
+		$query_id = $mock_query->get_id();
+		$query_var_value = [
+			'page' => [ 1 ],
+			'per_page' => 10,
+		];
+
+		// Mock get_query_var to return the encoded query var.
+		MockWordPressFunctions::inject_mock_query_var(
+			'rdb-pagination',
+			base64_encode( wp_json_encode( [ $query_id => $query_var_value ] ) )
+		);
+
+		$result = Pagination::get_pagination_input_variables_for_current_request( $mock_query );
+
+		$this->assertEquals( [ 'per_page' => 10 ], $result );
 	}
 }

--- a/tests/inc/Editor/DataBinding/PaginationTest.php
+++ b/tests/inc/Editor/DataBinding/PaginationTest.php
@@ -1,0 +1,137 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Tests\Editor\DataBinding;
+
+use PHPUnit\Framework\TestCase;
+use RemoteDataBlocks\Editor\DataBinding\Pagination;
+
+class PaginationTest extends TestCase {
+	public function test_decode_query_var(): void {
+		$query_var_value = [
+			'test-block' => [
+				'page' => 2,
+				'per_page' => 10,
+			],
+		];
+
+		$encoded_query_var = base64_encode( wp_json_encode( $query_var_value ) );
+
+		$reflection = new \ReflectionClass( Pagination::class );
+		$method = $reflection->getMethod( 'decode_query_var' );
+
+		$decoded_query_var = $method->invoke( null, $encoded_query_var );
+
+		$this->assertEquals( $query_var_value, $decoded_query_var );
+	}
+
+	public function test_encode_query_var(): void {
+		$query_var_value = [
+			'test-block' => [
+				'page' => 2,
+				'per_page' => 10,
+			],
+		];
+
+		$reflection = new \ReflectionClass( Pagination::class );
+		$method = $reflection->getMethod( 'encode_query_var' );
+
+		$encoded_query_var = $method->invoke( null, $query_var_value );
+		$decoded_query_var = json_decode( base64_decode( $encoded_query_var ), true );
+
+		$this->assertEquals( $query_var_value, $decoded_query_var );
+	}
+
+	public function test_format_pagination_data_for_offset_pagination(): void {
+		$pagination_data = [
+			'total_items' => 100,
+		];
+
+		$query_input_schema = [
+			'offset' => [ 'type' => 'ui:pagination_offset' ],
+			'per_page' => [ 'type' => 'ui:pagination_per_page' ],
+		];
+
+		$input_variables = [
+			'offset' => 20,
+			'per_page' => 10,
+		];
+
+		$result = Pagination::format_pagination_data_for_query_response( $pagination_data, $query_input_schema, $input_variables );
+
+		$this->assertEquals( 'OFFSET', $result['type'] );
+		$this->assertEquals( 10, $result['per_page'] );
+		$this->assertEquals( 100, $result['total_items'] );
+		$this->assertArrayHasKey( 'next_page', $result['input_variables'] );
+		$this->assertArrayHasKey( 'previous_page', $result['input_variables'] );
+		$this->assertEquals( 30, $result['input_variables']['next_page']['offset'] );
+		$this->assertEquals( 10, $result['input_variables']['previous_page']['offset'] );
+	}
+
+	public function test_format_pagination_data_for_page_pagination(): void {
+		$pagination_data = [
+			'total_items' => 50,
+		];
+
+		$query_input_schema = [
+			'page' => [ 'type' => 'ui:pagination_page' ],
+			'per_page' => [ 'type' => 'ui:pagination_per_page' ],
+		];
+
+		$input_variables = [
+			'page' => 2,
+			'per_page' => 10,
+		];
+
+		$result = Pagination::format_pagination_data_for_query_response( $pagination_data, $query_input_schema, $input_variables );
+
+		$this->assertEquals( 'PAGE', $result['type'] );
+		$this->assertEquals( 10, $result['per_page'] );
+		$this->assertEquals( 50, $result['total_items'] );
+		$this->assertArrayHasKey( 'next_page', $result['input_variables'] );
+		$this->assertArrayHasKey( 'previous_page', $result['input_variables'] );
+		$this->assertEquals( 3, $result['input_variables']['next_page']['page'] );
+		$this->assertEquals( 1, $result['input_variables']['previous_page']['page'] );
+	}
+
+	public function test_format_pagination_data_for_cursor_pagination(): void {
+		$pagination_data = [
+			'total_items' => 200,
+			'cursor_next' => 'next-cursor',
+			'cursor_previous' => 'previous-cursor',
+		];
+
+		$query_input_schema = [
+			'cursor_next' => [ 'type' => 'ui:pagination_cursor_next' ],
+			'cursor_previous' => [ 'type' => 'ui:pagination_cursor_previous' ],
+			'per_page' => [ 'type' => 'ui:pagination_per_page' ],
+		];
+
+		$input_variables = [
+			'per_page' => 20,
+		];
+
+		$result = Pagination::format_pagination_data_for_query_response( $pagination_data, $query_input_schema, $input_variables );
+
+		$this->assertEquals( 'CURSOR', $result['type'] );
+		$this->assertEquals( 20, $result['per_page'] );
+		$this->assertEquals( 200, $result['total_items'] );
+		$this->assertArrayHasKey( 'next_page', $result['input_variables'] );
+		$this->assertArrayHasKey( 'previous_page', $result['input_variables'] );
+		$this->assertEquals( 'next-cursor', $result['input_variables']['next_page']['cursor_next'] );
+		$this->assertEquals( 'previous-cursor', $result['input_variables']['previous_page']['cursor_previous'] );
+	}
+
+	public function test_format_pagination_data_for_no_pagination(): void {
+		$pagination_data = [
+			'total_items' => 0,
+		];
+
+		$query_input_schema = [];
+
+		$input_variables = [];
+
+		$result = Pagination::format_pagination_data_for_query_response( $pagination_data, $query_input_schema, $input_variables );
+
+		$this->assertEquals( [], $result );
+	}
+}

--- a/tests/inc/Mocks/MockWordPressFunctions.php
+++ b/tests/inc/Mocks/MockWordPressFunctions.php
@@ -15,6 +15,9 @@ class MockWordPressFunctions {
 	/** @var array<string, mixed> */
 	private static array $mocked_options = [];
 
+	/** @var array<string, string> */
+	private static array $mocked_query_vars = [];
+
 	public static function apply_filters( string $filter, mixed $thing, mixed ...$args ): mixed {
 		self::$done_filters[ $filter ] = $args;
 
@@ -38,8 +41,16 @@ class MockWordPressFunctions {
 		return self::$done_filters[ $filter ] ?? null;
 	}
 
+	public static function get_query_var( string $name, string|null $default_value = null ): ?string {
+		return self::$mocked_query_vars[ $name ] ?? $default_value;
+	}
+
 	public static function get_option( string $option, mixed $default = false ): mixed {
 		return self::$mocked_options[ $option ] ?? $default;
+	}
+
+	public static function inject_mock_query_var( string $name, string $value ): void {
+		self::$mocked_query_vars[ $name ] = $value;
 	}
 
 	public static function set_mock_option( string $option, mixed $value ): void {
@@ -51,5 +62,6 @@ class MockWordPressFunctions {
 		self::$done_filters = [];
 		self::$mocked_filters = [];
 		self::$mocked_options = [];
+		self::$mocked_query_vars = [];
 	}
 }

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -104,6 +104,10 @@ function get_page_by_path( string $path ): string {
 	return $path ?? 'fake WP_Post';
 }
 
+function get_query_var( string $_var_name, mixed $default_value ): mixed {
+	return $default_value;
+}
+
 function wp_generate_uuid4(): string {
 	return '00000000-0000-4000-8000-000000000000';
 }

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -104,8 +104,8 @@ function get_page_by_path( string $path ): string {
 	return $path ?? 'fake WP_Post';
 }
 
-function get_query_var( string $_var_name, mixed $default_value ): mixed {
-	return $default_value;
+function get_query_var( string $var_name, mixed $default_value = null ): ?string {
+	return MockWordPressFunctions::get_query_var( $var_name, $default_value );
 }
 
 function wp_generate_uuid4(): string {

--- a/tests/src/blocks/remote-data-container/hooks/usePaginationVariables.test.ts
+++ b/tests/src/blocks/remote-data-container/hooks/usePaginationVariables.test.ts
@@ -2,55 +2,33 @@ import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import {
-	PAGINATION_CURSOR_NEXT_VARIABLE_TYPE,
-	PAGINATION_CURSOR_PREVIOUS_VARIABLE_TYPE,
-	PAGINATION_CURSOR_VARIABLE_TYPE,
-	PAGINATION_OFFSET_VARIABLE_TYPE,
-	PAGINATION_PAGE_VARIABLE_TYPE,
-	PAGINATION_PER_PAGE_VARIABLE_TYPE,
-} from '@/blocks/remote-data-container/config/constants';
-import { usePaginationVariables } from '@/blocks/remote-data-container/hooks/usePaginationVariables';
-
-function generateRemoteData(
-	resultCount: number,
-	paginationData: RemoteDataPagination
-): RemoteData {
-	return {
-		blockName: 'test/block',
-		queryKey: 'test-query',
-		queryInputs: [],
-		metadata: {},
-		resultId: 'result-id',
-		results: Array.from( { length: resultCount }, () => ( {
-			result: {},
-			uuid: 'uuid',
-		} ) ),
-		pagination: paginationData,
-	};
-}
+	usePaginationVariables,
+	UsePaginationVariablesInput,
+} from '@/blocks/remote-data-container/hooks/usePaginationVariables';
 
 describe( 'usePaginationVariables', () => {
 	it( 'provides static variables when pagination is not supported', () => {
-		const inputVariables: InputVariable[] = [];
-
-		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+		const { result, rerender } = renderHook(
+			( props: UsePaginationVariablesInput ) => usePaginationVariables( props ),
+			{ initialProps: {} }
+		);
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBeUndefined();
 		expect( result.current.supportsPagination ).toBe( false );
 
 		// Simulate remote data fetch
-		act( () => {
-			result.current.onFetch(
-				generateRemoteData( 5, {
-					cursorNext: 'cursor-next',
-					totalItems: 100,
-				} )
-			);
+		rerender( {
+			paginationData: {
+				input_variables: {},
+				input_variable_targets: {},
+				type: 'NONE',
+			},
 		} );
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBeUndefined();
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 		expect( result.current.supportsPagination ).toBe( false );
 		expect( result.current.totalItems ).toBeUndefined();
 		expect( result.current.totalPages ).toBeUndefined();
@@ -61,50 +39,46 @@ describe( 'usePaginationVariables', () => {
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBeUndefined();
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 		expect( result.current.supportsPagination ).toBe( false );
 		expect( result.current.totalItems ).toBeUndefined();
 		expect( result.current.totalPages ).toBeUndefined();
 	} );
 
 	it( 'supports initial page and per-page input', () => {
-		const inputVariables: InputVariable[] = [];
-
-		const { result } = renderHook( () =>
-			usePaginationVariables( { initialPage: 11, initialPerPage: 27, inputVariables } )
+		const { result } = renderHook(
+			( props: UsePaginationVariablesInput ) => usePaginationVariables( props ),
+			{ initialProps: { initialPage: 11, initialPerPage: 27 } }
 		);
 
 		expect( result.current.page ).toBe( 11 );
 		expect( result.current.perPage ).toBe( 27 );
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 		expect( result.current.supportsPagination ).toBe( false );
 	} );
 
 	it( 'supports page-based pagination', () => {
-		const inputVariables = [
-			{
-				required: false,
-				slug: 'page',
-				type: PAGINATION_PAGE_VARIABLE_TYPE,
-			},
-			{
-				required: false,
-				slug: 'perPage',
-				type: PAGINATION_PER_PAGE_VARIABLE_TYPE,
-			},
-		];
-
-		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+		const { result, rerender } = renderHook(
+			( props: UsePaginationVariablesInput ) => usePaginationVariables( props ),
+			{ initialProps: {} }
+		);
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBeUndefined();
-		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 
 		// Simulate remote data fetch
-		act( () => {
-			result.current.onFetch(
-				generateRemoteData( 5, {
-					totalItems: 100,
-				} )
-			);
+		rerender( {
+			paginationData: {
+				input_variables: {},
+				input_variable_targets: {
+					page: 'item',
+					per_page: 'perPage',
+				},
+				per_page: 5,
+				total_items: 100,
+				type: 'PAGE',
+			},
 		} );
 
 		expect( result.current.page ).toBe( 1 );
@@ -118,6 +92,7 @@ describe( 'usePaginationVariables', () => {
 
 		expect( result.current.page ).toBe( 3 );
 		expect( result.current.perPage ).toBe( 5 );
+		expect( result.current.paginationQueryInput ).toEqual( { item: 3 } );
 		expect( result.current.supportsPagination ).toBe( true );
 		expect( result.current.totalItems ).toBe( 100 );
 		expect( result.current.totalPages ).toBe( 20 );
@@ -127,44 +102,41 @@ describe( 'usePaginationVariables', () => {
 
 		expect( result.current.page ).toBe( 3 );
 		expect( result.current.perPage ).toBe( 25 );
+		expect( result.current.paginationQueryInput ).toEqual( { item: 3, perPage: 25 } );
 		expect( result.current.supportsPagination ).toBe( true );
 		expect( result.current.totalItems ).toBe( 100 );
 		expect( result.current.totalPages ).toBe( 4 );
 	} );
 
 	it( 'should support cursor pagination', () => {
-		const inputVariables = [
-			{
-				required: false,
-				slug: 'next',
-				type: PAGINATION_CURSOR_NEXT_VARIABLE_TYPE,
-			},
-			{
-				required: false,
-				slug: 'previous',
-				type: PAGINATION_CURSOR_PREVIOUS_VARIABLE_TYPE,
-			},
-		];
-
-		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+		const { result, rerender } = renderHook(
+			( props: UsePaginationVariablesInput ) => usePaginationVariables( props ),
+			{ initialProps: {} }
+		);
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBeUndefined();
-		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 
 		// Simulate remote data fetch
-		act( () => {
-			result.current.onFetch(
-				generateRemoteData( 10, {
-					cursorNext: 'test-next-cursor',
-					totalItems: 115,
-				} )
-			);
+		rerender( {
+			paginationData: {
+				input_variables: {
+					next_page: {
+						next: 'test-next-cursor',
+					},
+					previous_page: {},
+				},
+				input_variable_targets: {},
+				per_page: 10,
+				total_items: 115,
+				type: 'CURSOR',
+			},
 		} );
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBe( 10 );
-		expect( result.current.paginationQueryInput ).toEqual( {} );
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 		expect( result.current.supportsPagination ).toBe( true );
 		expect( result.current.totalItems ).toBe( 115 );
 		expect( result.current.totalPages ).toBe( 12 );
@@ -180,14 +152,21 @@ describe( 'usePaginationVariables', () => {
 		expect( result.current.totalPages ).toBe( 12 );
 
 		// Simulate remote data fetch
-		act( () => {
-			result.current.onFetch(
-				generateRemoteData( 15, {
-					cursorNext: 'test-next-cursor-2',
-					cursorPrevious: 'test-previous-cursor',
-					totalItems: 105,
-				} )
-			);
+		rerender( {
+			paginationData: {
+				input_variables: {
+					next_page: {
+						next: 'test-next-cursor-2',
+					},
+					previous_page: {
+						previous: 'test-previous-cursor',
+					},
+				},
+				input_variable_targets: {},
+				per_page: 15,
+				total_items: 105,
+				type: 'CURSOR',
+			},
 		} );
 
 		// Update page - 1
@@ -202,33 +181,33 @@ describe( 'usePaginationVariables', () => {
 	} );
 
 	it( 'should support "simple" cursor pagination', () => {
-		const inputVariables = [
-			{
-				required: false,
-				slug: 'cursor',
-				type: PAGINATION_CURSOR_VARIABLE_TYPE,
-			},
-		];
-
-		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+		const { result, rerender } = renderHook(
+			( props: UsePaginationVariablesInput ) => usePaginationVariables( props ),
+			{ initialProps: {} }
+		);
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBeUndefined();
-		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 
 		// Simulate remote data fetch
-		act( () => {
-			result.current.onFetch(
-				generateRemoteData( 10, {
-					cursorNext: 'test-next-cursor',
-					totalItems: 115,
-				} )
-			);
+		rerender( {
+			paginationData: {
+				input_variables: {
+					next_page: {
+						cursor: 'test-next-cursor',
+					},
+				},
+				input_variable_targets: {},
+				per_page: 10,
+				total_items: 115,
+				type: 'CURSOR_SIMPLE',
+			},
 		} );
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBe( 10 );
-		expect( result.current.paginationQueryInput ).toEqual( {} );
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 		expect( result.current.supportsPagination ).toBe( true );
 		expect( result.current.totalItems ).toBe( 115 );
 		expect( result.current.totalPages ).toBe( 12 );
@@ -244,13 +223,14 @@ describe( 'usePaginationVariables', () => {
 		expect( result.current.totalPages ).toBe( 12 );
 
 		// Simulate remote data fetch
-		act( () => {
-			result.current.onFetch(
-				generateRemoteData( 15, {
-					cursorNext: 'test-next-cursor-2',
-					totalItems: 105,
-				} )
-			);
+		rerender( {
+			paginationData: {
+				input_variables: {},
+				input_variable_targets: {},
+				per_page: 15,
+				total_items: 105,
+				type: 'CURSOR_SIMPLE',
+			},
 		} );
 
 		// Update page - 1
@@ -258,44 +238,39 @@ describe( 'usePaginationVariables', () => {
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBe( 15 );
-		expect( result.current.paginationQueryInput ).toEqual( {} );
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 		expect( result.current.supportsPagination ).toBe( true );
 		expect( result.current.totalItems ).toBe( 105 );
 		expect( result.current.totalPages ).toBe( 7 );
 	} );
 
 	it( 'should support offset pagination', () => {
-		const inputVariables = [
-			{
-				required: false,
-				slug: 'offset',
-				type: PAGINATION_OFFSET_VARIABLE_TYPE,
-			},
-			{
-				required: false,
-				slug: 'perPage',
-				type: PAGINATION_PER_PAGE_VARIABLE_TYPE,
-			},
-		];
-
-		const { result } = renderHook( () => usePaginationVariables( { inputVariables } ) );
+		const { result, rerender } = renderHook(
+			( props: UsePaginationVariablesInput ) => usePaginationVariables( props ),
+			{ initialProps: {} }
+		);
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBeUndefined();
-		expect( result.current.supportsPagination ).toBe( true );
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 
 		// Simulate remote data fetch
-		act( () => {
-			result.current.onFetch(
-				generateRemoteData( 10, {
-					totalItems: 115,
-				} )
-			);
+		rerender( {
+			paginationData: {
+				input_variables: {},
+				input_variable_targets: {
+					offset: 'limit',
+					per_page: 'perPage',
+				},
+				per_page: 10,
+				total_items: 115,
+				type: 'OFFSET',
+			},
 		} );
 
 		expect( result.current.page ).toBe( 1 );
 		expect( result.current.perPage ).toBe( 10 );
-		expect( result.current.paginationQueryInput ).toEqual( {} );
+		expect( result.current.paginationQueryInput ).toBeUndefined();
 		expect( result.current.supportsPagination ).toBe( true );
 		expect( result.current.totalItems ).toBe( 115 );
 		expect( result.current.totalPages ).toBe( 12 );
@@ -305,18 +280,23 @@ describe( 'usePaginationVariables', () => {
 
 		expect( result.current.page ).toBe( 3 );
 		expect( result.current.perPage ).toBe( 10 );
-		expect( result.current.paginationQueryInput ).toEqual( { offset: 20 } );
+		expect( result.current.paginationQueryInput ).toEqual( { limit: 20 } );
 		expect( result.current.supportsPagination ).toBe( true );
 		expect( result.current.totalItems ).toBe( 115 );
 		expect( result.current.totalPages ).toBe( 12 );
 
 		// Simulate remote data fetch
-		act( () => {
-			result.current.onFetch(
-				generateRemoteData( 15, {
-					totalItems: 105,
-				} )
-			);
+		rerender( {
+			paginationData: {
+				input_variables: {},
+				input_variable_targets: {
+					offset: 'limit',
+					per_page: 'perPage',
+				},
+				per_page: 15,
+				total_items: 105,
+				type: 'OFFSET',
+			},
 		} );
 
 		// Update page - 1
@@ -324,7 +304,7 @@ describe( 'usePaginationVariables', () => {
 
 		expect( result.current.page ).toBe( 2 );
 		expect( result.current.perPage ).toBe( 15 );
-		expect( result.current.paginationQueryInput ).toEqual( { offset: 15 } );
+		expect( result.current.paginationQueryInput ).toEqual( { limit: 15 } );
 		expect( result.current.supportsPagination ).toBe( true );
 		expect( result.current.totalItems ).toBe( 105 );
 		expect( result.current.totalPages ).toBe( 7 );

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -3,11 +3,19 @@ interface InnerBlockContext {
 }
 
 interface RemoteDataPagination {
-	cursorNext?: string;
-	cursorPrevious?: string;
-	hasNextPage?: boolean;
-	perPage?: number;
-	totalItems?: number;
+	input_variables: {
+		next_page?: RemoteDataQueryInput;
+		previous_page?: RemoteDataQueryInput;
+	};
+	// Mapping of supported pagination input variables to their slugs.
+	input_variable_targets: {
+		offset?: string;
+		page?: string;
+		per_page?: string;
+	};
+	per_page?: number;
+	total_items?: number;
+	type: 'CURSOR' | 'CURSOR_SIMPLE' | 'OFFSET' | 'PAGE' | 'NONE';
 }
 
 interface RemoteDataResultFields {
@@ -35,6 +43,8 @@ interface RemoteData {
 interface RemoteDataBlockAttributes {
 	remoteData?: RemoteData;
 }
+
+interface RemoteDataPaginationBlockAttributes {}
 
 interface RemoteDataTemplateBlockAttributes {}
 
@@ -90,12 +100,7 @@ interface RemoteDataApiResult {
 interface RemoteDataApiResponseBody {
 	block_name: string;
 	metadata: Record< string, RemoteDataResultFields >;
-	pagination?: {
-		cursor_next?: string;
-		cursor_previous?: string;
-		has_next_page?: boolean;
-		total_items?: number;
-	};
+	pagination?: RemoteDataPagination;
 	query_inputs: RemoteDataQueryInput[];
 	query_key: string;
 	result_id: string;


### PR DESCRIPTION
This PR adds a pagination helper block that enables pagination on the front-end (render). It loosely follows the pattern of the Core query pagination block, but fully encapsulates the pagination links. This pagination block is automatically inserted whenever a collection that supports pagination is inserted.

The biggest change is moving logic from the `usePaginationVariables` hook to PHP, so that both server-side and client-side code can reuse the logic. This logic is encapsulated in the new `Pagination` class and consumed by `QueryRunner` and `BlockBindings`.

Pagination links are implemented via a single query variable (`rdb-pagination`) that envelopes all possible pagination parameters (cursor, offset, page, etc.) and encodes them in base64. Example: `?rdb-pagination=eyI3MDkzOWFmYWZmNDE4MWYwODI5MTUzMTk4Nzg1ODE0ZSI6eyJwYWdlIjozfX0`.

For now, we will only support navigating a single block's pagination thread at any time, but the implementation leaves room to support multiple threads in the future, should that surface as an important use case.

### Automatic pagination block insertion

https://github.com/user-attachments/assets/3c286105-a977-468f-a857-069bdf323fb6


### Front-end pagination

https://github.com/user-attachments/assets/a083e277-3dfb-45bd-bae5-49947807fa02

