### PR TITLE
Use `ubuntu-latest` in workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     name: End-to-End Testing against WordPress
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     name: WordPress Integration Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,6 @@ jobs:
 
   dependaban:
     name: Dependaban
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: Automattic/vip-actions/dependaban@trunk


### PR DESCRIPTION
Use `ubuntu-latest` in workflows; `ubuntu-20*` is being retired.