### PR TITLE
Improve manual query input components

### DIFF
--- a/example/rest-api/art-institute/art-institute.php
+++ b/example/rest-api/art-institute/art-institute.php
@@ -102,12 +102,12 @@ function register_aic_block(): void {
 		'input_schema' => [
 			'limit' => [
 				'default_value' => 10,
-				'name' => 'Pagination limit',
+				'name' => 'Items per page',
 				'type' => 'ui:pagination_per_page',
 			],
 			'page' => [
 				'default_value' => 1,
-				'name' => 'Pagination page',
+				'name' => 'Starting page',
 				'type' => 'ui:pagination_page',
 			],
 		],

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -78,6 +78,7 @@ class ConfigRegistry {
 					'image_url' => $display_query->get_image_url(),
 					'inputs' => array_map( function ( $slug, $input_var ) {
 						return [
+							'default_value' => isset( $input_var['default_value'] ) ? strval( $input_var['default_value'] ) : null,
 							'name' => $input_var['name'] ?? $slug,
 							'required' => $input_var['required'] ?? true,
 							'slug' => $slug,

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -76,15 +76,7 @@ class ConfigRegistry {
 			'selectors' => [
 				[
 					'image_url' => $display_query->get_image_url(),
-					'inputs' => array_map( function ( $slug, $input_var ) {
-						return [
-							'default_value' => isset( $input_var['default_value'] ) ? strval( $input_var['default_value'] ) : null,
-							'name' => $input_var['name'] ?? $slug,
-							'required' => $input_var['required'] ?? true,
-							'slug' => $slug,
-							'type' => $input_var['type'] ?? 'string',
-						];
-					}, array_keys( $input_schema ), array_values( $input_schema ) ),
+					'inputs' => self::map_input_variables( $input_schema ),
 					'name' => $has_required_variables ? 'Manual input' : ( $is_collection ? 'Load collection' : 'Load item' ),
 					'query_key' => self::DISPLAY_QUERY_KEY,
 					'type' => $has_required_variables ? 'manual-input' : 'load-without-input',
@@ -126,14 +118,7 @@ class ConfigRegistry {
 				$config['selectors'],
 				[
 					'image_url' => $from_query->get_image_url(),
-					'inputs' => array_map( function ( $slug, $input_var ) {
-						return [
-							'name' => $input_var['name'] ?? $slug,
-							'required' => $input_var['required'] ?? false,
-							'slug' => $slug,
-							'type' => $input_var['type'] ?? 'string',
-						];
-					}, array_keys( $from_input_schema ), array_values( $from_input_schema ) ),
+					'inputs' => self::map_input_variables( $input_schema ),
 					'name' => $selection_query['display_name'] ?? ucfirst( $from_query_type ),
 					'query_key' => $from_query::class,
 					'type' => $from_query_type,
@@ -193,5 +178,21 @@ class ConfigRegistry {
 		}
 
 		return $config;
+	}
+
+	private static function map_input_variables( array $input_schema ): array {
+		return array_map(
+			function ( string $slug, array $input_var ): array {
+				return [
+					'default_value' => isset( $input_var['default_value'] ) ? strval( $input_var['default_value'] ) : null,
+					'name' => $input_var['name'] ?? '',
+					'slug' => $slug,
+					'type' => $input_var['type'] ?? 'string',
+					'required' => $input_var['required'] ?? false,
+				];
+			},
+			array_keys( $input_schema ),
+			array_values( $input_schema )
+		);
 	}
 }

--- a/src/blocks/remote-data-container/components/modals/InputModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/InputModal.tsx
@@ -22,7 +22,7 @@ interface InputModalProps {
 
 export function InputModal( props: InputModalProps ) {
 	const initialInputState = props.inputs.reduce(
-		( acc, input ) => ( { ...acc, [ input.slug ]: '' } ),
+		( acc, input ) => ( { ...acc, [ input.slug ]: input.default_value ?? '' } ),
 		{}
 	);
 

--- a/src/blocks/remote-data-container/components/panels/QueryInputsPanel.tsx
+++ b/src/blocks/remote-data-container/components/panels/QueryInputsPanel.tsx
@@ -2,13 +2,23 @@ import { Button, PanelBody, TextControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+import { DISPLAY_QUERY_KEY } from '@/blocks/remote-data-container/config/constants';
+
 interface QueryInputsPanelProps {
-	queryInputs: RemoteDataQueryInput[];
-	onUpdateQueryInputs: ( inputs: RemoteDataQueryInput[] ) => void;
+	onUpdateQueryInputs: ( queryKey: string, inputs: RemoteDataQueryInput[] ) => void;
+	remoteData: RemoteData;
+	selectors: BlockConfig[ 'selectors' ];
 }
 
-export function QueryInputsPanel( { queryInputs, onUpdateQueryInputs }: QueryInputsPanelProps ) {
+export function QueryInputsPanel( {
+	onUpdateQueryInputs,
+	remoteData,
+	selectors,
+}: QueryInputsPanelProps ) {
+	const { queryInputs = [], queryKey = DISPLAY_QUERY_KEY } = remoteData;
 	const [ localInputs, setLocalInputs ] = useState( queryInputs );
+	const inputDefinitions =
+		selectors?.find( selector => selector.query_key === queryKey )?.inputs ?? [];
 
 	return (
 		<PanelBody title={ __( 'Query Inputs', 'remote-data-blocks' ) }>
@@ -29,17 +39,18 @@ export function QueryInputsPanel( { queryInputs, onUpdateQueryInputs }: QueryInp
 						return Object.fromEntries( entries ) as RemoteDataQueryInput;
 					} );
 
-					onUpdateQueryInputs( cleanedInputs );
+					onUpdateQueryInputs( queryKey, cleanedInputs );
 				} }
 			>
 				{ localInputs.map( ( input, index ) =>
 					Object.entries( input ).map( ( [ key, value ] ) => {
 						const displayValue = Array.isArray( value ) ? value.join( ',' ) : ( value as string );
+						const inputDefinition = inputDefinitions.find( definition => definition.slug === key );
 
 						return (
 							<TextControl
 								key={ `${ index }-${ key }` }
-								label={ key }
+								label={ inputDefinition?.name ?? key }
 								value={ displayValue }
 								onChange={ newValue => {
 									setLocalInputs(
@@ -49,7 +60,7 @@ export function QueryInputsPanel( { queryInputs, onUpdateQueryInputs }: QueryInp
 									);
 								} }
 								onBlur={ () => {
-									onUpdateQueryInputs( localInputs );
+									onUpdateQueryInputs( queryKey, localInputs );
 								} }
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom

--- a/src/blocks/remote-data-container/edit.tsx
+++ b/src/blocks/remote-data-container/edit.tsx
@@ -80,12 +80,15 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 		}
 	}
 
-	function onUpdateQueryInputs( inputs: RemoteDataQueryInput[] ): void {
-		if ( ! remoteDataAttribute ) return;
+	function onUpdateQueryInputs( queryKey: string, inputs: RemoteDataQueryInput[] ): void {
+		if ( ! remoteDataAttribute ) {
+			return;
+		}
 
 		updateRemoteData( {
 			...remoteDataAttribute,
 			queryInputs: inputs,
+			queryKey,
 		} );
 		refreshRemoteData();
 	}
@@ -128,8 +131,9 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 					resetRemoteData={ resetRemoteData }
 				/>
 				<QueryInputsPanel
-					queryInputs={ migrateRemoteData( props.attributes.remoteData )?.queryInputs ?? [] }
 					onUpdateQueryInputs={ onUpdateQueryInputs }
+					remoteData={ data }
+					selectors={ blockConfig.selectors }
 				/>
 			</InspectorControls>
 

--- a/tests/src/blocks/remote-data-container/components/panels/QueryInputsPanel.test.tsx
+++ b/tests/src/blocks/remote-data-container/components/panels/QueryInputsPanel.test.tsx
@@ -5,23 +5,50 @@ import { describe, expect, it, vi } from 'vitest';
 import { QueryInputsPanel } from '@/blocks/remote-data-container/components/panels/QueryInputsPanel';
 
 describe( 'QueryInputsPanel', () => {
+	const selectors: BlockConfig[ 'selectors' ] = [
+		{
+			inputs: [
+				{
+					name: 'id',
+					required: true,
+					slug: 'id',
+					type: 'string',
+					default_value: '',
+				},
+				{
+					name: 'record_id',
+					required: false,
+					slug: 'record_id',
+					type: 'string',
+					default_value: '',
+				},
+			],
+			name: 'test_selector',
+			query_key: 'test_query_key',
+			type: 'manual',
+		},
+	];
+
+	const remoteData: RemoteData = {
+		blockName: 'test/block',
+		metadata: {},
+		queryKey: 'test_query_key',
+		queryInputs: [],
+		resultId: 'test',
+		results: [],
+	};
+
 	it( 'should render multiple inputs for query inputs with an array of ids', async () => {
 		const user = userEvent.setup();
 		const onUpdateQueryInputs = vi.fn();
 		render(
 			<QueryInputsPanel
-				queryInputs={ [
-					{
-						id: 'test1',
-					},
-					{
-						id: 'test2',
-					},
-					{
-						id: 'test3',
-					},
-				] }
 				onUpdateQueryInputs={ onUpdateQueryInputs }
+				remoteData={ {
+					...remoteData,
+					queryInputs: [ { id: 'test1' }, { id: 'test2' }, { id: 'test3' } ],
+				} }
+				selectors={ selectors }
 			/>
 		);
 
@@ -42,7 +69,7 @@ describe( 'QueryInputsPanel', () => {
 		await user.tab();
 
 		// Called with only the first input value changed
-		expect( onUpdateQueryInputs ).toHaveBeenCalledWith( [
+		expect( onUpdateQueryInputs ).toHaveBeenCalledWith( 'test_query_key', [
 			{
 				id: 'test4',
 			},
@@ -60,12 +87,16 @@ describe( 'QueryInputsPanel', () => {
 		const onUpdateQueryInputs = vi.fn();
 		render(
 			<QueryInputsPanel
-				queryInputs={ [
-					{
-						record_id: [ 'test1', 'test2', 'test3', 'test4' ],
-					},
-				] }
 				onUpdateQueryInputs={ onUpdateQueryInputs }
+				remoteData={ {
+					...remoteData,
+					queryInputs: [
+						{
+							record_id: [ 'test1', 'test2', 'test3', 'test4' ],
+						},
+					],
+				} }
+				selectors={ selectors }
 			/>
 		);
 
@@ -76,7 +107,7 @@ describe( 'QueryInputsPanel', () => {
 		await user.type( screen.getByRole( 'textbox' ), 'test5' );
 		await user.tab();
 
-		expect( onUpdateQueryInputs ).toHaveBeenCalledWith( [
+		expect( onUpdateQueryInputs ).toHaveBeenCalledWith( 'test_query_key', [
 			{
 				record_id: 'test5',
 			},
@@ -86,7 +117,7 @@ describe( 'QueryInputsPanel', () => {
 		await user.type( screen.getByRole( 'textbox' ), ',test6' );
 		await user.tab();
 
-		expect( onUpdateQueryInputs ).toHaveBeenCalledWith( [
+		expect( onUpdateQueryInputs ).toHaveBeenCalledWith( 'test_query_key', [
 			{
 				record_id: 'test5,test6',
 			},

--- a/types/localized-block-data.d.ts
+++ b/types/localized-block-data.d.ts
@@ -5,6 +5,8 @@ type AvailableBindings = Record< string, RemoteDataBinding >;
  * This corresponds directly to the input schema defined by a query.
  */
 interface InputVariable {
+	/** The stringified default value of the variable */
+	default_value?: string;
 	/** The display friendly name of the variable */
 	name?: string;
 	/** Whether the variable is required, or not in the query */


### PR DESCRIPTION
Applying some improvements from @smithjw1 's comments and code review:

- [Provide default value to manual query input](https://github.com/Automattic/remote-data-blocks/commit/e8bdae5caf221d214e1ff2d19314f76db95c96eb)
- [Provide the input variable display name to QueryInputsPanel](https://github.com/Automattic/remote-data-blocks/commit/60cb06953771f923a83069e051be750aab166f44)
- [Update Art Institute pagination variable names](https://github.com/Automattic/remote-data-blocks/commit/9a0a819d8f4e532e324872f718d4ab67c9b0eaee)
- [Abstract input variable mapping](https://github.com/Automattic/remote-data-blocks/commit/542d41da44773c443c8333dc6134967fbf42fbcd)
