### PR TITLE
Use a label to highlight the connected block

### DIFF
--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -76,7 +76,7 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Remote Data', 'remote-data-blocks' ) }>
-					<p style={ { fontSize: 'small', color: 'rgb(117, 117, 117)' } }>
+					<p className="rdb-block-helper-text">
 						{ sprintf( __( 'Connected to %s', 'remote-data-blocks' ), remoteDataTitle ) }
 					</p>
 					<BlockBindingControls

--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -75,9 +75,10 @@ function BoundBlockEdit( props: BoundBlockEditProps ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody
-					title={ sprintf( __( 'Remote Data Block: %s', 'remote-data-blocks' ), remoteDataTitle ) }
-				>
+				<PanelBody title={ __( 'Remote Data', 'remote-data-blocks' ) }>
+					<p style={ { fontSize: 'small', color: 'rgb(117, 117, 117)' } }>
+						{ sprintf( __( 'Connected to %s', 'remote-data-blocks' ), remoteDataTitle ) }
+					</p>
 					<BlockBindingControls
 						attributes={ attributes }
 						availableBindings={ availableBindings }

--- a/src/blocks/remote-data-container/editor.scss
+++ b/src/blocks/remote-data-container/editor.scss
@@ -219,3 +219,9 @@ remote-data-blocks-inline-field {
 .components-modal__content.has-scrolled-content:not(.hide-header) .components-modal__header {
 	border: none;
 }
+
+// Set the helper text for the RDB block to be the same as the Gutenberg helper text
+.rdb-block-helper-text {
+	font-size: 0.75rem;
+	color: rgb(117, 117, 117);
+}

--- a/src/blocks/remote-data-container/editor.scss
+++ b/src/blocks/remote-data-container/editor.scss
@@ -220,7 +220,7 @@ remote-data-blocks-inline-field {
 	border: none;
 }
 
-// Set the helper text for the RDB block to be the same as the Gutenberg helper text
+// Mirror the Gutenberg helper text style for the RDB block
 .rdb-block-helper-text {
 	font-size: 0.75rem;
 	color: rgb(117, 117, 117);


### PR DESCRIPTION
### Description

This PR is meant to incorporate the feedback from @jarekmorawski, to build on #443. It does the following:

- Revert the title back to `Remote Data`
- Add in a paragraph that mirrors the Gutenberg helper text to highlight what the underlying block binding is.

![CleanShot 2025-04-10 at 11 49 44 (1)](https://github.com/user-attachments/assets/01a42a73-10ac-4a4c-8b34-04722e4c078a)
