### PR TITLE
Fix block name regression

### DIFF
--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -162,7 +162,7 @@ class ConfigRegistry {
 
 	private static function register_block_pattern( string $block_name, string $pattern_title, string $pattern_content ): string {
 		// Add the block arg to any bindings present in the pattern.
-		$pattern_name = 'remote-data-blocks/' . sanitize_title_with_dashes( $pattern_title );
+		$pattern_name = 'remote-data-blocks/' . sanitize_title_with_dashes( $pattern_title, '', 'save' );
 
 		// Create the pattern properties, allowing overrides via pattern options.
 		$pattern_properties = [

--- a/inc/Editor/BlockManagement/ConfigStore.php
+++ b/inc/Editor/BlockManagement/ConfigStore.php
@@ -29,7 +29,7 @@ class ConfigStore {
 	 * titles must be unique).
 	 */
 	public static function get_block_name( string $block_title ): string {
-		return 'remote-data-blocks/' . sanitize_title_with_dashes( $block_title );
+		return 'remote-data-blocks/' . sanitize_title_with_dashes( $block_title, '', 'save' );
 	}
 
 	/**

--- a/tests/integration/blocks/BlockConfigTest.php
+++ b/tests/integration/blocks/BlockConfigTest.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\IntegrationTests\Blocks;
+
+use RDBTestCase;
+use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;
+
+class BlockConfigTest extends RDBTestCase {
+	public function testBlockWithComplexName(): void {
+		$block_name = ConfigStore::get_block_name( 'Block Name with/slashes and*asterisks' );
+		$this->assertEquals( 'remote-data-blocks/block-name-with-slashes-andasterisks', $block_name );
+	}
+}


### PR DESCRIPTION
Fixes a regression when we moved to `sanitize_title_with_dashes` to generate the block name. This affected remotedatablocks.com because it passed slashes in the block title (e.g., "GitHub HTML for File Automattic/remote-data-blocks").

See https://developer.wordpress.org/reference/functions/sanitize_title_with_dashes/