### PR TITLE
Drop retry strategy and up cache time

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -72,7 +72,7 @@ When a request to your site renders one or more remote data blocks, our plugin w
 
 The plugin offers a caching layer for optimal performance and helps avoid rate limiting from remote data sources. It will be used if your WordPress environment configures a [persistent object cache](https://developer.wordpress.org/reference/classes/wp_object_cache/#persistent-cache-plugins). Otherwise, the plugin will utilize in-memory (per-page-load) caching. Deploying to production without a persistent object cache is not recommended.
 
-The default TTL for all cache objects is 60 seconds, but it can be [configured per query or request](../extending/query.md#get_cache_ttl).
+The default TTL for all cache objects is 5 minutes, but it can be [configured per query or request](../extending/query.md#get_cache_ttl).
 
 ## Theming
 

--- a/docs/extending/hooks.md
+++ b/docs/extending/hooks.md
@@ -146,30 +146,3 @@ function custom_query_response_metadata( array $metadata, HttpQueryInterface $qu
 }
 add_filter( 'remote_data_blocks_query_response_metadata', 'custom_query_response_metadata', 10, 3 );
 ```
-
-### remote_data_blocks_http_client_retry_delay
-
-Filter to change the defualt 1 second delapy after an HTTP request fails. The Remote Data Blocks Plugin uses the [Guzzle](https://github.com/guzzle/guzzle) HTTP client. You can read about the response interface in their [documentation](https://docs.guzzlephp.org/en/stable/).
-
-```php
-function custom_response_retry_delay( int $retry_after_ms, int $retries, ?ResponseInterface $response ): int {
-	// Implement a custom exponential backoff strategy.
-	return floor( pow( 1.5, $retries ) * 1000 );
-}
-add_filter( 'remote_data_blocks_http_client_retry_delay', 'custom_response_retry_delay', 10, 3 );
-```
-
-### remote_data_blocks_http_client_retry_decider
-
-Filter the default HTTP retry logic when an HTTP request fails or encounters an exception. The Remote Data Blocks Plugin uses the [Guzzle](https://github.com/guzzle/guzzle) HTTP client. You can read about the request, response, and exception interfaces in their [documentation](https://docs.guzzlephp.org/en/stable/).
-
-```php
-function custom_retry_decider( bool $should_retry, int $retries, RequestInterface $request, ?ResponseInterface $response, ?Exception $exception ): bool {
-	// Retry on a 408 error if the number of retries is less than 5.
-	if ( $retries < 5 && $response && 408 === $response->getStatusCode ) {
-		return true;
-	}
-	return $should_retry;
-}
-add_filter( 'remote_data_blocks_http_client_retry_decider', 'custom_response_retry_on_exception', 10, 5 );
-```

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -143,11 +143,8 @@ class HttpClient {
 	 * @return int Number of milliseconds to delay.
 	 */
 	public static function retry_delay( int $retries, ?ResponseInterface $response ): int {
-		// "Full Jitter" algorithm taken from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-		$retry_base = 1; // 1 second
-		$retry_cap = 60; // 1 minute
-		$min_retry_after = min( $retry_cap, $retry_base * ( 2 ** $retries ) );
-		$retry_after = wp_rand( $retry_base, $min_retry_after );
+		// Implement an exponential backoff strategy, with the delay capped at 60s.
+		$retry_after = min( 1 * pow( $retries, 2 ), 60 );
 
 		// If the response has a Retry-After header, use that value.
 		// If the value is a date, calculate the difference from now.

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -143,10 +143,11 @@ class HttpClient {
 	 * @return int Number of milliseconds to delay.
 	 */
 	public static function retry_delay( int $retries, ?ResponseInterface $response ): int {
-		// Implement an exponential backoff strategy with jitter, with the delay capped at 60s and a minimum of 1s.
+		// Implement an exponential backoff strategy with jitter, with the delay capped at 10s and a minimum of 1s.
 		// Full Jitter taken from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/.
-		$retry_after_without_jitter = min( 60, 1 * pow( 2, $retries ) );
-		$retry_after = wp_rand( 0, $retry_after_without_jitter );
+		// Given we only retry 3 times, this will really never exceed 8s.
+		$retry_after_without_jitter = min( 10, 1 * pow( 2, $retries ) );
+		$retry_after = wp_rand( 1, $retry_after_without_jitter );
 
 		// If the response has a Retry-After header, use that value.
 		// If the value is a date, calculate the difference from now.

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -143,8 +143,10 @@ class HttpClient {
 	 * @return int Number of milliseconds to delay.
 	 */
 	public static function retry_delay( int $retries, ?ResponseInterface $response ): int {
-		// Implement an exponential backoff strategy, with the delay capped at 60s.
-		$retry_after = min( 1 * pow( $retries, 2 ), 60 );
+		// Implement an exponential backoff strategy with jitter, with the delay capped at 60s and a minimum of 1s.
+		// Full Jitter taken from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/.
+		$retry_after_without_jitter = min( 60, 1 * pow( 2, $retries ) );
+		$retry_after = wp_rand( 0, $retry_after_without_jitter );
 
 		// If the response has a Retry-After header, use that value.
 		// If the value is a date, calculate the difference from now.

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -143,9 +143,15 @@ class HttpClient {
 	 * @return int Number of milliseconds to delay.
 	 */
 	public static function retry_delay( int $retries, ?ResponseInterface $response ): int {
-		// Be default, implement a linear backoff strategy.
-		$retry_after = $retries;
+		// "Full Jitter" algorithm taken from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+		$retry_base = 1; // 1 second
+		$retry_cap = 60; // 1 minute
+		$min_retry_after = min( $retry_cap, $retry_base * ( 2 ** $retries ) );
+		$retry_after = wp_rand( $retry_base, $min_retry_after );
 
+		// If the response has a Retry-After header, use that value.
+		// If the value is a date, calculate the difference from now.
+		// If the value is a number, use that as the delay.
 		if ( $response instanceof ResponseInterface && $response->hasHeader( 'Retry-After' ) ) {
 			$retry_after = $response->getHeaderLine( 'Retry-After' );
 
@@ -154,7 +160,9 @@ class HttpClient {
 			}
 		}
 
+		// Convert it to milliseconds.
 		$retry_after_ms = (int) $retry_after * 1000;
+
 		return apply_filters( 'remote_data_blocks_http_client_retry_delay', $retry_after_ms, $retries, $response );
 	}
 

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -92,9 +92,9 @@ class HttpClient {
 			return $request;
 		} ) );
 
-		// $default_ttl = $client_options[ self::CACHE_TTL_CLIENT_OPTION_KEY ] ?? null;
-		// $cache_middleware = self::get_cache_middleware( $default_ttl );
-		// $this->handler_stack->push( $cache_middleware, 'remote_data_blocks_cache' );
+		$default_ttl = $client_options[ self::CACHE_TTL_CLIENT_OPTION_KEY ] ?? null;
+		$cache_middleware = self::get_cache_middleware( $default_ttl );
+		$this->handler_stack->push( $cache_middleware, 'remote_data_blocks_cache' );
 
 		$this->handler_stack->push( Middleware::log(
 			LoggerManager::instance(),

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -124,7 +124,7 @@ class HttpClient {
 
 		$should_retry = false;
 
-		if ( $response && $response->getStatusCode() >= 500 ) {
+		if ( $response && ( $response->getStatusCode() >= 500 || $response->getStatusCode() === 429 ) ) {
 			$should_retry = true;
 		}
 

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -2,10 +2,8 @@
 
 namespace RemoteDataBlocks\HttpClient;
 
-use Exception;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\Utils;
@@ -20,8 +18,6 @@ defined( 'ABSPATH' ) || exit();
 
 class HttpClient {
 	public Client $client;
-
-	private const MAX_RETRIES = 3;
 
 	public const CACHE_TTL_CLIENT_OPTION_KEY = '__default_cache_ttl';
 
@@ -79,11 +75,6 @@ class HttpClient {
 
 		$this->handler_stack = HandlerStack::create( $request_handler );
 
-		$this->handler_stack->push( Middleware::retry(
-			self::class . '::retry_decider',
-			self::class . '::retry_delay'
-		) );
-
 		$this->handler_stack->push( Middleware::mapRequest( function ( RequestInterface $request ) {
 			foreach ( $this->headers as $header => $value ) {
 				$request = $request->withHeader( $header, $value );
@@ -105,62 +96,6 @@ class HttpClient {
 			'base_uri' => $this->base_uri,
 			'handler' => $this->handler_stack,
 		] ) );
-	}
-
-	/**
-	 * Determine if the request request be retried.
-	 *
-	 * @param int               $retries Number of retries that have been attempted so far.
-	 * @param RequestInterface  $request Request that was sent.
-	 * @param ResponseInterface $response Response that was received.
-	 * @param Exception         $exception Exception that was received (if any).
-	 * @return bool Whether the request should be retried.
-	 */
-	public static function retry_decider( int $retries, RequestInterface $request, ?ResponseInterface $response = null, ?Exception $exception = null ): bool {
-		// Exceeding max retries is not overrideable.
-		if ( $retries >= self::MAX_RETRIES ) {
-			return false;
-		}
-
-		$should_retry = false;
-
-		if ( $response && ( $response->getStatusCode() >= 500 || $response->getStatusCode() === 429 ) ) {
-			$should_retry = true;
-		}
-
-		if ( $exception ) {
-			$should_retry = $should_retry || $exception instanceof ConnectException;
-		}
-
-		return apply_filters( 'remote_data_blocks_http_client_retry_decider', $should_retry, $retries, $request, $response, $exception );
-	}
-
-	/**
-	 * Calculate the delay before retrying a request.
-	 *
-	 * @param int               $retries Number of retries that have been attempted so far.
-	 * @param ResponseInterface $response Response that was received.
-	 * @return int Number of milliseconds to delay.
-	 */
-	public static function retry_delay( int $retries, ?ResponseInterface $response ): int {
-		// Implement an exponential backoff strategy, with the delay capped at 10s and a minimum of 1s.
-		// Given we only retry 3 times, this will really never exceed 8s.
-		$retry_after = min( 10, 1 * pow( 2, $retries ) );
-
-		// If the response has a Retry-After header, use that value.
-		// If the value is a date, calculate the difference from now.
-		// If the value is a number, use that as the delay.
-		if ( $response instanceof ResponseInterface && $response->hasHeader( 'Retry-After' ) ) {
-			$retry_after = $response->getHeaderLine( 'Retry-After' );
-
-			if ( ! is_numeric( $retry_after ) ) {
-				$retry_after = ( new \DateTime( $retry_after ) )->getTimestamp() - time();
-			}
-		}
-
-		// Convert it to milliseconds.
-		$retry_after_ms = (int) $retry_after * 1000;
-		return apply_filters( 'remote_data_blocks_http_client_retry_delay', $retry_after_ms, $retries, $response );
 	}
 
 	/**

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -159,7 +159,6 @@ class HttpClient {
 
 		// Convert it to milliseconds.
 		$retry_after_ms = (int) $retry_after * 1000;
-
 		return apply_filters( 'remote_data_blocks_http_client_retry_delay', $retry_after_ms, $retries, $response );
 	}
 

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -92,9 +92,9 @@ class HttpClient {
 			return $request;
 		} ) );
 
-		$default_ttl = $client_options[ self::CACHE_TTL_CLIENT_OPTION_KEY ] ?? null;
-		$cache_middleware = self::get_cache_middleware( $default_ttl );
-		$this->handler_stack->push( $cache_middleware, 'remote_data_blocks_cache' );
+		// $default_ttl = $client_options[ self::CACHE_TTL_CLIENT_OPTION_KEY ] ?? null;
+		// $cache_middleware = self::get_cache_middleware( $default_ttl );
+		// $this->handler_stack->push( $cache_middleware, 'remote_data_blocks_cache' );
 
 		$this->handler_stack->push( Middleware::log(
 			LoggerManager::instance(),
@@ -143,11 +143,9 @@ class HttpClient {
 	 * @return int Number of milliseconds to delay.
 	 */
 	public static function retry_delay( int $retries, ?ResponseInterface $response ): int {
-		// Implement an exponential backoff strategy with jitter, with the delay capped at 10s and a minimum of 1s.
-		// Full Jitter taken from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/.
+		// Implement an exponential backoff strategy, with the delay capped at 10s and a minimum of 1s.
 		// Given we only retry 3 times, this will really never exceed 8s.
-		$retry_after_without_jitter = min( 10, 1 * pow( 2, $retries ) );
-		$retry_after = wp_rand( 1, $retry_after_without_jitter );
+		$retry_after = min( 10, 1 * pow( 2, $retries ) );
 
 		// If the response has a Retry-After header, use that value.
 		// If the value is a date, calculate the difference from now.

--- a/inc/HttpClient/RdbCacheStrategy.php
+++ b/inc/HttpClient/RdbCacheStrategy.php
@@ -14,7 +14,7 @@ use RemoteDataBlocks\Logging\LoggerManager;
 
 class RdbCacheStrategy extends GreedyCacheStrategy {
 	private const CACHE_INVALIDATING_REQUEST_HEADERS = [ 'Authorization', 'Cache-Control' ];
-	private const FALLBACK_CACHE_TTL_IN_SECONDS = 60;
+	private const FALLBACK_CACHE_TTL_IN_SECONDS = 300; // 5 minutes
 	private const WP_OBJECT_CACHE_GROUP = 'remote-data-blocks';
 
 	private Logger $logger;

--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -11,7 +11,6 @@ use Psr\Http\Message\ResponseInterface;
 class AirtableIntegration {
 	public static function init(): void {
 		add_action( 'init', [ __CLASS__, 'register_blocks' ], 10, 0 );
-		add_filter( 'rdb_http_client_set_retry_delay', [ __CLASS__, 'set_retry_delay_for_rate_limiting' ], 10, 3 );
 	}
 
 	public static function register_blocks(): void {

--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -6,10 +6,12 @@ use RemoteDataBlocks\Store\DataSource\DataSourceConfigManager;
 use RemoteDataBlocks\Config\Query\HttpQuery;
 use RemoteDataBlocks\Formatting\StringFormatter;
 use RemoteDataBlocks\Snippet\Snippet;
+use Psr\Http\Message\ResponseInterface;
 
 class AirtableIntegration {
 	public static function init(): void {
 		add_action( 'init', [ __CLASS__, 'register_blocks' ], 10, 0 );
+		add_filter( 'rdb_http_client_set_retry_delay', [ __CLASS__, 'set_retry_delay_for_rate_limiting' ], 10, 3 );
 	}
 
 	public static function register_blocks(): void {
@@ -208,5 +210,21 @@ class AirtableIntegration {
 		}
 
 		return $snippets;
+	}
+
+	/**
+	 * Set the retry delay to be 30s, when requests are rate limited by Airtable.
+	 *
+	 * @param int $retry_after_ms The retry delay in milliseconds.
+	 * @param int $retries The number of retries that have been attempted so far.
+	 * @param ResponseInterface|null $response The response that was received.
+	 * @return int The number of milliseconds to delay.
+	 */
+	public static function set_retry_delay_for_rate_limiting( int $retry_after_ms, int $retries, ?ResponseInterface $response ): int {
+		if ( $response && $response->getStatusCode() === 429 && $retry_after_ms < 300000 ) {
+			$retry_after_ms = 300000;
+		}
+
+		return $retry_after_ms;
 	}
 }

--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -6,7 +6,6 @@ use RemoteDataBlocks\Store\DataSource\DataSourceConfigManager;
 use RemoteDataBlocks\Config\Query\HttpQuery;
 use RemoteDataBlocks\Formatting\StringFormatter;
 use RemoteDataBlocks\Snippet\Snippet;
-use Psr\Http\Message\ResponseInterface;
 
 class AirtableIntegration {
 	public static function init(): void {

--- a/inc/Integrations/Airtable/AirtableIntegration.php
+++ b/inc/Integrations/Airtable/AirtableIntegration.php
@@ -211,20 +211,4 @@ class AirtableIntegration {
 
 		return $snippets;
 	}
-
-	/**
-	 * Set the retry delay to be 30s, when requests are rate limited by Airtable.
-	 *
-	 * @param int $retry_after_ms The retry delay in milliseconds.
-	 * @param int $retries The number of retries that have been attempted so far.
-	 * @param ResponseInterface|null $response The response that was received.
-	 * @return int The number of milliseconds to delay.
-	 */
-	public static function set_retry_delay_for_rate_limiting( int $retry_after_ms, int $retries, ?ResponseInterface $response ): int {
-		if ( $response && $response->getStatusCode() === 429 && $retry_after_ms < 300000 ) {
-			$retry_after_ms = 300000;
-		}
-
-		return $retry_after_ms;
-	}
 }

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -107,28 +107,6 @@ class HttpClientTest extends TestCase {
 		$this->assertSame( 'Connection Error', $results[2]['reason']->getMessage() );
 	}
 
-	public function testRepeatedGetCallsWithErrorsResultsInCacheHit(): void {
-		// We are going to simulate a scenario where the first request returns a 200 response,
-		// and the second request returns a 500 error.
-		$this->mock_handler->append( new Response( 200, [], 'Cached Response' ), new Response( 500, [], 'Server Error' ) );
-		$this->assertEquals( 2, $this->mock_handler->count(), 'The mock handler should have exactly two requests' );
-
-		// Make the first request and ensure the 200 is cached
-		$first_response = $this->http_client->request( 'GET', '/test' );
-		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have exactly one request after the first request' );
-		$this->assertEquals( 200, $first_response->getStatusCode() );
-		$this->assertEquals( 'Cached Response', (string) $first_response->getBody() );
-		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
-
-
-		// Make the second request to the same endpoint, and it should return the cached response
-		$second_response = $this->http_client->request( 'GET', '/test' );
-		$this->assertEquals( 200, $second_response->getStatusCode() );
-		$this->assertEquals( 'Cached Response', (string) $second_response->getBody() );
-		$this->assertEquals( 'HIT', $second_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
-		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should be not be empty as a cached 200 is returned during an error' );
-	}
-
 	public function testRepeatedGetCallsResultsInCacheHit(): void {
 		// Set up the mock handler with only one response
 		$this->mock_handler->append( new Response( 200, [], 'Cached Response' ) );

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -60,48 +60,6 @@ class HttpClientTest extends TestCase {
 		$this->assertSame( 'MISS', $response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 	}
 
-	public function testRetryDecider(): void {
-		$request = new Request( 'GET', '/test' );
-
-		// Test max retries
-		$this->assertFalse( HttpClient::retry_decider( 3, $request ) );
-
-		// Test 500 status code
-		$response = new Response( 500 );
-		$this->assertTrue( HttpClient::retry_decider( 0, $request, $response ) );
-
-		// Test 429 status code
-		$response = new Response( 429 );
-		$this->assertTrue( HttpClient::retry_decider( 0, $request, $response ) );
-
-		// Test ConnectException
-		$exception = new ConnectException( 'Error Connecting', $request );
-		$this->assertTrue( HttpClient::retry_decider( 0, $request, null, $exception ) );
-
-		// Test no retry on good response
-		$response = new Response( 200 );
-		$this->assertFalse( HttpClient::retry_decider( 0, $request, $response ) );
-	}
-
-	public function testRetryDelay(): void {
-		$response = new Response( 429, [ 'Retry-After' => '120' ] );
-		$delay = HttpClient::retry_delay( 1, $response );
-		$this->assertSame( 120000, $delay );
-
-		$response = new Response( 429, [ 'Retry-After' => ( new \DateTime( '+2 minutes' ) )->format( \DateTime::RFC7231 ) ] );
-		$delay = HttpClient::retry_delay( 1, $response );
-		$this->assertGreaterThan( 119000, $delay );
-		$this->assertLessThan( 121000, $delay );
-
-		$response = new Response( 500 );
-		$delay = HttpClient::retry_delay( 2, $response );
-		$this->assertSame( 4000, $delay );
-
-		$response = new Response( 500 );
-		$delay = HttpClient::retry_delay( 3, $response );
-		$this->assertSame( 8000, $delay );
-	}
-
 	public function testQueueRequestAndExecuteParallel(): void {
 		$this->mock_handler->append( new Response( 200, [], 'Response 1' ) );
 		$this->mock_handler->append( new Response( 201, [], 'Response 2' ) );

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -70,6 +70,10 @@ class HttpClientTest extends TestCase {
 		$response = new Response( 500 );
 		$this->assertTrue( HttpClient::retry_decider( 0, $request, $response ) );
 
+		// Test 429 status code
+		$response = new Response( 429 );
+		$this->assertTrue( HttpClient::retry_decider( 0, $request, $response ) );
+
 		// Test ConnectException
 		$exception = new ConnectException( 'Error Connecting', $request );
 		$this->assertTrue( HttpClient::retry_decider( 0, $request, null, $exception ) );
@@ -91,7 +95,11 @@ class HttpClientTest extends TestCase {
 
 		$response = new Response( 500 );
 		$delay = HttpClient::retry_delay( 2, $response );
-		$this->assertSame( 2000, $delay );
+		$this->assertSame( 4000, $delay );
+
+		$response = new Response( 500 );
+		$delay = HttpClient::retry_delay( 3, $response );
+		$this->assertSame( 8000, $delay );
 	}
 
 	public function testQueueRequestAndExecuteParallel(): void {

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -107,6 +107,28 @@ class HttpClientTest extends TestCase {
 		$this->assertSame( 'Connection Error', $results[2]['reason']->getMessage() );
 	}
 
+	public function testRepeatedGetCallsWithErrorsResultsInCacheHit(): void {
+		// We are going to simulate a scenario where the first request returns a 200 response,
+		// and the second request returns a 500 error.
+		$this->mock_handler->append( new Response( 200, [], 'Cached Response' ), new Response( 500, [], 'Server Error' ) );
+		$this->assertEquals( 2, $this->mock_handler->count(), 'The mock handler should have exactly two requests' );
+
+		// Make the first request and ensure the 200 is cached
+		$first_response = $this->http_client->request( 'GET', '/test' );
+		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have exactly one request after the first request' );
+		$this->assertEquals( 200, $first_response->getStatusCode() );
+		$this->assertEquals( 'Cached Response', (string) $first_response->getBody() );
+		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
+
+
+		// Make the second request to the same endpoint, and it should return the cached response
+		$second_response = $this->http_client->request( 'GET', '/test' );
+		$this->assertEquals( 200, $second_response->getStatusCode() );
+		$this->assertEquals( 'Cached Response', (string) $second_response->getBody() );
+		$this->assertEquals( 'HIT', $second_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
+		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should be not be empty as a cached 200 is returned during an error' );
+	}
+
 	public function testRepeatedGetCallsResultsInCacheHit(): void {
 		// Set up the mock handler with only one response
 		$this->mock_handler->append( new Response( 200, [], 'Cached Response' ) );


### PR DESCRIPTION
### Description

In trying to figure out how to add rate limiting to the plugin, I wanted to first see if our retry strategy was good enough especially in cases where a retry might be needed. This would cover the case where rate limiting is starting to occur, and we are able to ensure that we can stop it from worsening. It wouldn't cover the case where rate limiting may start happening, but hasn't yet. The [Airtable SDK caught my eye](https://github.com/Airtable/airtable.js/blob/master/src/run_action.ts#L70), as they implement an exponential backoff strategy with jitter to try and cover the case where rate limiting is starting to occur. 

I experimented with a script that fired off 50, and 100 requests to see rate limiting in action. I then added in linear backoff (what we have), followed by exponential backoff to see if they would solve it. Both options did solve it, with linear sometimes needing an extra request or two as the overall requests began to scale up unlike exponential. Exponential does add a bit more of a delay, compared to the linear backoff but its a much better guarantee in requests succeeding as requests don't go out at a consistent time.

Between this, and the fact that API calls are cached for 60s we should be in an even better place.

### Testing

- I tested this using a node script to isolate the retry behaviour without any caching. Essentially the script would make 50 GET requests to `https://api.airtable.com/v0/base_id/table_id` with an exponential backoff retry strategy. It would log when a request was retried, which was only on 429s though it can be expanded to 500s as well.