### PR TITLE
ignore node_modules for webpack watch

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,10 +9,21 @@ const additionalScripts = {
 
 const { modernize, moduleConfig, scriptConfig } = require( './webpack.utils' );
 
+// Add watchOptions configuration to reduce file watching load
+const watchOptions = {
+	ignored: /node_modules/,
+	aggregateTimeout: 300,
+};
+
 module.exports = [
-	modernize( scriptConfig, additionalScripts, [
-		// we only need to fork one copy of ts-checker off here in these webpack exports
-		new ForkTsCheckerWebpackPlugin(),
-	] ),
-	modernize( moduleConfig ),
+	modernize(
+		scriptConfig,
+		additionalScripts,
+		[
+			// we only need to fork one copy of ts-checker off here in these webpack exports
+			new ForkTsCheckerWebpackPlugin(),
+		],
+		watchOptions
+	),
+	modernize( moduleConfig, {}, [], watchOptions ),
 ];

--- a/webpack.utils.js
+++ b/webpack.utils.js
@@ -7,7 +7,7 @@ const path = require( 'path' );
 // This function modernizes the configuration object to support TypeScript. It
 // also allows for additional scripts to be added to the entry point. Blocks are
 // included by default, so this is only needed for non-block scripts.
-function modernize( config, additionalScripts = {}, additionalPlugins = [] ) {
+function modernize( config, additionalScripts = {}, additionalPlugins = [], watchOptions = {} ) {
 	return {
 		...config,
 		entry: {
@@ -37,6 +37,7 @@ function modernize( config, additionalScripts = {}, additionalPlugins = [] ) {
 				'@': path.resolve( __dirname, 'src/' ),
 			},
 		},
+		watchOptions: Object.keys( watchOptions ).length ? watchOptions : config.watchOptions,
 	};
 }
 

--- a/webpack.utils.js
+++ b/webpack.utils.js
@@ -37,7 +37,7 @@ function modernize( config, additionalScripts = {}, additionalPlugins = [], watc
 				'@': path.resolve( __dirname, 'src/' ),
 			},
 		},
-		watchOptions: Object.keys( watchOptions ).length ? watchOptions : config.watchOptions,
+		watchOptions: { ...config.watchOptions, ...watchOptions },
 	};
 }
 


### PR DESCRIPTION
The command to start local server was failing with EMFILE errors. Ignoring node_modules and increasing the aggregateTimeout in watchOptions fixed the issue for now. The files in node_modules won't be changed during development without any dependencies changing, so it's safe to ignore them for watching.