### PR TITLE
Adding authentication specific help text.

### DIFF
--- a/src/data-sources/components/HttpAuthSettingsInput.tsx
+++ b/src/data-sources/components/HttpAuthSettingsInput.tsx
@@ -2,10 +2,12 @@ import { SelectControl, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ChangeEvent } from 'react';
 
+import { HttpAuthTypes } from '../http/types';
 import PasswordInputControl from '@/data-sources/components/PasswordInputControl';
 import {
 	HTTP_SOURCE_AUTH_TYPE_SELECT_OPTIONS,
 	HTTP_SOURCE_ADD_TO_SELECT_OPTIONS,
+	HTTP_SOURCE_AUTH_HELP_TEXT,
 } from '@/data-sources/constants';
 import { HttpConfig } from '@/data-sources/types';
 
@@ -77,10 +79,7 @@ export const HttpAuthSettingsInput: React.FC< HttpAuthSettingsInputProps > = ( {
 					value={ auth?.value ?? '' }
 					onChange={ value => onChange( 'value', value ) }
 					__next40pxDefaultSize
-					help={ __(
-						'The authentication value to use for the HTTP endpoint. When using Basic Auth, this is "username:password" string.',
-						'remote-data-blocks'
-					) }
+					help={ HTTP_SOURCE_AUTH_HELP_TEXT[ ( auth?.type ?? 'none' ) as HttpAuthTypes ] }
 				/>
 			) }
 		</>

--- a/src/data-sources/components/HttpAuthSettingsInput.tsx
+++ b/src/data-sources/components/HttpAuthSettingsInput.tsx
@@ -2,7 +2,6 @@ import { SelectControl, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ChangeEvent } from 'react';
 
-import { HttpAuthTypes } from '../http/types';
 import PasswordInputControl from '@/data-sources/components/PasswordInputControl';
 import {
 	HTTP_SOURCE_AUTH_TYPE_SELECT_OPTIONS,
@@ -79,7 +78,7 @@ export const HttpAuthSettingsInput: React.FC< HttpAuthSettingsInputProps > = ( {
 					value={ auth?.value ?? '' }
 					onChange={ value => onChange( 'value', value ) }
 					__next40pxDefaultSize
-					help={ HTTP_SOURCE_AUTH_HELP_TEXT[ ( auth?.type ?? 'none' ) as HttpAuthTypes ] }
+					help={ HTTP_SOURCE_AUTH_HELP_TEXT[ auth?.type ?? 'none' ] }
 				/>
 			) }
 		</>

--- a/src/data-sources/constants.ts
+++ b/src/data-sources/constants.ts
@@ -44,6 +44,13 @@ export const HTTP_SOURCE_ADD_TO_SELECT_OPTIONS: SelectOption< HttpApiKeyDestinat
 	{ label: __( 'Query Params', 'remote-data-blocks' ), value: 'queryparams' },
 ];
 
+export const HTTP_SOURCE_AUTH_HELP_TEXT: Record< HttpAuthTypes, string > = {
+	none: __( 'No authentication is required.', 'remote-data-blocks' ),
+	bearer: __( 'A string like: "Bearer {token}".', 'remote-data-blocks' ),
+	basic: __( 'A string like: "username:password".', 'remote-data-blocks' ),
+	'api-key': __( 'The key provided by the API.', 'remote-data-blocks' ),
+};
+
 export enum ConfigSource {
 	CODE = 'code',
 	STORAGE = 'storage',


### PR DESCRIPTION
The generic help text left me with questions, so I added a constant to contain help text appropriate for each authenticating type.

Before:
![before](https://github.com/user-attachments/assets/71c92ce6-ea52-44f8-9d18-bd91a3ae50ed)

After:
<img width="545" alt="Screenshot 2025-04-15 at 13 59 52" src="https://github.com/user-attachments/assets/6f50acf0-2cc8-4797-af87-b08edf8c146a" />
