### PR TITLE
Simplify HttpClient to a simple singleton pattern and use TTL request header

### DIFF
--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -83,6 +83,8 @@ class QueryRunner implements QueryRunnerInterface {
 		$pass = ! empty( $parsed_url['pass'] ?? '' ) ? ':' . $parsed_url['pass'] : '';
 		$pass = ( $user || $pass ) ? $pass . '@' : '';
 
+		$origin = sprintf( '%s://%s%s%s%s', $scheme, $user, $pass, $host, $port );
+
 		$request_details = [
 			'method' => $method,
 			'options' => [
@@ -91,8 +93,8 @@ class QueryRunner implements QueryRunnerInterface {
 				] ),
 				RequestOptions::JSON => $body,
 			],
-			'origin' => sprintf( '%s://%s%s%s%s', $scheme, $user, $pass, $host, $port ),
-			'uri' => sprintf( '%s%s', $path, $query ),
+			'origin' => $origin,
+			'uri' => sprintf( '%s%s%s', $origin, $path, $query ),
 		];
 
 		/**

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -7,6 +7,7 @@ use GuzzleHttp\RequestOptions;
 use RemoteDataBlocks\Config\Query\HttpQueryInterface;
 use RemoteDataBlocks\Editor\DataBinding\Pagination;
 use RemoteDataBlocks\HttpClient\HttpClient;
+use RemoteDataBlocks\HttpClient\RdbCacheStrategy;
 use WP_Error;
 
 defined( 'ABSPATH' ) || exit();
@@ -17,10 +18,14 @@ defined( 'ABSPATH' ) || exit();
  * Class that executes queries.
  */
 class QueryRunner implements QueryRunnerInterface {
+	protected HttpClient $http_client;
+
 	/**
-	 * @param HttpClient $http_client The HTTP client used to make HTTP requests.
+	 * @param HttpClient|null $http_client The HTTP client used to make HTTP requests.
 	 */
-	public function __construct( private HttpClient $http_client = new HttpClient() ) {}
+	public function __construct( ?HttpClient $http_client = null ) {
+		$this->http_client = $http_client ?? HttpClient::instance();
+	}
 
 	/**
 	 * Get the HTTP request details for the query
@@ -81,11 +86,12 @@ class QueryRunner implements QueryRunnerInterface {
 		$request_details = [
 			'method' => $method,
 			'options' => [
-				RequestOptions::HEADERS => $headers,
+				RequestOptions::HEADERS => array_merge( $headers, [
+					RdbCacheStrategy::CACHE_TTL_REQUEST_HEADER => $cache_ttl,
+				] ),
 				RequestOptions::JSON => $body,
 			],
 			'origin' => sprintf( '%s://%s%s%s%s', $scheme, $user, $pass, $host, $port ),
-			'ttl' => $cache_ttl,
 			'uri' => sprintf( '%s%s', $path, $query ),
 		];
 
@@ -121,12 +127,6 @@ class QueryRunner implements QueryRunnerInterface {
 		if ( is_wp_error( $request_details ) ) {
 			return $request_details;
 		}
-
-		$client_options = [
-			HttpClient::CACHE_TTL_CLIENT_OPTION_KEY => $request_details['ttl'],
-		];
-
-		$this->http_client->init( $request_details['origin'], [], $client_options );
 
 		try {
 			$response = $this->http_client->request( $request_details['method'], $request_details['uri'], $request_details['options'] );

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -82,15 +82,20 @@ class QueryRunner implements QueryRunnerInterface {
 		$port = ! empty( $parsed_url['port'] ?? '' ) ? ':' . $parsed_url['port'] : '';
 		$pass = ! empty( $parsed_url['pass'] ?? '' ) ? ':' . $parsed_url['pass'] : '';
 		$pass = ( $user || $pass ) ? $pass . '@' : '';
-
 		$origin = sprintf( '%s://%s%s%s%s', $scheme, $user, $pass, $host, $port );
+
+		$cache_headers = [];
+		if ( intval( $cache_ttl ) > 0 ) {
+			$cache_headers[ RdbCacheStrategy::CACHE_TTL_REQUEST_HEADER ] = $cache_ttl;
+		}
+		if ( intval( $cache_ttl ) < 0 ) {
+			$cache_headers['Cache-Control'] = 'no-store';
+		}
 
 		$request_details = [
 			'method' => $method,
 			'options' => [
-				RequestOptions::HEADERS => array_merge( $headers, [
-					RdbCacheStrategy::CACHE_TTL_REQUEST_HEADER => $cache_ttl,
-				] ),
+				RequestOptions::HEADERS => array_merge( $headers, $cache_headers ),
 				RequestOptions::JSON => $body,
 			],
 			'origin' => $origin,

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -6,7 +6,6 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Client;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
-use GuzzleHttp\Promise\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -45,16 +44,11 @@ class HttpClient {
 	];
 
 	/**
-	 * @var array<int, array{method: string, uri: string|UriInterface, options: array<string, mixed>}>
-	 */
-	private array $queued_requests = [];
-
-	/**
 	 * Get the cache middleware for the HTTP client.
 	 */
-	protected static function get_cache_middleware( int|null $default_ttl = null ): callable {
+	protected static function get_cache_middleware(): callable {
 		if ( ! isset( self::$cache_middleware ) ) {
-			self::$cache_middleware = new RdbCacheMiddleware( new RdbCacheStrategy( $default_ttl ) );
+			self::$cache_middleware = new RdbCacheMiddleware( new RdbCacheStrategy() );
 		}
 
 		return self::$cache_middleware;
@@ -99,55 +93,9 @@ class HttpClient {
 	}
 
 	/**
-	 * Queue a request for later execution.
-	 */
-	public function queue_request( string $method, string|UriInterface $uri, array $options = [] ): void {
-		$this->queued_requests[] = [
-			'method' => $method,
-			'uri' => $uri,
-			'options' => array_merge( $this->options, $options ),
-		];
-	}
-
-	/**
-	 * Execute all queued requests in parallel.
-	 */
-	public function execute_parallel(): array {
-		$promises = [];
-		foreach ( $this->queued_requests as $request ) {
-			$promises[] = $this->client->requestAsync(
-				$request['method'],
-				$request['uri'],
-				$request['options']
-			);
-		}
-
-		$results = Utils::settle( $promises )->wait();
-
-		// Clear the queue after execution
-		$this->queued_requests = [];
-
-		return $results;
-	}
-
-	/**
 	 * Execute a request.
 	 */
 	public function request( string $method, string|UriInterface $uri, array $options = [] ): ResponseInterface {
 		return $this->client->request( $method, $uri, array_merge( $this->options, $options ) );
-	}
-
-	/**
-	 * Execute a GET request.
-	 */
-	public function get( string|UriInterface $uri, array $options = [] ): ResponseInterface {
-		return $this->request( 'GET', $uri, $options );
-	}
-
-	/**
-	 * Execute a POST request.
-	 */
-	public function post( string|UriInterface $uri, array $options = [] ): ResponseInterface {
-		return $this->request( 'POST', $uri, $options );
 	}
 }

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -16,86 +16,56 @@ use RemoteDataBlocks\Logging\LoggerManager;
 defined( 'ABSPATH' ) || exit();
 
 class HttpClient {
-	public Client $client;
+	public const USER_AGENT_STRING = 'WordPress Remote Data Blocks/1.0';
 
-	public const CACHE_TTL_CLIENT_OPTION_KEY = '__default_cache_ttl';
-
-	private string $base_uri;
-	private HandlerStack $handler_stack;
-	private static RdbCacheMiddleware $cache_middleware;
+	protected Client $client;
 
 	/**
-	 * @var array<string, string>
+	 * Private constructor to enforce singleton pattern.
 	 */
-	private array $headers = [];
-
-	/**
-	 * @var array<string, mixed>
-	 */
-	private array $options = [];
-
-	/**
-	 * @var array<string, mixed>
-	 */
-	private array $default_options = [
-		'headers' => [
-			'User-Agent' => 'WordPress Remote Data Blocks/1.0',
-		],
-	];
-
-	/**
-	 * Get the cache middleware for the HTTP client.
-	 */
-	protected static function get_cache_middleware(): callable {
-		if ( ! isset( self::$cache_middleware ) ) {
-			self::$cache_middleware = new RdbCacheMiddleware( new RdbCacheStrategy() );
-		}
-
-		return self::$cache_middleware;
-	}
-
-	/**
-	 * Initialize the HTTP client.
-	 */
-	public function init( string $base_uri, array $headers = [], array $client_options = [] ): void {
-		$this->base_uri = $base_uri;
-		$this->headers = $headers;
-		$this->options = $client_options;
-
+	private function __construct() {
 		// Initialize a request handler that uses wp_remote_request instead of cURL.
 		// PHP cURL bindings are not always available, e.g., in WASM environments
 		// like WP Now and WP Playground.
 		$request_handler = new WPRemoteRequestHandler();
 
-		$this->handler_stack = HandlerStack::create( $request_handler );
+		$handler_stack = HandlerStack::create( $request_handler );
 
-		$this->handler_stack->push( Middleware::mapRequest( function ( RequestInterface $request ) {
-			foreach ( $this->headers as $header => $value ) {
-				$request = $request->withHeader( $header, $value );
-			}
+		$handler_stack->push( new RdbCacheMiddleware( new RdbCacheStrategy() ), 'remote_data_blocks_cache' );
 
-			return $request;
-		} ) );
-
-		$default_ttl = $client_options[ self::CACHE_TTL_CLIENT_OPTION_KEY ] ?? null;
-		$cache_middleware = self::get_cache_middleware( $default_ttl );
-		$this->handler_stack->push( $cache_middleware, 'remote_data_blocks_cache' );
-
-		$this->handler_stack->push( Middleware::log(
+		$handler_stack->push( Middleware::log(
 			LoggerManager::instance(),
 			new MessageFormatter( '{total_time} {code} {phrase} {method} {url}' )
 		) );
 
-		$this->client = new Client( array_merge( $this->default_options, $this->options, [
-			'base_uri' => $this->base_uri,
-			'handler' => $this->handler_stack,
-		] ) );
+		// Set our User Agent header.
+		$handler_stack->push( Middleware::mapRequest( function ( RequestInterface $request ) {
+			return $request->withHeader( 'User-Agent', self::USER_AGENT_STRING );
+		} ) );
+
+		$this->client = new Client( [ 'handler' => $handler_stack ] );
+	}
+
+	/**
+	 * Get the singleton instance of HttpClient.
+	 *
+	 * @return self The singleton instance.
+	 */
+	public static function instance(): self {
+		static $instance = null;
+
+		if ( null === $instance ) {
+			$instance = new self();
+		}
+
+		return $instance;
 	}
 
 	/**
 	 * Execute a request.
 	 */
-	public function request( string $method, string|UriInterface $uri, array $options = [] ): ResponseInterface {
-		return $this->client->request( $method, $uri, array_merge( $this->options, $options ) );
+	public function request( string $method, string|UriInterface $uri, array $options = [], ?Client $client = null ): ResponseInterface {
+		$http_client = $client ?? $this->client;
+		return $http_client->request( $method, $uri, $options );
 	}
 }

--- a/inc/HttpClient/RdbCacheStrategy.php
+++ b/inc/HttpClient/RdbCacheStrategy.php
@@ -13,19 +13,21 @@ use RemoteDataBlocks\Logging\Logger;
 use RemoteDataBlocks\Logging\LoggerManager;
 
 class RdbCacheStrategy extends GreedyCacheStrategy {
+	public const CACHE_TTL_REQUEST_HEADER = GreedyCacheStrategy::HEADER_TTL;
+
 	private const CACHE_INVALIDATING_REQUEST_HEADERS = [ 'Authorization', 'Cache-Control' ];
 	private const FALLBACK_CACHE_TTL_IN_SECONDS = 300; // 5 minutes
 	private const WP_OBJECT_CACHE_GROUP = 'remote-data-blocks';
 
 	private Logger $logger;
 
-	public function __construct( ?int $default_ttl = null, ?CacheStorageInterface $storage = null ) {
+	public function __construct( ?CacheStorageInterface $storage = null ) {
 		// Filter this if customization is needed.
 		$vary_headers = new KeyValueHttpHeader( self::CACHE_INVALIDATING_REQUEST_HEADERS );
 
 		parent::__construct(
 			$storage ?? new WordPressObjectCacheStorage( self::WP_OBJECT_CACHE_GROUP ),
-			$default_ttl ?? self::FALLBACK_CACHE_TTL_IN_SECONDS,
+			self::FALLBACK_CACHE_TTL_IN_SECONDS,
 			$vary_headers
 		);
 

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -375,7 +375,7 @@ class QueryRunnerTest extends TestCase {
 			->expects( $this->exactly( 1 ) )
 			->method( 'request' )
 			->willReturn( $response )
-			->with( 'GET', '/api?foo=bar&baz=MISSING' );
+			->with( 'GET', 'https://example.com/api?foo=bar&baz=MISSING' );
 
 		$result = $query->execute( [] );
 

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -60,53 +60,6 @@ class HttpClientTest extends TestCase {
 		$this->assertSame( 'MISS', $response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 	}
 
-	public function testQueueRequestAndExecuteParallel(): void {
-		$this->mock_handler->append( new Response( 200, [], 'Response 1' ) );
-		$this->mock_handler->append( new Response( 201, [], 'Response 2' ) );
-
-		$this->http_client->queue_request( 'GET', '/test1' );
-		$this->http_client->queue_request( 'POST', '/test2' );
-
-		$results = $this->http_client->execute_parallel();
-
-		$this->assertCount( 2, $results );
-		$this->assertSame( 'fulfilled', $results[0]['state'] );
-		$this->assertSame( 200, $results[0]['value']->getStatusCode() );
-		$this->assertSame( 'Response 1', (string) $results[0]['value']->getBody() );
-		$this->assertSame( 'MISS', $results[0]['value']->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
-
-		$this->assertSame( 'fulfilled', $results[1]['state'] );
-		$this->assertSame( 201, $results[1]['value']->getStatusCode() );
-		$this->assertSame( 'Response 2', (string) $results[1]['value']->getBody() );
-		$this->assertSame( 'MISS', $results[1]['value']->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
-	}
-
-	public function testQueueRequestAndExecuteParallelWithFailures(): void {
-		$this->mock_handler->append( new Response( 200, [], 'Success Response' ) );
-		$this->mock_handler->append( new RequestException( 'Error', new Request( 'GET', '/test2' ) ) );
-		$this->mock_handler->append( new ConnectException( 'Connection Error', new Request( 'POST', '/test3' ) ) );
-
-		$this->http_client->queue_request( 'GET', '/test1' );
-		$this->http_client->queue_request( 'GET', '/test2' );
-		$this->http_client->queue_request( 'POST', '/test3' );
-
-		$results = $this->http_client->execute_parallel();
-
-		$this->assertCount( 3, $results );
-
-		$this->assertSame( 'fulfilled', $results[0]['state'] );
-		$this->assertSame( 200, $results[0]['value']->getStatusCode() );
-		$this->assertSame( 'Success Response', (string) $results[0]['value']->getBody() );
-
-		$this->assertSame( 'rejected', $results[1]['state'] );
-		$this->assertInstanceOf( RequestException::class, $results[1]['reason'] );
-		$this->assertSame( 'Error', $results[1]['reason']->getMessage() );
-
-		$this->assertSame( 'rejected', $results[2]['state'] );
-		$this->assertInstanceOf( ConnectException::class, $results[2]['reason'] );
-		$this->assertSame( 'Connection Error', $results[2]['reason']->getMessage() );
-	}
-
 	public function testRepeatedGetCallsResultsInCacheHit(): void {
 		// Set up the mock handler with only one response
 		$this->mock_handler->append( new Response( 200, [], 'Cached Response' ) );

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -7,38 +7,37 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Exception\RequestException;
 use Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage;
 use RemoteDataBlocks\HttpClient\RdbCacheMiddleware;
 use RemoteDataBlocks\HttpClient\RdbCacheStrategy;
 use RemoteDataBlocks\HttpClient\HttpClient;
 
 class HttpClientTest extends TestCase {
-	private $http_client;
-	private $mock_handler;
+	private Client $client;
+	private HttpClient $http_client;
+	private MockHandler $mock_handler;
 
 	protected function setUp(): void {
 		parent::setUp();
+
 		$this->mock_handler = new MockHandler();
 		$handler = HandlerStack::create( $this->mock_handler );
 
-		$handler->push( new RdbCacheMiddleware( new RdbCacheStrategy( null, new VolatileRuntimeStorage() ) ) );
+		$handler->push( new RdbCacheMiddleware( new RdbCacheStrategy( new VolatileRuntimeStorage() ) ) );
 		$client = new Client( [ 'handler' => $handler ] );
 
-		$this->http_client = new HttpClient( 'https://api.example.com' );
-		$this->http_client->client = $client;
+		$this->client = $client;
+		$this->http_client = HttpClient::instance();
 	}
 
-	public function testConstructor(): void {
-		$client = new HttpClient( 'https://api.example.com', [ 'X-Test' => 'value' ] );
+	public function testSingleton(): void {
+		$client = HttpClient::instance();
 		$this->assertInstanceOf( HttpClient::class, $client );
 	}
 
 	public function testRequest(): void {
 		$this->mock_handler->append( new Response( 200, [], 'Success' ) );
-		$response = $this->http_client->request( 'GET', '/test' );
+		$response = $this->http_client->request( 'GET', '/test', [], $this->client );
 		$this->assertSame( 200, $response->getStatusCode() );
 		$this->assertSame( 'Success', (string) $response->getBody() );
 		$this->assertSame( 'MISS', $response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
@@ -46,7 +45,7 @@ class HttpClientTest extends TestCase {
 
 	public function testGet(): void {
 		$this->mock_handler->append( new Response( 200, [], 'GET Success' ) );
-		$response = $this->http_client->get( '/test' );
+		$response = $this->http_client->request( 'GET', '/test', [], $this->client );
 		$this->assertSame( 200, $response->getStatusCode() );
 		$this->assertSame( 'GET Success', (string) $response->getBody() );
 		$this->assertSame( 'MISS', $response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
@@ -54,7 +53,7 @@ class HttpClientTest extends TestCase {
 
 	public function testPost(): void {
 		$this->mock_handler->append( new Response( 201, [], 'POST Success' ) );
-		$response = $this->http_client->post( '/test' );
+		$response = $this->http_client->request( 'POST', '/test', [], $this->client );
 		$this->assertSame( 201, $response->getStatusCode() );
 		$this->assertSame( 'POST Success', (string) $response->getBody() );
 		$this->assertSame( 'MISS', $response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
@@ -67,7 +66,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have exactly one request' );
 
 		// Make the first request
-		$first_response = $this->http_client->request( 'GET', '/test' );
+		$first_response = $this->http_client->request( 'GET', '/test', [], $this->client );
 
 		$this->assertEquals( 0, $this->mock_handler->count(), 'The mock handler should be empty after the first request' );
 
@@ -77,7 +76,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second request to the same endpoint
-		$second_response = $this->http_client->request( 'GET', '/test' );
+		$second_response = $this->http_client->request( 'GET', '/test', [], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -92,7 +91,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have exactly one request' );
 
 		// Make the first request
-		$first_response = $this->http_client->request( 'GET', '/test?arg1=value1&arg2=value2' );
+		$first_response = $this->http_client->request( 'GET', '/test?arg1=value1&arg2=value2', [], $this->client );
 
 		$this->assertEquals( 0, $this->mock_handler->count(), 'The mock handler should be empty after the first request' );
 
@@ -102,7 +101,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second request to the same endpoint
-		$second_response = $this->http_client->request( 'GET', '/test?arg1=value1&arg2=value2' );
+		$second_response = $this->http_client->request( 'GET', '/test?arg1=value1&arg2=value2', [], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -120,7 +119,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 2, $this->mock_handler->count(), 'The mock handler should have exactly two requests' );
 
 		// Make the first request
-		$first_response = $this->http_client->request( 'GET', '/test0' );
+		$first_response = $this->http_client->request( 'GET', '/test0', [], $this->client );
 
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have exactly one request after the first request' );
 
@@ -130,7 +129,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second request to the same endpoint
-		$second_response = $this->http_client->request( 'GET', '/test1' );
+		$second_response = $this->http_client->request( 'GET', '/test1', [], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -150,7 +149,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 2, $this->mock_handler->count(), 'The mock handler should have exactly two requests' );
 
 		// Make the first request
-		$first_response = $this->http_client->request( 'GET', '/test?arg1=value1&arg2=value2' );
+		$first_response = $this->http_client->request( 'GET', '/test?arg1=value1&arg2=value2', [], $this->client );
 
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have exactly one request after the first request' );
 
@@ -160,7 +159,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second request to the same endpoint
-		$second_response = $this->http_client->request( 'GET', '/test?arg1=value1&arg2=value3' );
+		$second_response = $this->http_client->request( 'GET', '/test?arg1=value1&arg2=value3', [], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -177,7 +176,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have exactly one request' );
 
 		// Make the first POST request with an empty body
-		$first_response = $this->http_client->post( '/test' );
+		$first_response = $this->http_client->request( 'POST', '/test', [], $this->client );
 
 		$this->assertEquals( 0, $this->mock_handler->count(), 'The mock handler should be empty after the first request' );
 
@@ -187,7 +186,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second POST request to the same endpoint with an empty body
-		$second_response = $this->http_client->post( '/test' );
+		$second_response = $this->http_client->request( 'POST', '/test', [], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -204,7 +203,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have exactly one request' );
 
 		// Make the first POST request
-		$first_response = $this->http_client->post( '/test', [ 'body' => 'test data' ] );
+		$first_response = $this->http_client->request( 'POST', '/test', [ 'body' => 'test data' ], $this->client );
 
 		$this->assertEquals( 0, $this->mock_handler->count(), 'The mock handler should be empty after the first request' );
 
@@ -214,7 +213,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second POST request to the same endpoint
-		$second_response = $this->http_client->post( '/test', [ 'body' => 'test data' ] );
+		$second_response = $this->http_client->request( 'POST', '/test', [ 'body' => 'test data' ], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -234,10 +233,10 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 2, $this->mock_handler->count(), 'The mock handler should have exactly two requests' );
 
 		// Make the first POST request with an Authorization header
-		$first_response = $this->http_client->post( '/test', [
+		$first_response = $this->http_client->request( 'POST', '/test', [
 			'headers' => [ 'Authorization' => 'Bearer token1' ],
 			'body' => 'test data',
-		] );
+		], $this->client );
 
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have one request left after the first request' );
 
@@ -247,10 +246,10 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second POST request to the same endpoint but with a different Authorization header
-		$second_response = $this->http_client->post( '/test', [
+		$second_response = $this->http_client->request( 'POST', '/test', [
 			'headers' => [ 'Authorization' => 'Bearer token2' ],
 			'body' => 'test data',
-		] );
+		], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -270,7 +269,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 2, $this->mock_handler->count(), 'The mock handler should have exactly two requests' );
 
 		// Make the first POST request
-		$first_response = $this->http_client->post( '/test', [ 'body' => 'first data' ] );
+		$first_response = $this->http_client->request( 'POST', '/test', [ 'body' => 'first data' ], $this->client );
 
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have one request left after the first request' );
 
@@ -280,7 +279,7 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second POST request to the same endpoint but with different body
-		$second_response = $this->http_client->post( '/test', [ 'body' => 'second data' ] );
+		$second_response = $this->http_client->request( 'POST', '/test', [ 'body' => 'second data' ], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -325,13 +324,13 @@ class HttpClientTest extends TestCase {
 		];
 
 		// Make the first POST request
-		$first_response = $this->http_client->post( '/graphql', [
+		$first_response = $this->http_client->request( 'POST', '/graphql', [
 			'headers' => [ 'Content-Type' => 'application/json' ],
 			'json' => [
 				'query' => $first_mutation,
 				'variables' => $variables,
 			],
-		] );
+		], $this->client );
 
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have one request left after the first request' );
 
@@ -341,12 +340,12 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second POST request with a different GraphQL mutation
-		$second_response = $this->http_client->post( '/graphql', [
+		$second_response = $this->http_client->request( 'POST', '/graphql', [
 			'json' => [
 				'query' => $second_mutation,
 				'variables' => array_merge( $variables, [ 'id' => '1' ] ),
 			],
-		] );
+		], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -374,13 +373,13 @@ class HttpClientTest extends TestCase {
 		];
 
 		// Make the first POST request
-		$first_response = $this->http_client->post( '/graphql', [
+		$first_response = $this->http_client->request( 'POST', '/graphql', [
 			'headers' => [ 'Content-Type' => 'application/json' ],
 			'json' => [
 				'query' => $query,
 				'variables' => $variables,
 			],
-		] );
+		], $this->client );
 
 		$this->assertEquals( 0, $this->mock_handler->count(), 'The mock handler should be empty after the first request' );
 
@@ -390,13 +389,13 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second POST request with the same GraphQL query
-		$second_response = $this->http_client->post( '/graphql', [
+		$second_response = $this->http_client->request( 'POST', '/graphql', [
 			'headers' => [ 'Content-Type' => 'application/json' ],
 			'json' => [
 				'query' => $query,
 				'variables' => $variables,
 			],
-		] );
+		], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -436,13 +435,13 @@ class HttpClientTest extends TestCase {
 		];
 
 		// Make the first POST request
-		$first_response = $this->http_client->post( '/graphql', [
+		$first_response = $this->http_client->request( 'POST', '/graphql', [
 			'headers' => [ 'Content-Type' => 'application/json' ],
 			'json' => [
 				'query' => $first_query,
 				'variables' => $variables,
 			],
-		] );
+		], $this->client );
 
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have one response left after the first request' );
 
@@ -452,13 +451,13 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second POST request with a different GraphQL query
-		$second_response = $this->http_client->post( '/graphql', [
+		$second_response = $this->http_client->request( 'POST', '/graphql', [
 			'headers' => [ 'Content-Type' => 'application/json' ],
 			'json' => [
 				'query' => $second_query,
 				'variables' => $variables,
 			],
-		] );
+		], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );
@@ -493,13 +492,13 @@ class HttpClientTest extends TestCase {
 		];
 
 		// Make the first POST request
-		$first_response = $this->http_client->post( '/graphql', [
+		$first_response = $this->http_client->request( 'POST', '/graphql', [
 			'headers' => [ 'Content-Type' => 'application/json' ],
 			'json' => [
 				'query' => $query,
 				'variables' => $first_variables,
 			],
-		] );
+		], $this->client );
 
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have one response left after the first request' );
 
@@ -509,13 +508,13 @@ class HttpClientTest extends TestCase {
 		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
 
 		// Make the second POST request with the same GraphQL query but different variables
-		$second_response = $this->http_client->post( '/graphql', [
+		$second_response = $this->http_client->request( 'POST', '/graphql', [
 			'headers' => [ 'Content-Type' => 'application/json' ],
 			'json' => [
 				'query' => $query,
 				'variables' => $second_variables,
 			],
-		] );
+		], $this->client );
 
 		// Assert the second response
 		$this->assertEquals( 200, $second_response->getStatusCode() );


### PR DESCRIPTION
This PR does a few related things that are necessary to unblock improved performance and logging.

1. Make `HttpClient` a true singleton. Originally, `HttpClient` was not implemented as a singleton, but over time we realized that we needed a single instance of our caching middleware to preserve in-memory state. However, it's much simpler and clearer to implement a singleton pattern for `HttpClient` itself.
2. The `HttpClient->init()` method was flawed, because it injected per-request options into shared state. In theory, this could allow the options of one request to overwrite those of another. With a singleton pattern, we can pass all options via the `request` method.
3. Setting a custom TTL did not actually work because of the static caching middleware. We should use the same strategy as the vendor cache middleware that we are extending: Set a custom request header, read it, then remove it before sending the request. This is all handled by the vendor code.
4. Remove unused methods. Early exploration exposed methods for queuing and parallel execution, but they proved incompatible with how block bindings are executed. We can remove them and their tests. Similarly, we remove the unused shorthand `get` and `post` methods in favor of `request`.
