### PR TITLE
Cache error responses for a short time

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -72,7 +72,7 @@ When a request to your site renders one or more remote data blocks, our plugin w
 
 The plugin offers a caching layer for optimal performance and helps avoid rate limiting from remote data sources. It will be used if your WordPress environment configures a [persistent object cache](https://developer.wordpress.org/reference/classes/wp_object_cache/#persistent-cache-plugins). Otherwise, the plugin will utilize in-memory (per-page-load) caching. Deploying to production without a persistent object cache is not recommended.
 
-The default TTL for all cache objects is 5 minutes, but it can be [configured per query or request](../extending/query.md#cache_ttl-intnullcallable).
+The default TTL for all cache objects is 5 minutes, but it can be [configured per query or request](../extending/query.md#cache_ttl-intnullcallable). Error responses are cached for 30 seconds to avoid overwhelming the remote data source with repeated requests under error conditions.
 
 ## Theming
 

--- a/docs/extending/query.md
+++ b/docs/extending/query.md
@@ -255,11 +255,13 @@ The `request_body` property defines the request body for the query. It can be an
 
 The `cache_ttl` property defines how long the query response should be cached in seconds. It can be an integer, a callable function that returns an integer, or `null`. The callable function accepts an associative array of input variables (`[ $var_name => $value ]`).
 
-A value of `-1` indicates the query should not be cached. A value of `null` indicates the default TTL should be used (60 seconds). If omitted, the default TTL is used.
+A value of `-1` indicates the query should not be cached. A value of `null` indicates the default TTL should be used (300 seconds). If omitted, the default TTL is used.
 
 Remote data blocks utilize the WordPress object cache (`wp_cache_get()` / `wp_cache_set()`) for response caching. Ensure that your platform provides or installs a persistent object cache plugin so that this value is respected.
 
-If you do not have a peristent object cache, no caching will be available. We do not recommend running the Remote Data Blocks plugin in this configuration.
+If you do not have a peristent object cache, this property will be ignored and responses will only be cached in-memory. We do not recommend running the Remote Data Blocks plugin in this configuration.
+
+Note that error responses are cached for 30 seconds to avoid overwhelming the remote data source with repeated requests under error conditions.
 
 #### Example
 

--- a/inc/Config/Query/HttpQuery.php
+++ b/inc/Config/Query/HttpQuery.php
@@ -42,7 +42,7 @@ class HttpQuery extends ArraySerializable implements HttpQueryInterface {
 	 * Define the cache object TTL for the current query execution's responses:
 	 * - Return a positive integer to set a custom TTL in seconds.
 	 * - Return -1 to disable caching.
-	 * - Return null to use the global default cache TTL (60 seconds).
+	 * - Return null to use the global default cache TTL (300 seconds).
 	 *
 	 * @return int|null The cache object TTL in seconds.
 	 */

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -5,6 +5,7 @@ namespace RemoteDataBlocks\HttpClient;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Client;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -58,6 +59,11 @@ class HttpClient {
 	 */
 	public function request( string $method, string|UriInterface $uri, array $options = [], ?Client $client = null ): ResponseInterface {
 		$http_client = $client ?? $this->client;
+		$options = array_merge( $options, [
+			// Avoid thrown exceptions for HTTP errors.
+			RequestOptions::HTTP_ERRORS => false,
+		] );
+
 		return $http_client->request( $method, $uri, $options );
 	}
 }

--- a/inc/HttpClient/RdbCacheStrategy.php
+++ b/inc/HttpClient/RdbCacheStrategy.php
@@ -2,12 +2,15 @@
 
 namespace RemoteDataBlocks\HttpClient;
 
+use DateTime;
+use Kevinrob\GuzzleCache\CacheEntry;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Kevinrob\GuzzleCache\KeyValueHttpHeader;
 use Kevinrob\GuzzleCache\Storage\CacheStorageInterface;
 use Kevinrob\GuzzleCache\Storage\WordPressObjectCacheStorage;
 use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class RdbCacheStrategy extends GreedyCacheStrategy {
 	public const CACHE_AGE_RESPONSE_HEADER = 'Age';
@@ -16,7 +19,8 @@ class RdbCacheStrategy extends GreedyCacheStrategy {
 	public const WP_OBJECT_CACHE_GROUP = 'remote-data-blocks';
 
 	private const CACHE_INVALIDATING_REQUEST_HEADERS = [ 'Authorization', 'Cache-Control' ];
-	private const FALLBACK_CACHE_TTL_IN_SECONDS = 300; // 5 minutes
+	private const ERROR_CACHE_TTL_IN_SECONDS = 30; // 30 seconds for error responses
+	private const FALLBACK_CACHE_TTL_IN_SECONDS = 300; // 5 minutes for success responses
 
 	public function __construct( ?CacheStorageInterface $storage = null ) {
 		// Filter this if customization is needed.
@@ -55,5 +59,26 @@ class RdbCacheStrategy extends GreedyCacheStrategy {
 	/** @psalm-suppress ParamNameMismatch reason: parent is camelCase, but we want snake_case */
 	protected function getCacheKey( RequestInterface $request, ?KeyValueHttpHeader $_vary_headers = null ): string {
 		return self::get_object_cache_key_from_request( $request );
+	}
+
+	protected function getCacheObject( RequestInterface $request, ResponseInterface $response ): ?CacheEntry {
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$ttl = $this->defaultTtl;
+		if ( $request->hasHeader( static::HEADER_TTL ) ) {
+			$ttl_header_values = $request->getHeader( static::HEADER_TTL );
+			$ttl = (int) reset( $ttl_header_values );
+		}
+
+		if ( ! array_key_exists( $response->getStatusCode(), $this->statusAccepted ) ) {
+			// Cache it for a short time period to prevent error floods.
+			$ttl = self::ERROR_CACHE_TTL_IN_SECONDS;
+		}
+
+		// NOTE: We skip the vary headers '*' check from the parent method
+		// since our defined vary headers cannot accept a '*' value.
+
+		$response = $response->withoutHeader( 'Etag' )->withoutHeader( 'Last-Modified' );
+
+		return new CacheEntry( $request->withoutHeader( static::HEADER_TTL ), $response, new DateTime( sprintf( '%+d seconds', $ttl ) ) );
 	}
 }

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -523,4 +523,32 @@ class HttpClientTest extends TestCase {
 
 		$this->assertEquals( 0, $this->mock_handler->count(), 'The mock handler should be empty after the second request' );
 	}
+
+	public function testRepeatedErrorsWithSameCacheKeyResultInCacheHit(): void {
+		// Set up the mock handler with one response
+		$this->mock_handler->append( new Response( 500, [], 'Error response' ) );
+		$this->mock_handler->append( new Response( 200, [], 'Success response' ) );
+
+		$this->assertEquals( 2, $this->mock_handler->count(), 'The mock handler should have two requests' );
+
+		// Make the first request
+		$first_response = $this->http_client->request( 'GET', '/test', [], $this->client );
+
+		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should have one request left after the first request' );
+
+		// Assert the first response
+		$this->assertEquals( 500, $first_response->getStatusCode() );
+		$this->assertEquals( 'Error response', (string) $first_response->getBody() );
+		$this->assertEquals( 'MISS', $first_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
+
+		// Make the second request to the same endpoint
+		$second_response = $this->http_client->request( 'GET', '/test', [], $this->client );
+
+		// Assert the second response
+		$this->assertEquals( 500, $second_response->getStatusCode() );
+		$this->assertEquals( 'Error response', (string) $second_response->getBody() );
+		$this->assertEquals( 'HIT', $second_response->getHeaderLine( RdbCacheMiddleware::HEADER_CACHE_INFO ) );
+
+		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should still have one request left after the second request' );
+	}
 }


### PR DESCRIPTION
As discussed in https://github.com/Automattic/remote-data-blocks/pull/461#pullrequestreview-2768267664, remote API downtime or a sustained error rate can threaten the stability of a site. In-memory caching cannot completely mitigate this risk, since a high volume of requests across a high number of workers could still result in a high failure rate.

To address this, we can cache errors in object cache for a short time (30 seconds in this PR). This is very similar to the behavior of our edge cache, which caches 404s for a short time.

We can make this value filterable, but I'd like to see that request presented by a real-world user so that we can tailor the filter to their needs.