### PR TITLE
Add in-memory caching to `QueryRunner`

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -1123,7 +1123,7 @@ By default, the `deserialize_response` assumes a JSON string and deserializes it
 
 The `get_request_details` method extracts and validates the request details provided by the query. The input variables for the current request are provided as an associative array (`[ $var_name => $value ]`). The return value is an associative array that provides the HTTP method, request options, origin, and URI.
 
-### get_raw_response_data( HttpQueryInterface $query, array $input_variables ): array|WP_Error
+### get_raw_response_data( array $request_details, array $input_variables ): array|WP_Error
 
 The `get_raw_response_data` method dispatches the HTTP request and assembles the raw (pre-processed) response data. The input variables for the current request are provided as an associative array (`[ $var_name => $value ]`). The return value is an associative array that provides the response metadata and the raw response data.
 

--- a/docs/extending/query-runner.md
+++ b/docs/extending/query-runner.md
@@ -22,7 +22,7 @@ By default, the `deserialize_response` assumes a JSON string and deserializes it
 
 The `get_request_details` method extracts and validates the request details provided by the query. The input variables for the current request are provided as an associative array (`[ $var_name => $value ]`). The return value is an associative array that provides the HTTP method, request options, origin, and URI.
 
-### get_raw_response_data( HttpQueryInterface $query, array $input_variables ): array|WP_Error
+### get_raw_response_data( array $request_details, array $input_variables ): array|WP_Error
 
 The `get_raw_response_data` method dispatches the HTTP request and assembles the raw (pre-processed) response data. The input variables for the current request are provided as an associative array (`[ $var_name => $value ]`). The return value is an associative array that provides the response metadata and the raw response data.
 

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -18,13 +18,20 @@ defined( 'ABSPATH' ) || exit();
  * Class that executes queries.
  */
 class QueryRunner implements QueryRunnerInterface {
+	/**
+	 * @var array<string, array|WP_Error>
+	 */
+	protected static array $in_memory_cache;
+
 	protected HttpClient $http_client;
 
 	/**
 	 * @param HttpClient|null $http_client The HTTP client used to make HTTP requests.
+	 * @param array|null $in_memory_cache The in-memory cache used to store query results.
 	 */
-	public function __construct( ?HttpClient $http_client = null ) {
+	public function __construct( ?HttpClient $http_client = null, ?array $in_memory_cache = null ) {
 		$this->http_client = $http_client ?? HttpClient::instance();
+		self::$in_memory_cache = $in_memory_cache ?? self::$in_memory_cache ?? [];
 	}
 
 	/**
@@ -121,20 +128,14 @@ class QueryRunner implements QueryRunnerInterface {
 	/**
 	 * Dispatch the HTTP request and assemble the raw (pre-processed) response data.
 	 *
-	 * @param HttpQueryInterface $query The query being executed.
+	 * @param array<string, mixed> $request_details The parsed request details for the current request.
 	 * @param array<string, mixed> $input_variables The input variables for the current request.
-	 * @return WP_Error|array{
+	 * @return array{
 	 *   metadata:      array<string, string|int|null>,
-	 *   response_data: string|array|object|null,
+	 *   response_data: string|array|object|null|WP_Error,
 	 * }
 	 */
-	protected function get_raw_response_data( HttpQueryInterface $query, array $input_variables ): array|WP_Error {
-		$request_details = $this->get_request_details( $query, $input_variables );
-
-		if ( is_wp_error( $request_details ) ) {
-			return $request_details;
-		}
-
+	protected function get_raw_response_data( array $request_details, array $input_variables ): array|WP_Error {
 		try {
 			$response = $this->http_client->request( $request_details['method'], $request_details['uri'], $request_details['options'] );
 		} catch ( Exception $e ) {
@@ -152,7 +153,6 @@ class QueryRunner implements QueryRunnerInterface {
 
 		return [
 			'metadata' => [
-				'age' => intval( $response->getHeaderLine( 'Age' ) ),
 				'status_code' => $response_code,
 			],
 			'response_data' => $this->deserialize_response( $raw_response_string, $input_variables ),
@@ -222,10 +222,31 @@ class QueryRunner implements QueryRunnerInterface {
 			}
 		}
 
-		$raw_response_data = $this->get_raw_response_data( $query, $input_variables );
+		$request_details = $this->get_request_details( $query, $input_variables );
 
+		if ( is_wp_error( $request_details ) ) {
+			return $request_details;
+		}
+
+		// Try to resolve the request from the in-memory cache using a hash of
+		// the query and input. This is not 1:1 with the object caching that is
+		// implemented by HttpClient, but it is good enough to de-duplicate
+		// requests that occur in the same process.
+		//
+		// This avoids redundant post-processing (QueryResponseParser) and
+		// object cache requests.
+		$in_memory_cache_key = sprintf( 'query-runner:%s', md5( wp_json_encode( $request_details ) ) );
+		$cached_result = $this->cache_get( $in_memory_cache_key );
+
+		if ( null !== $cached_result ) {
+			return $cached_result;
+		}
+
+		$raw_response_data = $this->get_raw_response_data( $request_details, $input_variables );
+
+		// Errors are also cached in-memory to prevent repeating failed requests.
 		if ( is_wp_error( $raw_response_data ) ) {
-			return $raw_response_data;
+			return $this->cache_save( $in_memory_cache_key, $raw_response_data );
 		}
 
 		// Preprocess the response data.
@@ -258,13 +279,15 @@ class QueryRunner implements QueryRunnerInterface {
 			}
 		}
 
-		return [
+		$result = [
 			'metadata' => $metadata,
 			'pagination' => Pagination::format_pagination_data_for_query_response( $pagination, $input_schema, $input_variables ),
 			'results' => $results,
 			'query_id' => $query->get_id(),
 			'query_inputs' => [ $input_variables ],
 		];
+
+		return $this->cache_save( $in_memory_cache_key, $result );
 	}
 
 	/**
@@ -343,5 +366,27 @@ class QueryRunner implements QueryRunnerInterface {
 	 */
 	protected function preprocess_response( HttpQueryInterface $query, mixed $response_data, array $input_variables ): mixed {
 		return $query->preprocess_response( $response_data, $input_variables );
+	}
+
+	/**
+	 * Cache the response data in memory.
+	 *
+	 * @param string $cache_key The cache key.
+	 * @return array|WP_Error|null The cached data or null if not found.
+	 */
+	protected function cache_get( string $cache_key ): array|WP_Error|null {
+		return self::$in_memory_cache[ $cache_key ] ?? null;
+	}
+
+	/**
+	 * Cache the response data in memory.
+	 *
+	 * @param string $cache_key The cache key.
+	 * @param array|WP_Error $data The data to cache.
+	 * @return array|WP_Error The cached data.
+	 */
+	protected function cache_save( string $cache_key, array|WP_Error $data ): array|WP_Error {
+		self::$in_memory_cache[ $cache_key ] = $data;
+		return $data;
 	}
 }

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -153,6 +153,7 @@ class QueryRunner implements QueryRunnerInterface {
 
 		return [
 			'metadata' => [
+				'age' => $response->getHeaderLine( RdbCacheStrategy::CACHE_AGE_RESPONSE_HEADER ),
 				'status_code' => $response_code,
 			],
 			'response_data' => $this->deserialize_response( $raw_response_string, $input_variables ),

--- a/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
+++ b/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
@@ -2,10 +2,8 @@
 
 namespace RemoteDataBlocks\ExampleApi\Queries;
 
-use RemoteDataBlocks\Config\Query\HttpQueryInterface;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
 use RemoteDataBlocks\ExampleApi\Data\ExampleApiData;
-use WP_Error;
 
 defined( 'ABSPATH' ) || exit();
 
@@ -19,7 +17,7 @@ defined( 'ABSPATH' ) || exit();
  *
  */
 class ExampleApiQueryRunner extends QueryRunner {
-	protected function get_raw_response_data( HttpQueryInterface $query, array $input_variables ): array|WP_Error {
+	protected function get_raw_response_data( array $request_details, array $input_variables ): array {
 		if ( isset( $input_variables['record_id'] ) ) {
 			return [
 				'metadata' => [],

--- a/inc/HttpClient/RdbCacheStrategy.php
+++ b/inc/HttpClient/RdbCacheStrategy.php
@@ -13,6 +13,7 @@ use RemoteDataBlocks\Logging\Logger;
 use RemoteDataBlocks\Logging\LoggerManager;
 
 class RdbCacheStrategy extends GreedyCacheStrategy {
+	public const CACHE_AGE_RESPONSE_HEADER = 'Age';
 	public const CACHE_TTL_REQUEST_HEADER = GreedyCacheStrategy::HEADER_TTL;
 
 	private const CACHE_INVALIDATING_REQUEST_HEADERS = [ 'Authorization', 'Cache-Control' ];

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -23,7 +23,7 @@ class QueryRunnerTest extends TestCase {
 
 		$this->query = MockQuery::create( [
 			'data_source' => $this->http_data_source,
-			'query_runner' => new QueryRunner( $this->http_client ),
+			'query_runner' => new QueryRunner( $this->http_client, [] ),
 		] );
 	}
 
@@ -382,5 +382,57 @@ class QueryRunnerTest extends TestCase {
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'metadata', $result );
 		$this->assertArrayHasKey( 'results', $result );
+	}
+
+	public function testSubsequentRequestsResolveFromInMemoryCache(): void {
+		$response_body = wp_json_encode( [
+			'data' => [
+				'id' => 1,
+				'name' => 'Test',
+			],
+		] );
+		$response = new Response( 200, [], $response_body );
+
+		$this->query->set_output_schema( [
+			'is_collection' => false,
+			'path' => '$.data',
+			'type' => [
+				'id' => [
+					'name' => 'ID',
+					'type' => 'id',
+				],
+				'name' => [
+					'name' => 'Name',
+					'type' => 'string',
+				],
+			],
+		] );
+
+		$this->http_client->method( 'request' )->willReturn( $response );
+
+		$result = $this->query->execute( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'results', $result );
+		$this->assertEquals( 1, $result['results'][0]['result']['id']['value'] );
+		$this->assertEquals( 'Test', $result['results'][0]['result']['name']['value'] );
+
+		$updated_response_body = wp_json_encode( [
+			'data' => [
+				'id' => 2,
+				'name' => 'Test 2',
+			],
+		] );
+		$updated_response = new Response( 200, [], $updated_response_body );
+
+		$this->http_client->method( 'request' )->willReturn( $updated_response );
+
+		$result = $this->query->execute( [] );
+
+		// Returns original response from in-memory cache.
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'results', $result );
+		$this->assertEquals( 1, $result['results'][0]['result']['id']['value'] );
+		$this->assertEquals( 'Test', $result['results'][0]['result']['name']['value'] );
 	}
 }

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -74,13 +74,14 @@ function is_wp_error( mixed $thing ): bool {
 }
 
 function wp_parse_url( string $url ): array|false {
-    // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 	return parse_url( $url );
 }
 
 function wp_json_encode( mixed $data ): string {
-    // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
-	return json_encode( $data );
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+	$string = json_encode( $data );
+	return $string ?: '';
 }
 
 function wp_cache_get(): bool {

--- a/tests/integration/RDBTestCase.php
+++ b/tests/integration/RDBTestCase.php
@@ -3,7 +3,6 @@
 use WP_UnitTestCase;
 use RemoteDataBlocks\Config\DataSource\HttpDataSource;
 use RemoteDataBlocks\Config\Query\HttpQuery;
-use RemoteDataBlocks\Config\Query\HttpQueryInterface;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
 use RemoteDataBlocks\Editor\BlockManagement\BlockRegistration;
 use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;
@@ -102,11 +101,13 @@ class RDBTestCase extends WP_UnitTestCase {
 			private $status_code;
 
 			public function __construct( array $response_data, int $status_code ) {
+				parent::__construct( null, [] );
+
 				$this->response_data = $response_data;
 				$this->status_code = $status_code;
 			}
 
-			protected function get_raw_response_data( HttpQueryInterface $query, array $input_variables ): array|WP_Error {
+			protected function get_raw_response_data( array $request_details, array $input_variables ): array|WP_Error {
 				return [
 					'metadata' => [
 						'age' => 100,


### PR DESCRIPTION
This is a performance and developer experience improvement to remove redundant query executions during a single request. It implements a simple in-memory cache in `QueryRunner` so that repeated identical queries are quickly resolved from cache.

## Why is in-memory caching beneficial?

Mainly, because block bindings with identical queries are often repeated within a remote data block. For example, this remote data block has 7 children core blocks with block bindings, each of which needs the same data from the exact same query:

<img width="777" alt="Screenshot 2025-04-21 at 15 24 30" src="https://github.com/user-attachments/assets/737458d6-871a-4eed-b6e1-ed817ee43ee9" />

Currently, for this example, our block binding resolver function executes the exact same query 7 times. Via our Guzzle client, the redundant query executions resolve from object cache. On top of this, WP Core implements its own in-memory cache for object cache, which means that there is only one network request to object cache.

So why do we need this additional caching? Two main reasons:

1. There is additional post-processing that happens after the query is executed. The response is parsed as JSON and traversed recursively by `JsonPath` in order to extract the values defined by the query's output schema.
   - In aggregate across many blocks (or across many posts on an archive page), this can be expensive. 
   - Additionally, the plugin user has the opportunity to define their own callback functions to generate or transform this output, which might contain expensive code. They might have the (very reasonable) expectation that these callback functions would only be called once.
2. While we will soon cache error responses in object cache (#474), some errors unavoidably manifest as exceptions that must be caught, and therefore cannot be cached by Guzzle middleware. We do not want to repeat these requests many times over within the same request.

It has a small side benefit of removing the _appearance_ of multiple calls in our logging and debugging tools:


| Before  | After |
| ------------- | ------------- |
| <img width="904" alt="Screenshot 2025-04-21 at 15 30 07" src="https://github.com/user-attachments/assets/04e31117-fa35-481f-838d-e910216c454c" />  | <img width="906" alt="Screenshot 2025-04-21 at 15 29 46" src="https://github.com/user-attachments/assets/01a773dc-63b1-4f19-96b8-05f22cb010df" />  |


## Why implement in-memory caching _here_?

The `QueryRunner` implements query execution and response parsing, so it feels like a natural location. We could implement caching at the block binding level, but use cases that executed queries directly (e.g., custom code, REST API, interactivity API) would not benefit.

Another option is to inject the post-processing logic into our Guzzle middleware and cache the result, but that could result in breakage when processing code is updated. It's much safer to cache the raw API response.