### PR TITLE
Bugfix: Avoid repeated render of dynamic blocks

### DIFF
--- a/inc/Config/QueryRunner/QueryResponseParser.php
+++ b/inc/Config/QueryRunner/QueryResponseParser.php
@@ -55,7 +55,8 @@ final class QueryResponseParser {
 	 */
 	public function parse( mixed $data, array $schema ): mixed {
 		$json_obj = $data instanceof JsonObject ? $data : new JsonObject( $data );
-		$value = $json_obj->get( $schema['path'] ?? '$' );
+		$default_path = $schema['is_collection'] ?? false ? '$[*]' : '$';
+		$value = $json_obj->get( $schema['path'] ?? $default_path );
 
 		if ( is_array( $schema['type'] ?? null ) ) {
 			$value = $this->parse_response_objects( $value, $schema['type'] ) ?? [];

--- a/inc/Config/QueryRunner/QueryResponseParser.php
+++ b/inc/Config/QueryRunner/QueryResponseParser.php
@@ -55,7 +55,7 @@ final class QueryResponseParser {
 	 */
 	public function parse( mixed $data, array $schema ): mixed {
 		$json_obj = $data instanceof JsonObject ? $data : new JsonObject( $data );
-		$default_path = $schema['is_collection'] ?? false ? '$[*]' : '$';
+		$default_path = ( $schema['is_collection'] ?? false ) ? '$[*]' : '$';
 		$value = $json_obj->get( $schema['path'] ?? $default_path );
 
 		if ( is_array( $schema['type'] ?? null ) ) {

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -327,7 +327,7 @@ class BlockBindings {
 		// Look for a template block in the parsed block's inner blocks. If
 		// there is one, we can delegate to it for template rendering.
 		if ( self::has_template_block( $block->parsed_block ) ) {
-			return $block->render( [ 'dynamic' => false ] );
+			return $content;
 		}
 
 		// Otherwise, use this block's inner blocks as the template.
@@ -352,6 +352,12 @@ class BlockBindings {
 
 		if ( null === $query_response ) {
 			self::log_error( 'Cannot resolve query response for block binding', $block_name, $operation_name );
+			return $content;
+		}
+
+		// If there is only one result, it has already been resolved by the
+		// block bindings. We can just return the content.
+		if ( 1 === count( $query_response['results'] ) ) {
 			return $content;
 		}
 

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -210,6 +210,139 @@ class QueryRunnerTest extends TestCase {
 		$this->assertSame( $expected_result, $result['results'][0] );
 	}
 
+	public function testExecuteSuccessfulResponseWithCollectionResponse(): void {
+		$response_body = $this->createMock( \Psr\Http\Message\StreamInterface::class );
+		$response_body->method( 'getContents' )->willReturn(
+			wp_json_encode( [
+				'values' => [
+					[
+						'test' => 'test value 1',
+					],
+					[
+						'test' => 'test value 2',
+					],
+				],
+			]
+		) );
+
+		$response = new Response( 200, [], $response_body );
+
+		$this->http_client->method( 'request' )->willReturn( $response );
+
+		$this->query->set_output_schema( [
+			'is_collection' => true,
+			'path' => '$.values[*]',
+			'type' => [
+				'test' => [
+					'name' => 'Test Field',
+					'path' => '$.test',
+					'type' => 'string',
+				],
+			],
+		] );
+
+		$result = $this->query->execute( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'results', $result );
+
+		$this->assertArrayHasKey( 'metadata', $result );
+		$this->assertArrayHasKey( 'total_count', $result['metadata'] );
+		$this->assertSame( 2, $result['metadata']['total_count']['value'] );
+
+		$expected_results = [
+			[
+				'result' => [
+					'test' => [
+						'name' => 'Test Field',
+						'type' => 'string',
+						'value' => 'test value 1',
+					],
+				],
+				'uuid' => '00000000-0000-4000-8000-000000000000',
+			],
+			[
+				'result' => [
+					'test' => [
+						'name' => 'Test Field',
+						'type' => 'string',
+						'value' => 'test value 2',
+					],
+				],
+				'uuid' => '00000000-0000-4000-8000-000000000000',
+			],
+		];
+
+		$this->assertIsArray( $result['results'] );
+		$this->assertCount( 2, $result['results'] );
+		$this->assertSame( $expected_results, $result['results'] );
+	}
+
+	public function testExecuteSuccessfulResponseWithCollectionResponseAtRoot(): void {
+		$response_body = $this->createMock( \Psr\Http\Message\StreamInterface::class );
+		$response_body->method( 'getContents' )->willReturn(
+			wp_json_encode( [
+				[
+					'test' => 'test value 1',
+				],
+				[
+					'test' => 'test value 2',
+				],
+			]
+		) );
+
+		$response = new Response( 200, [], $response_body );
+
+		$this->http_client->method( 'request' )->willReturn( $response );
+
+		$this->query->set_output_schema( [
+			'is_collection' => true,
+			'type' => [
+				'test' => [
+					'name' => 'Test Field',
+					'path' => '$.test',
+					'type' => 'string',
+				],
+			],
+		] );
+
+		$result = $this->query->execute( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'results', $result );
+
+		$this->assertArrayHasKey( 'metadata', $result );
+		$this->assertArrayHasKey( 'total_count', $result['metadata'] );
+		$this->assertSame( 2, $result['metadata']['total_count']['value'] );
+
+		$expected_results = [
+			[
+				'result' => [
+					'test' => [
+						'name' => 'Test Field',
+						'type' => 'string',
+						'value' => 'test value 1',
+					],
+				],
+				'uuid' => '00000000-0000-4000-8000-000000000000',
+			],
+			[
+				'result' => [
+					'test' => [
+						'name' => 'Test Field',
+						'type' => 'string',
+						'value' => 'test value 2',
+					],
+				],
+				'uuid' => '00000000-0000-4000-8000-000000000000',
+			],
+		];
+
+		$this->assertIsArray( $result['results'] );
+		$this->assertCount( 2, $result['results'] );
+		$this->assertSame( $expected_results, $result['results'] );
+	}
+
 	public function testExecuteSuccessfulResponseWithJsonStringResponseData(): void {
 		$response_body = $this->createMock( \Psr\Http\Message\StreamInterface::class );
 		$response = new Response( 200, [], $response_body );

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -222,8 +222,8 @@ class QueryRunnerTest extends TestCase {
 						'test' => 'test value 2',
 					],
 				],
-			]
-		) );
+			] )
+		);
 
 		$response = new Response( 200, [], $response_body );
 
@@ -288,8 +288,8 @@ class QueryRunnerTest extends TestCase {
 				[
 					'test' => 'test value 2',
 				],
-			]
-		) );
+			] )
+		);
 
 		$response = new Response( 200, [], $response_body );
 

--- a/tests/integration/RDBTestCase.php
+++ b/tests/integration/RDBTestCase.php
@@ -139,6 +139,13 @@ class RDBTestCase extends WP_UnitTestCase {
 		return $nodes;
 	}
 
+	protected function get_dom_elements_by_html_class( DOMDocument $dom, string $html_class ): DOMNodeList|false {
+		$xpath = new DOMXPath( $dom );
+		$nodes = $xpath->query( sprintf( "//*[@class='%s']", $html_class ) );
+
+		return $nodes;
+	}
+
 	protected function assertDomIdHasTextContent( DOMDocument $dom, string $html_id, string $expected_content ): void {
 		$id_nodes = $this->get_dom_element_by_html_id( $dom, $html_id );
 

--- a/tests/integration/blocks/RemoteDataTemplateBlockTest.php
+++ b/tests/integration/blocks/RemoteDataTemplateBlockTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\IntegrationTests\Blocks;
+
+use RDBTestCase;
+
+class RemoteDataTemplateBlockTest extends RDBTestCase {
+	public function testTemplateBlockIsRenderedForEachResult(): void {
+		$test_api_response = [
+			[
+				'title' => 'Product 1',
+				'content' => 'Product 1 details',
+			],
+			[
+				'title' => 'Product 2',
+				'content' => 'Product 2 details',
+			],
+			[
+				'title' => 'Product 3',
+				'content' => 'Product 3 details',
+			],
+		];
+
+		$test_output_schema = [
+			'is_collection' => true,
+			'type' => [
+				'title' => [
+					'name' => 'Title',
+					'path' => '$.title',
+					'type' => 'string',
+				],
+				'content' => [
+					'name' => 'Content',
+					'path' => '$.content',
+					'type' => 'string',
+				],
+			],
+		];
+
+		$this->register_mocked_data_block( 'test-template-render', $test_api_response, $test_output_schema );
+
+		$result_html = do_blocks('
+			<!-- wp:remote-data-blocks/test-template-render {"remoteData":{"blockName":"remote-data-blocks/test-template-render"}} -->
+			<div>
+				<!-- wp:heading {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"block":"remote-data-blocks/test-template-render","field":"title"}}},"name":"Title"}} -->
+				<h2 id="field-title" class="wp-block-heading">Fallback title</h2>
+				<!-- /wp:heading -->
+
+				<!-- wp:remote-data-blocks/template -->
+					<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"field":"content"}}},"name":"Content"}} -->
+					<p class="field-content">Fallback content</p>
+					<!-- /wp:paragraph -->
+				<!-- /wp:remote-data-blocks/template -->
+			</div>
+			<!-- /wp:remote-data-blocks/test-template-render -->');
+
+		$dom = $this->load_html( $result_html );
+
+		// The title is outside the template block, so it should only be rendered once.
+		$this->assertDomIdHasHtmlContent( $dom, 'field-title', 'Product 1' );
+
+		// The content is inside the template block, so it should be rendered for each result.
+		$content_nodes = $this->get_dom_elements_by_html_class( $dom, 'field-content' );
+
+		$this->assertCount( 3, $content_nodes );
+		$this->assertEquals( 'Product 1 details', $content_nodes[0]->textContent );
+		$this->assertEquals( 'Product 2 details', $content_nodes[1]->textContent );
+		$this->assertEquals( 'Product 3 details', $content_nodes[2]->textContent );
+	}
+}

--- a/tests/integration/blocks/RemoteHtmlBlockTest.php
+++ b/tests/integration/blocks/RemoteHtmlBlockTest.php
@@ -6,10 +6,8 @@ use RDBTestCase;
 
 class RemoteHtmlBlockTest extends RDBTestCase {
 	public function testRemoteHtmlBlockRenders(): void {
-		$test_title = 'My Product';
-
 		$test_api_response = [
-			'title' => $test_title,
+			'title' => 'My product',
 			'content' => '<div id="rendered-html">A <strong>one of a kind</strong> product!</div>',
 		];
 
@@ -35,7 +33,7 @@ class RemoteHtmlBlockTest extends RDBTestCase {
 			<!-- wp:remote-data-blocks/test-html-render {"remoteData":{"blockName":"remote-data-blocks/test-html-render"}} -->
 			<div>
 				<!-- wp:heading {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"block":"remote-data-blocks/test-html-render","field":"title"}}},"name":"Title"}} -->
-				<h2 id="field-title" class="wp-block-heading"></h2>
+				<h2 id="field-title" class="wp-block-heading">Fallback title</h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:remote-data-blocks/remote-html {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"field":"content","block":"remote-data-blocks/test-html-render"}}},"name":"Content"}} /-->
@@ -44,6 +42,8 @@ class RemoteHtmlBlockTest extends RDBTestCase {
 		');
 
 		$dom = $this->load_html( $result_html );
+
+		$this->assertDomIdHasHtmlContent( $dom, 'field-title', 'My product' );
 		$this->assertDomIdHasHtmlContent( $dom, 'rendered-html', 'A <strong>one of a kind</strong> product!' );
 	}
 
@@ -54,7 +54,7 @@ class RemoteHtmlBlockTest extends RDBTestCase {
 			<!-- wp:remote-data-blocks/test-html-failure {"remoteData":{"blockName":"remote-data-blocks/test-html-failure"}} -->
 			<div>
 				<!-- wp:heading {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"block":"remote-data-blocks/test-html-failure","field":"title"}}},"name":"Title"}} -->
-				<h2 id="field-title" class="wp-block-heading"></h2>
+				<h2 id="field-title" class="wp-block-heading">Fallback title</h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:remote-data-blocks/remote-html {"metadata":{"bindings":{"content":{"source":"remote-data/binding","args":{"field":"content","block":"remote-data-blocks/test-html-failure"}}},"name":"Content"}} --><div id="fallback-content"><div class="warning">Use <em>this</em> content in case of emergency!</div></div><!-- /wp:remote-data-blocks/remote-html -->
@@ -63,6 +63,8 @@ class RemoteHtmlBlockTest extends RDBTestCase {
 		');
 
 		$dom = $this->load_html( $result_html );
+
+		$this->assertDomIdHasHtmlContent( $dom, 'field-title', 'Fallback title' );
 		$this->assertDomIdHasHtmlContent( $dom, 'fallback-content', '<div class="warning">Use <em>this</em> content in case of emergency!</div>' );
 	}
 }


### PR DESCRIPTION
In a block tree, the deepest descendant blocks are rendered first. This makes intuitive sense, since the ancestor blocks cannot be rendered without rendered descendants. This means that our dynamic template block does not need to be rerendered if there is only one result.

Similarly, our dynamic container block does not need to be rerendered if it contains a template block, since that block has already been rendered.

Depends on #478 