### PR TITLE
Add block binding Query Monitor panel

### DIFF
--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -4,12 +4,14 @@ namespace RemoteDataBlocks\Editor\DataBinding;
 
 defined( 'ABSPATH' ) || exit();
 
+use Psr\Log\LogLevel;
 use RemoteDataBlocks\Config\BlockAttribute\RemoteDataBlockAttribute;
 use RemoteDataBlocks\Editor\BlockManagement\ConfigRegistry;
 use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;
-use RemoteDataBlocks\Logging\LoggerManager;
 use RemoteDataBlocks\Sanitization\Sanitizer;
 use WP_Block;
+use WP_Error;
+
 use function add_action;
 use function add_filter;
 use function remove_filter;
@@ -19,6 +21,10 @@ use function register_block_bindings_source;
 class BlockBindings {
 	public static string $context_name = 'remote-data-blocks/remoteData';
 	public static string $binding_source = 'remote-data/binding';
+	public static string $log_action_name = 'remote_data_blocks_log_block_binding_event';
+
+	protected static string $hydrated_results_key = 'hydrated_results';
+	protected static string $prerendered_content_key = 'prerendered_content';
 
 	public static function init(): void {
 		add_action( 'init', [ __CLASS__, 'register_block_bindings' ], 50, 0 );
@@ -110,19 +116,18 @@ class BlockBindings {
 		return $block_type_args;
 	}
 
-	private static function execute_queries( array $block_context, array $source_args, string $operation_name ): array|null {
+	private static function execute_queries( array $block_context, array $source_args ): array|WP_Error {
 		// If this binding is inside a remote data block, we should have hydrated
 		// results already present. Use them.
-		if ( isset( $source_args['hydrated_results'] ) ) {
-			return $source_args['hydrated_results'];
+		if ( isset( $source_args[ self::$hydrated_results_key ] ) ) {
+			return $source_args[ self::$hydrated_results_key ];
 		}
 
 		// Load the attribute data and validate it.
 		$remote_data = RemoteDataBlockAttribute::from_array( $block_context );
 
 		if ( is_wp_error( $remote_data ) ) {
-			self::log_error( sprintf( 'Missing or malformed block context for block binding %s', self::$context_name ), $operation_name );
-			return null;
+			return $remote_data;
 		}
 
 		// Extract block and query information. In cases where the binding has become
@@ -140,8 +145,7 @@ class BlockBindings {
 		$query = $block_config['queries'][ $query_key ] ?? null;
 
 		if ( null === $query ) {
-			self::log_error( sprintf( 'Cannot load query %s for block binding', $query_key ), $block_name, $operation_name );
-			return null;
+			return new WP_Error( 'remote_data_blocks_binding_query_error', 'Cannot load query for block binding' );
 		}
 
 		// If there is a single array of input variables, fetch pagination variables.
@@ -187,20 +191,22 @@ class BlockBindings {
 			);
 
 			if ( is_wp_error( $query_response ) ) {
-				self::log_error( 'Error executing query for block binding: ' . $query_response->get_error_message(), $block_name, $operation_name );
-				return null;
+				return $query_response;
 			}
 
 			return $query_response;
 		} catch ( \Exception $e ) {
-			self::log_error( 'Unexpected exception for block binding: ' . $e->getMessage(), $block_name, $operation_name );
-			return null;
+			return new WP_Error( 'remote_data_blocks_binding_query_error', $e->getMessage(), [ 'cause' => $e ] );
 		}
 	}
 
 	public static function get_pagination_links( WP_Block $block ): array {
 		$block_context = $block->context[ self::$context_name ] ?? [];
-		$query_response = self::execute_queries( $block_context, [], 'remote_data_block_get_pagination_data' );
+		$query_response = self::execute_queries( $block_context, [] );
+
+		if ( is_wp_error( $query_response ) ) {
+			return [];
+		}
 
 		$pagination_data = $query_response['pagination'] ?? null;
 		$query_id = $query_response['query_id'] ?? null;
@@ -233,9 +239,11 @@ class BlockBindings {
 		if ( $block instanceof WP_Block ) {
 			$block_context = $block->context[ self::$context_name ] ?? [];
 			$block_attributes = $block->attributes;
+			$bound_block_name = $block->name;
 		} else {
 			$block_context = $block['context'][ self::$context_name ] ?? [];
 			$block_attributes = $block['attributes'] ?? [];
+			$bound_block_name = $block['name'] ?? 'unknown';
 		}
 
 		// Provide some flexibility for external callers to pass the block name.
@@ -256,15 +264,24 @@ class BlockBindings {
 		// have the expected context.
 		$fallback_content = self::get_block_fallback_content( $field_name, $block_attributes, $attribute_name, $serialized_results, $result_index );
 
+		$log_context = [
+			'block_name' => $bound_block_name,
+			'remote_data_block_name' => $block_name,
+			'source_args' => $source_args,
+		];
+
 		if ( null === $field_name ) {
-			self::log_error( 'Missing field mapping for block binding', $block_name, $field_name );
+			self::log_error( $log_context, new WP_Error(
+				'remote_data_blocks_binding_get_value_error',
+				'Missing field mapping for block binding',
+			) );
 			return $fallback_content;
 		}
 
-		$query_response = self::execute_queries( $block_context, $source_args, $field_name );
+		$query_response = self::execute_queries( $block_context, $source_args );
 
-		if ( empty( $query_response ) ) {
-			self::log_error( 'Cannot resolve query response for block binding', $block_name, $field_name );
+		if ( is_wp_error( $query_response ) ) {
+			self::log_error( $log_context, $query_response );
 			return $fallback_content;
 		}
 
@@ -275,12 +292,18 @@ class BlockBindings {
 		}
 
 		if ( null === $value ) {
-			self::log_error( sprintf( 'Cannot resolve %s %s for block binding', $field_type, $field_name ), $block_name, $field_name );
+			self::log_error( $log_context, new WP_Error(
+				'remote_data_blocks_binding_get_value_error',
+				'Cannot resolve field mapping for block binding',
+			) );
 			return $fallback_content;
 		}
 
 		// Convert the value to a string.
 		$value = strval( $value );
+
+		// If we've reached this point, the binding was successful.
+		self::log_success( $log_context );
 
 		// Prepend label to value if provided. Class name should match the one
 		// generated by the block editor script.
@@ -304,7 +327,7 @@ class BlockBindings {
 
 	/**
 	 * Find a "template block" in a parsed block's inner blocks.
-	 * 
+	 *
 	 * @param array $parsed_block The parsed block.
 	 * @return bool True if a template block was found.
 	 */
@@ -336,22 +359,33 @@ class BlockBindings {
 
 	public static function render_remote_data_template_block( array $attributes, string $content, WP_Block $block ): string {
 		// If already rendered, don't render dynamically again.
-		if ( isset( $block->parsed_block['dynamicallyRenderedContent'] ) ) {
-			return $block->parsed_block['dynamicallyRenderedContent'];
+		if ( isset( $block->parsed_block[ self::$prerendered_content_key ] ) ) {
+			return $block->parsed_block[ self::$prerendered_content_key ];
 		}
 
 		// If this is the parent block that *provides* the context, we won't have
 		// context available on the block's context property. However, context for
 		// children blocks comes from this block's `remoteData` attribtue (see
 		// block.json#providesContext), so we can access it directly.
-		$block_context = $block->context[ self::$context_name ] ?? $attributes['remoteData'] ?? [];
-		$block_name = $block_context['blockName'] ?? null;
-		$operation_name = 'remote_data_block_render';
+		$block_context = $block->context[ self::$context_name ] ?? $attributes['remoteData'] ?? null;
 
-		$query_response = self::execute_queries( $block_context, [], $operation_name );
+		$log_context = [
+			'block_name' => $block->name,
+			'remote_data_block_name' => $block_context['blockName'] ?? 'unknown',
+		];
 
-		if ( null === $query_response ) {
-			self::log_error( 'Cannot resolve query response for block binding', $block_name, $operation_name );
+		if ( empty( $block_context ) ) {
+			self::log_error( $log_context, new WP_Error(
+				'remote_data_blocks_binding_template_render_error',
+				'Missing block context for block binding',
+			) );
+			return $content;
+		}
+
+		$query_response = self::execute_queries( $block_context, [] );
+
+		if ( is_wp_error( $query_response ) ) {
+			self::log_error( $log_context, $query_response );
 			return $content;
 		}
 
@@ -363,14 +397,14 @@ class BlockBindings {
 
 		$source_args_for_each_item = array_map( function ( $index ) use ( $query_response ): array {
 			return [
-				'hydrated_results' => $query_response,
+				self::$hydrated_results_key => $query_response,
 				'index' => $index,
 			];
 		}, array_keys( $query_response['results'] ) );
 
 		$loop_template = $block->parsed_block['innerBlocks'];
 		$loop_template_content = $block->parsed_block['innerContent'];
-		
+
 		// Remove the existing blocks and content so that we can repopulate it.
 		$block->parsed_block['innerBlocks'] = [];
 		$block->parsed_block['innerContent'] = [];
@@ -398,9 +432,9 @@ class BlockBindings {
 		// parsed block, which will not be persisted. This is needed because
 		// our container block can trigger a non-dynamic re-render. This helps
 		// avoid descendant dynamic blocks from being rendered twice.
-		$block->parsed_block['dynamicallyRenderedContent'] = $updated_block->render( [ 'dynamic' => false ] );
+		$block->parsed_block[ self::$prerendered_content_key ] = $updated_block->render( [ 'dynamic' => false ] );
 
-		return $block->parsed_block['dynamicallyRenderedContent'];
+		return $block->parsed_block[ self::$prerendered_content_key ];
 	}
 
 	/**
@@ -437,8 +471,21 @@ class BlockBindings {
 		return $inner_blocks;
 	}
 
-	public static function log_error( string $message, ?string $block_name = 'unknown', ?string $operation_name = 'unknown' ): void {
-		$logger = LoggerManager::instance();
-		$logger->error( sprintf( '%s %s (block: %s; operation: %s)', $message, self::$context_name, $block_name, $operation_name ) );
+	protected static function log_error( array $log_context, WP_Error $error ): void {
+		// Remove key "hydrated_results" if it exists.
+		if ( isset( $log_context['source_args'][ self::$hydrated_results_key ] ) ) {
+			unset( $log_context['source_args'][ self::$hydrated_results_key ] );
+		}
+
+		do_action( self::$log_action_name, LogLevel::ERROR, $error->get_error_message(), $log_context, $error );
+	}
+
+	protected static function log_success( array $log_context ): void {
+		// Remove key "hydrated_results" if it exists.
+		if ( isset( $log_context['source_args'][ self::$hydrated_results_key ] ) ) {
+			unset( $log_context['source_args'][ self::$hydrated_results_key ] );
+		}
+
+		do_action( self::$log_action_name, LogLevel::INFO, 'Successfully resolved block binding', $log_context );
 	}
 }

--- a/inc/Editor/DataBinding/FieldShortcode.php
+++ b/inc/Editor/DataBinding/FieldShortcode.php
@@ -45,7 +45,7 @@ class FieldShortcode {
 					'type' => $query_data['type'] ?? 'field',
 				];
 
-				$value = BlockBindings::get_value( $source_args, [], 'content' );
+				$value = BlockBindings::get_value( $source_args, [ 'name' => '<field-shortcode>' ], 'content' );
 
 				if ( is_null( $value ) ) {
 					$status = 'query-error';

--- a/inc/Logging/QueryMonitor/QueryMonitor.php
+++ b/inc/Logging/QueryMonitor/QueryMonitor.php
@@ -17,6 +17,7 @@ class QueryMonitor {
 	public static function add_collectors( array $collectors ): array {
 		$collector_classes = [
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbMainCollector',
+			'RemoteDataBlocks\Logging\QueryMonitor\RdbBlockBindingCollector',
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbHttpRequestCollector',
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbValidationCollector',
 		];
@@ -34,6 +35,7 @@ class QueryMonitor {
 	public static function add_outputters( array $outputters ): array {
 		$outputter_classes = [
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbMainOutputHtml',
+			'RemoteDataBlocks\Logging\QueryMonitor\RdbBlockBindingOutputHtml',
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbHttpRequestOutputHtml',
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbValidationOutputHtml',
 		];

--- a/inc/Logging/QueryMonitor/RdbBlockBindingCollector.php
+++ b/inc/Logging/QueryMonitor/RdbBlockBindingCollector.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Logging\QueryMonitor;
+
+use QM_Backtrace;
+use QM_Collector_Logger;
+use QM_Data_Logger;
+use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
+use WP_Error;
+use function get_post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'QM_Collector_Logger' ) ) {
+	/**
+	 * @extends QM_Collector<QM_Data_Logger>
+	 */
+	class RdbBlockBindingCollector extends QM_Collector_Logger {
+		/**
+		 * @var string
+		 */
+		public $id = 'remote-data-blocks-block-binding';
+
+		/**
+		 * Intentionally do not call parent
+		 */
+		public function set_up(): void {
+			add_action( BlockBindings::$log_action_name, [ $this, 'log_event' ], 90, 3 );
+
+			$this->data->counts = array_fill_keys( $this->get_levels(), 0 );
+		}
+
+		public function tear_down(): void {
+			remove_action( BlockBindings::$log_action_name, [ $this, 'log_event' ], 90, 3 );
+		}
+
+		/**
+		 * @return array<int, string>
+		 */
+		public function get_concerned_actions(): array {
+			return [];
+		}
+
+		/**
+		 * @return array<int, string>
+		 */
+		public function get_concerned_filters(): array {
+			return [];
+		}
+
+		/**
+		 * @return array<int, string>
+		 */
+		public function get_concerned_constants(): array {
+			return [];
+		}
+
+		public function log_event( string $level, string $message, array $context, ?WP_Error $error = null ): void {
+			$this->log( $level, $message, $context );
+		}
+
+		/**
+		 * This method must match the implementation of the parent class,
+		 * including the missing type hints.
+		 *
+		 * @param string $level Log level (e.g., 'error', 'warning', 'info')
+		 * @param string $message Log message
+		 * @param array<string, mixed> $context Context
+		 * @param string|null $prefix Optional prefix for the log message
+		 * @return void
+		 */
+		// phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint,SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+		protected function store( $level, $message, array $context = [], ?string $prefix = null ) {
+			$trace = new QM_Backtrace( [
+				'ignore_class' => [
+					self::class => true,
+				],
+				'ignore_hook' => array(
+					current_filter() => true,
+				),
+				'ignore_method' => [
+					BlockBindings::class => [
+						'log_error' => true,
+						'log_success' => true,
+					],
+				],
+			] );
+
+			$this->data->counts[ $level ] = ( $this->data->counts[ $level ] ?? 0 ) + 1;
+			$this->data->logs[] = [
+				'block_name' => $context['block_name'] ?? 'unknown',
+				'block_info' => [
+					'Source args' => $context['source_args'] ?? [],
+				],
+				'component' => $trace->get_component(),
+				'filtered_trace' => $trace->get_filtered_trace(),
+				'level' => $level,
+				'message' => $message,
+				'post_id' => get_post()->ID ?? '',
+				'remote_data_block_name' => $context['remote_data_block_name'] ?? 'unknown',
+			];
+		}
+	}
+}

--- a/inc/Logging/QueryMonitor/RdbBlockBindingOutputHtml.php
+++ b/inc/Logging/QueryMonitor/RdbBlockBindingOutputHtml.php
@@ -1,0 +1,189 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Logging\QueryMonitor;
+
+use QueryMonitor as QM;
+use QM_Output_Html_Logger;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'QM_Output_Html_Logger' ) ) {
+	class RdbBlockBindingOutputHtml extends QM_Output_Html_Logger {
+		public static string $collector_id = 'remote-data-blocks-block-binding';
+
+		public function output(): void {
+			/** @var QM_Data_Logger $data */
+			$data = $this->collector->get_data();
+
+			if ( ! empty( $data->logs ) ) {
+				$block_names = array_unique( array_column( $data->logs, 'block_name' ) );
+				$levels = array_unique( array_column( $data->logs, 'level' ) );
+				$remote_data_block_names = array_unique( array_column( $data->logs, 'remote_data_block_name' ) );
+
+				$this->before_tabular_output();
+
+				echo '<thead>';
+				echo '<tr>';
+				echo '<th scope="col" class="qm-filterable-column">';
+				echo $this->build_filter( 'result', $levels, __( 'Level', 'remote-data-blocks' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '</th>';
+				echo '<th scope="col">' . esc_html__( 'Message', 'remote-data-blocks' ) . '</th>';
+				echo '<th scope="col" class="qm-filterable-column">';
+				echo $this->build_filter( 'component', $remote_data_block_names, __( 'Remote data block', 'remote-data-blocks' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '</th>';
+				echo '<th scope="col" class="qm-filterable-column">';
+				echo $this->build_filter( 'type', $block_names, __( 'Block', 'remote-data-blocks' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '</th>';
+				echo '<th scope="col">' . esc_html__( 'Post ID', 'remote-data-blocks' ) . '</th>';
+				echo '<th scope="col">' . esc_html__( 'Caller', 'remote-data-blocks' ) . '</th>';
+				echo '</tr>';
+				echo '</thead>';
+
+				echo '<tbody>';
+
+				foreach ( $data->logs as $row ) {
+					$row_attr = [];
+					$class = '';
+
+					$is_warning = in_array( $row['level'], $this->collector->get_warning_levels(), true );
+
+					if ( $is_warning ) {
+						$class = 'qm-warn';
+					}
+
+					$stack = array();
+
+					foreach ( $row['filtered_trace'] as $frame ) {
+						$stack[] = self::output_filename( $frame['display'], $frame['calling_file'], $frame['calling_line'] );
+					}
+
+					// These tokens are chosen to match the filters that ship in QM core.
+					$row_attr['data-qm-component'] = $row['remote_data_block_name'];
+					$row_attr['data-qm-result'] = $row['level'];
+					$row_attr['data-qm-type'] = $row['block_name'];
+
+					$attr = '';
+					foreach ( $row_attr as $a => $v ) {
+						$attr .= ' ' . $a . '="' . esc_attr( (string) $v ) . '"';
+					}
+
+					printf(
+						'<tr %s class="%s">',
+						$attr, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						esc_attr( $class )
+					);
+
+					/* Level */
+					echo '<td class="qm-nowrap">';
+
+					if ( $is_warning ) {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo QM::icon( 'warning' );
+					} else {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo QM::icon( 'blank' );
+					}
+
+					echo esc_html( ucfirst( $row['level'] ) );
+					echo '</td>';
+
+					/* Message */
+					printf(
+						'<td>%s</td>',
+						esc_html( $row['message'] )
+					);
+
+					/* Remote data block */
+					printf(
+						'<td>%s</td>',
+						esc_html( $row['remote_data_block_name'] )
+					);
+
+					/* Block */
+					echo '<td class="qm-has-toggle qm-ltr qm-wrap">';
+					echo self::build_toggler(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo esc_html( $row['block_name'] );
+					echo '<div class="qm-toggled qm-info qm-supplemental">';
+					echo '<table><tbody>';
+					foreach ( $row['block_info'] as $key => $value ) {
+						echo '<tr>';
+						echo '<td>' . esc_html( $key ) . '</td>';
+						echo '<td><pre><code>' . esc_html( wp_json_encode( $value ) ) . '</code></pre></td>';
+						echo '</tr>';
+					}
+					echo '</tbody></table>';
+					echo '</div></td>';
+
+					/* Post ID */
+					printf(
+						'<td>%s</td>',
+						esc_html( strval( $row['post_id'] ) )
+					);
+
+					/* Caller / trace */
+
+					$caller = array_shift( $stack );
+					echo '<td class="qm-has-toggle qm-nowrap qm-ltr">';
+
+					if ( ! empty( $stack ) ) {
+						echo self::build_toggler(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					}
+
+					echo '<ol>';
+					echo '<li>' . $caller . '</li>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+					if ( ! empty( $stack ) ) {
+						echo '<div class="qm-toggled"><li>' . implode( '</li><li>', $stack ) . '</li></div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					}
+
+					echo '</ol></td>';
+
+					echo '</tr>';
+				}
+
+				echo '</tbody>';
+
+				$this->after_tabular_output();
+			} else {
+				$this->before_non_tabular_output();
+
+				$notice = __( 'No block bindings.', 'remote-data-blocks' );
+				echo $this->build_notice( $notice ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+				$this->after_non_tabular_output();
+			}
+		}
+
+		/**
+		 * @param array<string, mixed[]> $menu
+		 * @return array<string, mixed[]>
+		 */
+		public function admin_menu( array $menu ): array {
+			/** @var QM_Data_HTTP $data */
+			$data = $this->collector->get_data();
+			$count = 0;
+
+			if ( ! empty( $data->logs ) ) {
+				$count = count( $data->logs );
+
+				/* translators: %s: Number of logs that are available */
+				$label = __( 'Block bindings (%s)', 'query-monitor' );
+			} else {
+				$label = __( 'Block bindings', 'query-monitor' );
+			}
+
+			$menu['qm-remote-data-blocks']['children'][ $this->collector->id() ] = $this->menu( [
+				'id' => $this->collector->id(),
+				'title' => esc_html( sprintf(
+					$label,
+					number_format_i18n( $count )
+				) ),
+
+			] );
+
+			return $menu;
+		}
+	}
+}

--- a/inc/Logging/QueryMonitor/RdbValidationOutputHtml.php
+++ b/inc/Logging/QueryMonitor/RdbValidationOutputHtml.php
@@ -12,6 +12,25 @@ if ( class_exists( 'QM_Output_Html_Logger' ) ) {
 	class RdbValidationOutputHtml extends QM_Output_Html_Logger {
 		public static string $collector_id = 'remote-data-blocks-validation';
 
+		public function output(): void {
+			/** @var QM_Data_Logger $data */
+			$data = $this->collector->get_data();
+
+			if ( empty( $data->logs ) ) {
+				$this->before_non_tabular_output();
+
+				$notice = __( 'No validation issues.', 'remote-data-blocks' );
+				echo $this->build_notice( $notice ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+				$this->after_non_tabular_output();
+
+				return;
+			}
+
+			paremt::output();
+		}
+
+
 		public function admin_menu( array $menu ): array {
 			/** @var QM_Data_Logger $data */
 			$data = $this->collector->get_data();

--- a/inc/REST/RemoteDataController.php
+++ b/inc/REST/RemoteDataController.php
@@ -5,7 +5,6 @@ namespace RemoteDataBlocks\REST;
 defined( 'ABSPATH' ) || exit();
 
 use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;
-use RemoteDataBlocks\Logging\LoggerManager;
 use WP_Error;
 use WP_REST_Request;
 use function wp_generate_uuid4;
@@ -63,8 +62,6 @@ class RemoteDataController {
 		$query_response = $query->execute_batch( $query_inputs );
 
 		if ( is_wp_error( $query_response ) ) {
-			$logger = LoggerManager::instance();
-			$logger->warning( $query_response->get_error_message() );
 			return $query_response;
 		}
 

--- a/inc/Store/DataSource/ConstantConfigStore.php
+++ b/inc/Store/DataSource/ConstantConfigStore.php
@@ -3,7 +3,6 @@
 namespace RemoteDataBlocks\Store\DataSource;
 
 use RemoteDataBlocks\Config\DataSource\DataSourceInterface;
-use RemoteDataBlocks\Logging\LoggerManager;
 use WP_Error;
 
 use const RemoteDataBlocks\REMOTE_DATA_BLOCKS__DATA_SOURCE_CLASSMAP;
@@ -31,14 +30,6 @@ class ConstantConfigStore {
 			$validation_result = self::validate_config( $config );
 			if ( ! is_wp_error( $validation_result ) ) {
 				$valid_configs[] = $config;
-			} else {
-				LoggerManager::instance()->error(
-					sprintf(
-						'Invalid data source config found (uuid: %s): %s',
-						$config['uuid'] ?? 'unknown',
-						$validation_result->get_error_message()
-					)
-				);
 			}
 		}
 
@@ -50,7 +41,7 @@ class ConstantConfigStore {
 		$found = array_filter( $configs, function ( $config ) use ( $uuid ) {
 			return $config['uuid'] === $uuid;
 		} );
-		
+
 		if ( empty( $found ) ) {
 			return new WP_Error(
 				'data_source_not_found',
@@ -61,7 +52,7 @@ class ConstantConfigStore {
 
 		$config = reset( $found );
 		$validation_result = self::validate_config( $config );
-		
+
 		if ( is_wp_error( $validation_result ) ) {
 			return $validation_result;
 		}

--- a/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
+++ b/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
@@ -4,6 +4,7 @@ namespace RemoteDataBlocks\Tests\Integrations\VipBlockDataApi;
 
 use PHPUnit\Framework\TestCase;
 use RemoteDataBlocks\Editor\BlockManagement\ConfigRegistry;
+use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 use RemoteDataBlocks\Integrations\VipBlockDataApi\VipBlockDataApi;
 use RemoteDataBlocks\Tests\Mocks\MockQuery;
 use RemoteDataBlocks\Tests\Mocks\MockQueryRunner;
@@ -167,9 +168,10 @@ class VipBlockDataApiTest extends TestCase {
 	}
 
 	public function testResolveRemoteDataFallsBackToDbOnQuery(): void {
+		$error = new \WP_Error( 'rdb-uh-oh', 'uh-oh!' );
 		$mock_qr = new MockQueryRunner();
 		$mock_qr->addResult( 'title', 'Happy happy hour! No networking!' );
-		$mock_qr->addResult( 'location', new \WP_Error( 'rdb-uh-oh', 'uh-oh!' ) );
+		$mock_qr->addResult( 'location', $error );
 
 		$mock_query = MockQuery::create( [ 'query_runner' => $mock_qr ] );
 		register_remote_data_block( [
@@ -181,14 +183,37 @@ class VipBlockDataApiTest extends TestCase {
 
 		$result = VipBlockDataApi::resolve_remote_data( self::$sourced_block1, 'remote-data-blocks/events', 12, self::$parsed_block1 );
 
+		// The first binding is successful.
 		$this->assertSame(
 			[
-				'remote-data-blocks',
-				'error',
-				'Error executing query for block binding: uh-oh! remote-data-blocks/remoteData (block: remote-data-blocks/events; operation: location)',
-				[],
+				'info',
+				'Successfully resolved block binding',
+				[
+					'block_name' => 'core/paragraph',
+					'remote_data_block_name' => 'remote-data-blocks/events',
+					'source_args' => [
+						'field' => 'title',
+					],
+				],
 			],
-			MockWordPressFunctions::get_done_action( 'wpcomvip_log', 0 )
+			MockWordPressFunctions::get_done_action( BlockBindings::$log_action_name, 0 )
+		);
+
+		// The first binding results in an error.
+		$this->assertSame(
+			[
+				'error',
+				'uh-oh!',
+				[
+					'block_name' => 'core/heading',
+					'remote_data_block_name' => 'remote-data-blocks/events',
+					'source_args' => [
+						'field' => 'location',
+					],
+				],
+				$error,
+			],
+			MockWordPressFunctions::get_done_action( BlockBindings::$log_action_name, 1 )
 		);
 		$this->assertSame( 'Happy happy hour! No networking!', $result['innerBlocks'][0]['attributes']['content'] );
 		$this->assertSame( 'President&#039;s dining hall', $result['innerBlocks'][1]['attributes']['content'] );


### PR DESCRIPTION
Add a panel showing details about block binding that were resolved during the current render, including any related to "field shortcodes."

https://github.com/user-attachments/assets/77dbce6d-bfbb-4bab-b9fc-b60807a2cb0f

Also remove some logging calls that are already surfaced via other channels (like validation errors).