### PR TITLE
Update HTTP tutorial documentation to correct API URL for Zip Code API

### DIFF
--- a/docs/tutorials/http.md
+++ b/docs/tutorials/http.md
@@ -9,7 +9,7 @@ This page will walk you through registering a remote data block that loads data 
 3. Choose "HTTP" from the dropdown menu as the data source type.
 4. Fill in the following details:
    - Data Source Name: Zip Code API
-   - URL: https://api.zippopotam.us/us/
+   - URL: https://api.zippopotam.us/
 5. If your API requires authentication, enter those details. This API does not.
 6. Save the data source and return the data source list.
 7. In the Actions column, click the three-dot menu, then "Copy UUID" to copy the data source's UUID to your clipboard.


### PR DESCRIPTION
There's an error when trying to access https://api.zippopotam.us/us/

<img width="618" alt="Screenshot 2025-04-28 at 07 02 07" src="https://github.com/user-attachments/assets/964468ec-e9e2-4a53-822c-15ae2bc206a6" />

This PR fixes the URL to point to https://api.zippopotam.us/
