### PR TITLE
Restore example URL and add clarification

### DIFF
--- a/docs/tutorials/http.md
+++ b/docs/tutorials/http.md
@@ -9,7 +9,7 @@ This page will walk you through registering a remote data block that loads data 
 3. Choose "HTTP" from the dropdown menu as the data source type.
 4. Fill in the following details:
    - Data Source Name: Zip Code API
-   - URL: https://api.zippopotam.us/us/
+   - URL: https://api.zippopotam.us/
 5. If your API requires authentication, enter those details. This API does not.
 6. Save the data source and return the data source list.
 7. In the Actions column, click the three-dot menu, then "Copy UUID" to copy the data source's UUID to your clipboard.

--- a/docs/tutorials/http.md
+++ b/docs/tutorials/http.md
@@ -11,7 +11,7 @@ This page will walk you through registering a remote data block that loads data 
    - Data Source Name: Zip Code API
    - URL: https://api.zippopotam.us/us/
 
-_Note: The `endpoint` function in the code below will append the provided Zip Code (by the user) to the "URL" value defined here, to form the final endpoint_
+_Note: The `endpoint` function in the code below will append the provided Zip Code (by the user) to the "URL" value defined here, to form the final endpoint of this example_
 
 5. If your API requires authentication, enter those details. This API does not.
 6. Save the data source and return the data source list.

--- a/docs/tutorials/http.md
+++ b/docs/tutorials/http.md
@@ -9,7 +9,10 @@ This page will walk you through registering a remote data block that loads data 
 3. Choose "HTTP" from the dropdown menu as the data source type.
 4. Fill in the following details:
    - Data Source Name: Zip Code API
-   - URL: https://api.zippopotam.us/
+   - URL: https://api.zippopotam.us/us/
+
+_Note: The `endpoint` function in the code below will append the provided Zip Code (by the user) to the "URL" value defined here, to form the final endpoint_
+
 5. If your API requires authentication, enter those details. This API does not.
 6. Save the data source and return the data source list.
 7. In the Actions column, click the three-dot menu, then "Copy UUID" to copy the data source's UUID to your clipboard.


### PR DESCRIPTION
The PR https://github.com/Automattic/remote-data-blocks/pull/483 merged, updated a URL value that was actually correct for the inner logic of the code although it cannot be accessed directly. Sorry about opening that PR in the first place.

I think a clarification note could be useful for developers to understand the purpose of the value and its connection with the code provided below in the same doc page.

This PR restores the original value for the "URL" field and adds a clarification note.