### PR TITLE
Switch to the private playground version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 **Remote Data Blocks** is a WordPress plugin that makes it easy to combine content and remote data in the block editor. Easily register blocks that load data from Airtable, Google Sheets, Shopify, GitHub, or any other API. Your data stays in sync. Built-in caching ensures performance and reliability. [Read more about well-supported use cases](docs/concepts/index.md#supported-use-cases).
 
-[![Launch in WordPress Playground](https://img.shields.io/badge/Launch%20in%20WordPress%20Playground-DA9A45?style=for-the-badge&logo=wordpress)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/remote-data-blocks/trunk/blueprint.json)
+[![Launch in WordPress Playground](https://img.shields.io/badge/Launch%20in%20WordPress%20Playground-DA9A45?style=for-the-badge&logo=wordpress)](https://wordpress-playground.atomicsites.blog/?blueprint-url=https://raw.githubusercontent.com/Automattic/remote-data-blocks/trunk/blueprint.json)
 
-[Launch the plugin in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/remote-data-blocks/trunk/blueprint.json) and explore. An example API ("Conference Event") is included, or visit Settings > Remote Data Blocks to add your own. Read our [tutorials](docs/tutorials/index.md) to dive in.
+[Launch the plugin in WordPress Playground](https://wordpress-playground.atomicsites.blog/?blueprint-url=https://raw.githubusercontent.com/Automattic/remote-data-blocks/trunk/blueprint.json) and explore. An example API ("Conference Event") is included, or visit Settings > Remote Data Blocks to add your own. Read our [tutorials](docs/tutorials/index.md) to dive in.
 
 ## Next steps
 

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "$schema": "https://wordpress-playground.atomicsites.blog/blueprint-schema.json",
   "meta": {
     "title": "Remote Data Blocks latest",
     "description": "Installs the latest release of remote-data-blocks plugin to WordPress Playground",

--- a/blueprint.local.json
+++ b/blueprint.local.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "$schema": "https://wordpress-playground.atomicsites.blog/blueprint-schema.json",
   "meta": {
     "title": "Remote Data Blocks local playground",
     "description": "Runs Remote Data Blocks plugin in a local WordPress Playground",


### PR DESCRIPTION
### Description

This will replace the public playground link with the private a8c hosted playground. That's been opened up to the general public so we are free to start using that.

It doesn't allow installation of any package just yet, so we are still using the GitHub proxy. That's in progress so it'll be dropped shortly.