### PR TITLE
add default empty string value for shopify search input

### DIFF
--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -86,6 +86,7 @@ class ShopifyIntegration {
 				'input_schema' => [
 					'search' => [
 						'type' => 'ui:search_input',
+						'default_value' => '',
 					],
 					'limit' => [
 						'default_value' => 8,


### PR DESCRIPTION
# Description

Ensures that an empty string is passed as the default value for the search parameter in the Shopify product search query, fixing issues when API broke if it's not provided.

# Testing

Set up a Shopify data source from WP-Admin and verify that adding blocks works in editor and the frontend renders them.
