### PR TITLE
apply http data source service config to request

### DIFF
--- a/inc/Config/DataSource/HttpDataSource.php
+++ b/inc/Config/DataSource/HttpDataSource.php
@@ -98,11 +98,51 @@ class HttpDataSource extends ArraySerializable implements HttpDataSourceInterfac
 		return ConfigSchemas::get_http_data_source_service_config_schema();
 	}
 
+	private static function get_auth_to_request_headers( array $service_config ): array {
+		if ( ! isset( $service_config['auth'] ) ) {
+			return [];
+		}
+
+		$auth_headers = [];
+		$auth = $service_config['auth'];
+
+		if ( 'bearer' === $auth['type'] ) {
+			$auth_headers['Authorization'] = 'Bearer ' . $auth['value'];
+		} elseif ( 'basic' === $auth['type'] ) {
+			$auth_headers['Authorization'] = 'Basic ' . base64_encode( $auth['value'] );
+		} elseif ( 'api-key' === $auth['type'] && 'header' === $auth['add_to'] ) {
+			$auth_headers[ $auth['key'] ] = $auth['value'];
+		}
+
+		return $auth_headers;
+	}
+
+	private static function add_auth_to_endpoint( string|null $endpoint, array $service_config ): string|null {
+		if ( ! isset( $service_config['auth'] ) 
+			|| 'api-key' !== $service_config['auth']['type'] 
+			|| 'queryparams' !== $service_config['auth']['add_to']
+			|| empty( $endpoint )
+		) {
+			return $endpoint;
+		}
+
+		$query_string = $service_config['auth']['key'] . '=' . $service_config['auth']['value'];
+		
+		return $endpoint . ( strpos( $endpoint, '?' ) === false ? '?' : '&' ) . $query_string;
+	}
+
 	protected static function map_service_config( array $service_config ): array {
+		$request_headers = $service_config['request_headers'] ?? [];
+		$endpoint = $service_config['endpoint'] ?? null; // Invalid, but we won't guess it.
+
+		$auth_headers = self::get_auth_to_request_headers( $service_config );
+		$request_headers = array_merge( $request_headers, $auth_headers );
+		$endpoint = self::add_auth_to_endpoint( $endpoint, $service_config );
+
 		return [
 			'display_name' => $service_config['display_name'] ?? static::SERVICE_NAME,
-			'endpoint' => $service_config['endpoint'] ?? null, // Invalid, but we won't guess it.
-			'request_headers' => $service_config['request_headers'] ?? [],
+			'endpoint' => $endpoint,
+			'request_headers' => $request_headers,
 		];
 	}
 

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -152,7 +152,7 @@ final class ConfigSchemas {
 			'__version' => Types::integer(),
 			'auth' => Types::nullable(
 				Types::object( [
-					'add_to' => Types::nullable( Types::enum( 'header', 'query' ) ),
+					'add_to' => Types::nullable( Types::enum( 'header', 'queryparams' ) ),
 					'key' => Types::nullable( Types::skip_sanitize( Types::string() ) ),
 					'type' => Types::enum( 'basic', 'bearer', 'api-key', 'none' ),
 					'value' => Types::skip_sanitize( Types::string() ),

--- a/tests/inc/Config/HttpDataSourceTest.php
+++ b/tests/inc/Config/HttpDataSourceTest.php
@@ -67,4 +67,158 @@ class HttpDataSourceTest extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $this->http_data_source );
 		$this->assertSame( 'testUserId must be an integer', $this->http_data_source->get_error_message() );
 	}
+
+	public function testBearerAuthHeaderIsAdded(): void {
+		$config = [
+			'service_config' => [
+				'__version' => 1,
+				'display_name' => 'Mock Data Source',
+				'endpoint' => 'http://example.com',
+				'auth' => [
+					'type' => 'bearer',
+					'value' => 'test-token',
+				],
+			],
+		];
+		$this->http_data_source = MockDataSource::create( $config );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->http_data_source );
+		$headers = $this->http_data_source->get_request_headers();
+		$this->assertIsArray( $headers );
+		$this->assertArrayHasKey( 'Authorization', $headers );
+		$this->assertSame( 'Bearer test-token', $headers['Authorization'] );
+	}
+
+	public function testBasicAuthHeaderIsAdded(): void {
+		$config = [
+			'service_config' => [
+				'__version' => 1,
+				'display_name' => 'Mock Data Source',
+				'endpoint' => 'http://example.com',
+				'auth' => [
+					'type' => 'basic',
+					'value' => 'user:pass',
+				],
+			],
+		];
+		$this->http_data_source = MockDataSource::create( $config );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->http_data_source );
+		$headers = $this->http_data_source->get_request_headers();
+		$this->assertIsArray( $headers );
+		$this->assertArrayHasKey( 'Authorization', $headers );
+		$this->assertSame( 'Basic ' . base64_encode( 'user:pass' ), $headers['Authorization'] );
+	}
+
+	public function testApiKeyHeaderIsAdded(): void {
+		$config = [
+			'service_config' => [
+				'__version' => 1,
+				'display_name' => 'Mock Data Source',
+				'endpoint' => 'http://example.com',
+				'auth' => [
+					'type' => 'api-key',
+					'add_to' => 'header',
+					'key' => 'X-Api-Key',
+					'value' => 'test-api-key',
+				],
+			],
+		];
+		$this->http_data_source = MockDataSource::create( $config );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->http_data_source );
+		$headers = $this->http_data_source->get_request_headers();
+		$this->assertIsArray( $headers );
+		$this->assertArrayHasKey( 'X-Api-Key', $headers );
+		$this->assertSame( 'test-api-key', $headers['X-Api-Key'] );
+	}
+
+	public function testApiKeyQueryParamIsAdded(): void {
+		$config = [
+			'service_config' => [
+				'__version' => 1,
+				'display_name' => 'Mock Data Source',
+				'endpoint' => 'http://example.com/data',
+				'auth' => [
+					'type' => 'api-key',
+					'add_to' => 'queryparams',
+					'key' => 'api_key',
+					'value' => 'test-api-key',
+				],
+			],
+		];
+		$this->http_data_source = MockDataSource::create( $config );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->http_data_source );
+		$endpoint = $this->http_data_source->get_endpoint();
+		$this->assertSame( 'http://example.com/data?api_key=test-api-key', $endpoint );
+	}
+
+	public function testApiKeyQueryParamIsAppended(): void {
+		$config = [
+			'service_config' => [
+				'__version' => 1,
+				'display_name' => 'Mock Data Source',
+				'endpoint' => 'http://example.com/data?existing=true',
+				'auth' => [
+					'type' => 'api-key',
+					'add_to' => 'queryparams',
+					'key' => 'api_key',
+					'value' => 'test-api-key',
+				],
+			],
+		];
+		$this->http_data_source = MockDataSource::create( $config );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->http_data_source );
+		$endpoint = $this->http_data_source->get_endpoint();
+		$this->assertSame( 'http://example.com/data?existing=true&amp;api_key=test-api-key', $endpoint );
+	}
+
+	public function testNoAuthLeavesConfigUnchanged(): void {
+		$config = [
+			'service_config' => [
+				'__version' => 1,
+				'display_name' => 'Mock Data Source',
+				'endpoint' => 'http://example.com/data',
+				'request_headers' => [ 'X-Custom' => 'value' ],
+			],
+		];
+		$this->http_data_source = MockDataSource::create( $config );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->http_data_source );
+		$headers = $this->http_data_source->get_request_headers();
+		$endpoint = $this->http_data_source->get_endpoint();
+
+		$this->assertIsArray( $headers );
+		$this->assertSame( [ 'X-Custom' => 'value' ], $headers );
+		$this->assertSame( 'http://example.com/data', $endpoint );
+	}
+
+	public function testExistingHeadersAreMergedWithAuthHeaders(): void {
+		$config = [
+			'service_config' => [
+				'__version' => 1,
+				'display_name' => 'Mock Data Source',
+				'endpoint' => 'http://example.com',
+				'request_headers' => [ 'X-Custom' => 'value' ],
+				'auth' => [
+					'type' => 'bearer',
+					'value' => 'test-token',
+				],
+			],
+		];
+		$this->http_data_source = MockDataSource::create( $config );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->http_data_source );
+		$headers = $this->http_data_source->get_request_headers();
+		$this->assertIsArray( $headers );
+		$this->assertSame(
+			[
+				'X-Custom' => 'value',
+				'Authorization' => 'Bearer test-token',
+			],
+			$headers
+		);
+	}
 }


### PR DESCRIPTION
The generic HTTP data source supports authentication configuration in the service config, including Bearer Token, Basic Auth, and API Key. Authentication headers are now properly applied to outgoing requests based on the configured authentication type -

- Bearer Token: Adds to `Authorization` header with value `Bearer {token}`
- Basic Auth: Adds to `Authorization` header with value `Basic {base64_encoded_credentials}`
- API Key: Adds to `Authorization` header if `add_to` is `header`, or as a query parameter if `add_to` is `queryparams`
