### PR TITLE
Add Types::not() to exclude types

### DIFF
--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -142,7 +142,7 @@ final class ConfigSchemas {
 				)
 			),
 			'service' => Types::string(),
-			'service_config' => Types::record( Types::string(), Types::any() ),
+			'service_config' => Types::record( Types::string(), Types::not( Types::callable() ) ),
 			'uuid' => Types::nullable( Types::uuid() ),
 		] );
 	}

--- a/inc/Validation/Types.php
+++ b/inc/Validation/Types.php
@@ -172,6 +172,15 @@ final class Types {
 		return self::generate_non_primitive_type( 'list_of', $member_type );
 	}
 
+	// This type is equivalent to an `any` type with exclusions.
+	public static function not( array ...$array_of_excluded_types ): array {
+		foreach ( $array_of_excluded_types as $type ) {
+			self::check_type( $type );
+		}
+
+		return self::generate_non_primitive_type( 'not', $array_of_excluded_types );
+	}
+
 	public static function object( array $properties ): array {
 		return self::generate_non_primitive_type( 'object', $properties );
 	}

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -117,6 +117,23 @@ final class Validator implements ValidatorInterface {
 
 				return true;
 
+			case 'not':
+				// This type is equivalent to an `any` type with exclusions.
+				$excluded_types = Types::get_type_args( $type );
+
+				foreach ( $excluded_types as $excluded_type ) {
+					$validated = $this->check_type( $excluded_type, $path, $value );
+					if ( true === $validated ) {
+						$excluded_type_names = array_map( static function ( array $type ): string {
+							return Types::get_type_name( $type );
+						}, $excluded_types );
+
+						return $this->create_error( sprintf( 'must not be one of the specified types: %s', join( ', ', $excluded_type_names ) ), $path );
+					}
+				}
+
+				return true;
+
 			case 'one_of':
 				// Keep track of all failed validations. Since one_of is a union type,
 				// if none of the types match, we will return all of the errors so that

--- a/tests/inc/Sanitization/SanitizerTest.php
+++ b/tests/inc/Sanitization/SanitizerTest.php
@@ -239,6 +239,24 @@ class SanitizerTest extends TestCase {
 		$this->assertSame( $expected, $result );
 	}
 
+	public function test_sanitize_not(): void {
+		$schema = Types::record(
+			Types::string(),
+			Types::not( Types::callable() )
+		);
+		$data = [
+			'string' => 'string',
+			'number' => 123,
+			'boolean' => true,
+			'list_of' => [ 'array' ],
+			'null' => null,
+		];
+
+		$sanitizer = new Sanitizer( $schema );
+		$result = $sanitizer->sanitize( $data );
+
+		$this->assertSame( $data, $result );
+	}
 
 	public function test_sanitize_object(): void {
 		$schema = Types::object( [

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -436,6 +436,27 @@ class ValidatorTest extends TestCase {
 		$this->assertSame( '$instance_of must be an instance of class "RemoteDataBlocks\Tests\Validation\ValidatorTest"', $result->get_error_message() );
 	}
 
+	public function testNot(): void {
+		$schema = Types::not( Types::string(), Types::callable() );
+
+		$validator = new Validator( $schema, 'NotValidator', '$not' );
+
+		$this->assertTrue( $validator->validate( 42 ) );
+		$this->assertTrue( $validator->validate( null ) );
+
+		$result = $validator->validate( 'foo' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( '$not must not be one of the specified types: string, callable', $result->get_error_message() );
+
+		$result = $validator->validate( function (): int {
+			return 123;
+		} );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( '$not must not be one of the specified types: string, callable', $result->get_error_message() );
+	}
+
 	public function testOneOf(): void {
 		$schema = Types::one_of( Types::string(), Types::integer() );
 


### PR DESCRIPTION
Add a new non-primitive `not` type that allows us to exclude types from a wider type like `any`. This is useful as a type narrowing tool, and especially to exclude unserializable types like `callable`.

With some future type additions, we could probably move to remove `any`.