### PR TITLE
Add an error block

### DIFF
--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -53,8 +53,8 @@ class BlockRegistration {
 		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-no-results', [
 			'variations' => [
 				[
-					'name' => 'remote-data-blocks/error-fallback',
-					'title' => 'Error Fallback',
+					'name' => 'remote-data-blocks/error',
+					'title' => 'Error',
 					'description' => 'Display an error message when the remote data fails to load.',
 					'attributes' => [
 						'mode' => 'error',

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -50,19 +50,8 @@ class BlockRegistration {
 		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-pagination' );
 
 		// Remote data error fallback block - used to render a message when results aren't available to load.
-		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-no-results', [
-			'variations' => [
-				[
-					'name' => 'remote-data-blocks/error',
-					'title' => 'Error',
-					'description' => 'Display an error message when the remote data fails to load.',
-					'attributes' => [
-						'mode' => 'error',
-					],
-					'isActive' => [ 'mode' ],
-				],
-			],
-		] );
+		// This registers the empty results block, with a variation for when there is an error.
+		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-no-results' );
 
 		// Remote data template - used to render remote data collections.
 		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-template' );

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -49,8 +49,23 @@ class BlockRegistration {
 		// Remote data pagination block - used to render pagination links for collections.
 		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-pagination' );
 
-		// Remote data empty result block - used to render a message when no results are found.
-		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-no-results' );
+		// Remote data error fallback block - used to render a message when results aren't available to load.
+		$result = register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-no-results', [
+			'variations' => [
+				[
+					'name' => 'remote-data-blocks/error-fallback',
+					'title' => 'Error Fallback',
+					'description' => 'Display an error message when the remote data fails to load.',
+					'attributes' => [
+						'mode' => 'error',
+					],
+				],
+			],
+		] );
+
+		// if ( empty( $result->variations ) ) {
+		// 	error_log( 'No variations found for remote-data-no-results block' );
+		// }
 
 		// Remote data template - used to render remote data collections.
 		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-template' );

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -50,7 +50,7 @@ class BlockRegistration {
 		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-pagination' );
 
 		// Remote data error fallback block - used to render a message when results aren't available to load.
-		$result = register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-no-results', [
+		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-no-results', [
 			'variations' => [
 				[
 					'name' => 'remote-data-blocks/error-fallback',
@@ -59,13 +59,10 @@ class BlockRegistration {
 					'attributes' => [
 						'mode' => 'error',
 					],
+					'isActive' => [ 'mode' ],
 				],
 			],
 		] );
-
-		// if ( empty( $result->variations ) ) {
-		// 	error_log( 'No variations found for remote-data-no-results block' );
-		// }
 
 		// Remote data template - used to render remote data collections.
 		register_block_type( REMOTE_DATA_BLOCKS__PLUGIN_DIRECTORY . '/build/blocks/remote-data-template' );

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -210,17 +210,19 @@ class BlockBindings {
 		// stale results from the block.
 		$query_response = self::execute_queries( $block_context, [] );
 
-		// If there is an error, and it's the error block variation, return true.
+		// If there is an error, and it's the error block variation, the fallback
+		// content should be rendered.
 		if ( is_wp_error( $query_response ) ) {
 			return 'error' === $attributes['mode'];
 		}
 
-		// If there are no results, and it's the empty block variation, return true.
+		// If there are no results, and it's the empty block variation, the fallback
+		// content should be rendered.
 		if ( isset( $query_response['results'] ) && empty( $query_response['results'] ) ) {
 			return 'empty' === $attributes['mode'];
 		}
 
-		// If there are results, it's fine to render the block.
+		// If there are results, the fallback content should not be rendered.
 		return false;
 	}
 

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -204,20 +204,23 @@ class BlockBindings {
 		}
 	}
 
-	public static function determine_block_state_to_render( WP_Block $block ): string|null {
+	public static function get_empty_or_error_state_for_block( WP_Block $block ): string|null {
 		$block_context = $block->context[ self::$context_name ] ?? [];
 		// Re-execute the query to get the latest results, rather than using the
 		// stale results from the block.
 		$query_response = self::execute_queries( $block_context, [] );
 
+		// If there is an error, return the error state.
 		if ( is_wp_error( $query_response ) ) {
 			return 'error';
 		}
 
+		// If there are no results, return the empty state.
 		if ( isset( $query_response['results'] ) && empty( $query_response['results'] ) ) {
 			return 'empty';
 		}
 
+		// If there are results, it's fine to render the block.
 		return null;
 	}
 

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -204,7 +204,7 @@ class BlockBindings {
 		}
 	}
 
-	public static function is_error_or_empty_state( array $context, array $attributes ): bool {
+	public static function should_render_fallback_content( array $context, array $attributes ): bool {
 		$block_context = $context[ self::$context_name ] ?? [];
 		// Re-execute the query to get the latest results, rather than using the
 		// stale results from the block.
@@ -212,12 +212,12 @@ class BlockBindings {
 
 		// If there is an error, and it's the error block variation, return true.
 		if ( is_wp_error( $query_response ) ) {
-			return 'error' === $attributes['mode'] ?? 'unknown';
+			return 'error' === $attributes['mode'];
 		}
 
 		// If there are no results, and it's the empty block variation, return true.
 		if ( isset( $query_response['results'] ) && empty( $query_response['results'] ) ) {
-			return 'empty' === $attributes['mode'] ?? 'unknown';
+			return 'empty' === $attributes['mode'];
 		}
 
 		// If there are results, it's fine to render the block.

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -204,20 +204,20 @@ class BlockBindings {
 		}
 	}
 
-	public static function is_error_or_empty_state( WP_Block $block ): bool {
-		$block_context = $block->context[ self::$context_name ] ?? [];
+	public static function is_error_or_empty_state( array $context, array $attributes ): bool {
+		$block_context = $context[ self::$context_name ] ?? [];
 		// Re-execute the query to get the latest results, rather than using the
 		// stale results from the block.
 		$query_response = self::execute_queries( $block_context, [] );
 
 		// If there is an error, and it's the error block variation, return true.
 		if ( is_wp_error( $query_response ) ) {
-			return 'error' === $block->attributes['mode'] ?? 'unknown';
+			return 'error' === $attributes['mode'] ?? 'unknown';
 		}
 
 		// If there are no results, and it's the empty block variation, return true.
 		if ( isset( $query_response['results'] ) && empty( $query_response['results'] ) ) {
-			return 'empty' === $block->attributes['mode'] ?? 'unknown';
+			return 'empty' === $attributes['mode'] ?? 'unknown';
 		}
 
 		// If there are results, it's fine to render the block.

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -204,24 +204,24 @@ class BlockBindings {
 		}
 	}
 
-	public static function get_empty_or_error_state_for_block( WP_Block $block ): string|null {
+	public static function is_error_or_empty_state( WP_Block $block ): bool {
 		$block_context = $block->context[ self::$context_name ] ?? [];
 		// Re-execute the query to get the latest results, rather than using the
 		// stale results from the block.
 		$query_response = self::execute_queries( $block_context, [] );
 
-		// If there is an error, return the error state.
+		// If there is an error, and it's the error block variation, return true.
 		if ( is_wp_error( $query_response ) ) {
-			return 'error';
+			return 'error' === $block->attributes['mode'] ?? 'unknown';
 		}
 
-		// If there are no results, return the empty state.
+		// If there are no results, and it's the empty block variation, return true.
 		if ( isset( $query_response['results'] ) && empty( $query_response['results'] ) ) {
-			return 'empty';
+			return 'empty' === $block->attributes['mode'] ?? 'unknown';
 		}
 
 		// If there are results, it's fine to render the block.
-		return null;
+		return false;
 	}
 
 	public static function get_pagination_links( WP_Block $block ): array {

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -204,18 +204,21 @@ class BlockBindings {
 		}
 	}
 
-	public static function should_render_empty_result( WP_Block $block ): bool {
+	public static function determine_block_state_to_render( WP_Block $block ): string|null {
 		$block_context = $block->context[ self::$context_name ] ?? [];
 		// Re-execute the query to get the latest results, rather than using the
 		// stale results from the block.
 		$query_response = self::execute_queries( $block_context, [] );
 
 		if ( is_wp_error( $query_response ) ) {
-			return false;
+			return 'error';
 		}
 
-		// Only give back true if there are no results
-		return isset( $query_response['results'] ) && empty( $query_response['results'] );
+		if ( isset( $query_response['results'] ) && empty( $query_response['results'] ) ) {
+			return 'empty';
+		}
+
+		return null;
 	}
 
 	public static function get_pagination_links( WP_Block $block ): array {

--- a/src/blocks/remote-data-container/hooks/usePatterns.ts
+++ b/src/blocks/remote-data-container/hooks/usePatterns.ts
@@ -77,6 +77,7 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 		}
 
 		innerBlocks.push( createBlock( 'remote-data-blocks/no-results' ) );
+		innerBlocks.push( createBlock( 'remote-data-blocks/error-fallback' ) );
 
 		replaceInnerBlocks( rootClientId, innerBlocks ).catch( () => {} );
 	}

--- a/src/blocks/remote-data-container/hooks/usePatterns.ts
+++ b/src/blocks/remote-data-container/hooks/usePatterns.ts
@@ -76,7 +76,10 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 			innerBlocks.push( createBlock( 'remote-data-blocks/pagination' ) );
 		}
 
+		// Add the no-results block with the empty mode.
 		innerBlocks.push( createBlock( 'remote-data-blocks/no-results', { mode: 'empty' } ) );
+
+		// Add the error fallback block variation with the error mode.
 		innerBlocks.push( createBlock( 'remote-data-blocks/no-results', { mode: 'error' } ) );
 
 		replaceInnerBlocks( rootClientId, innerBlocks ).catch( () => {} );

--- a/src/blocks/remote-data-container/hooks/usePatterns.ts
+++ b/src/blocks/remote-data-container/hooks/usePatterns.ts
@@ -76,8 +76,8 @@ export function usePatterns( remoteDataBlockName: string, rootClientId: string =
 			innerBlocks.push( createBlock( 'remote-data-blocks/pagination' ) );
 		}
 
-		innerBlocks.push( createBlock( 'remote-data-blocks/no-results' ) );
-		innerBlocks.push( createBlock( 'remote-data-blocks/error-fallback' ) );
+		innerBlocks.push( createBlock( 'remote-data-blocks/no-results', { mode: 'empty' } ) );
+		innerBlocks.push( createBlock( 'remote-data-blocks/no-results', { mode: 'error' } ) );
 
 		replaceInnerBlocks( rootClientId, innerBlocks ).catch( () => {} );
 	}

--- a/src/blocks/remote-data-no-results/block.json
+++ b/src/blocks/remote-data-no-results/block.json
@@ -8,6 +8,7 @@
   "description": "Contains the blocks to display when no remote data is found.",
   "category": "widgets",
   "example": {},
+  "icon": "media-default",
   "attributes": {
     "mode": {
       "enum": [ "empty", "error" ],
@@ -23,6 +24,7 @@
     {
       "name": "remote-data-blocks/error",
       "title": "Error",
+      "icon": "warning",
       "description": "Display an error message when the remote data fails to load.",
       "attributes": {
         "mode": "error"

--- a/src/blocks/remote-data-no-results/block.json
+++ b/src/blocks/remote-data-no-results/block.json
@@ -21,8 +21,8 @@
   },
   "variations": [
     {
-      "name": "remote-data-blocks/error-fallback",
-      "title": "Error Fallback",
+      "name": "remote-data-blocks/error",
+      "title": "Error",
       "description": "Display an error message when the remote data fails to load.",
       "attributes": {
         "mode": "error"

--- a/src/blocks/remote-data-no-results/block.json
+++ b/src/blocks/remote-data-no-results/block.json
@@ -10,7 +10,7 @@
   "example": {},
   "attributes": {
     "mode": {
-      "type": "string",
+      "enum": [ "empty", "error" ],
       "default": "empty"
     }
   },
@@ -26,7 +26,8 @@
       "description": "Display an error message when the remote data fails to load.",
       "attributes": {
         "mode": "error"
-      }
+      },
+      "isActive": [ "mode" ]
     }
   ],
   "textdomain": "remote-data-blocks",

--- a/src/blocks/remote-data-no-results/block.json
+++ b/src/blocks/remote-data-no-results/block.json
@@ -4,16 +4,31 @@
   "name": "remote-data-blocks/no-results",
   "version": "0.1.0",
   "usesContext": [ "remote-data-blocks/remoteData" ],
-  "title": "No Remote Data Results",
+  "title": "No Results",
   "description": "Contains the blocks to display when no remote data is found.",
   "category": "widgets",
   "example": {},
-  "attributes": {},
+  "attributes": {
+    "mode": {
+      "type": "string",
+      "default": "empty"
+    }
+  },
   "supports": {
     "customClassName": false,
     "className": false,
     "html": false
   },
+  "variations": [
+    {
+      "name": "remote-data-blocks/error-fallback",
+      "title": "Error Fallback",
+      "description": "Display an error message when the remote data fails to load.",
+      "attributes": {
+        "mode": "error"
+      }
+    }
+  ],
   "textdomain": "remote-data-blocks",
   "editorScript": "file:./index.js",
   "editorStyle": "file:./index.css",

--- a/src/blocks/remote-data-no-results/edit.tsx
+++ b/src/blocks/remote-data-no-results/edit.tsx
@@ -46,17 +46,13 @@ export function Edit( props: BlockEditProps< RemoteDataNoResultsBlockAttributes 
 		);
 	}
 
-	if ( props.attributes?.mode === 'error' ) {
-		return (
-			<div { ...blockProps }>
-				<InnerBlocks template={ ERROR_FALLBACK_TEMPLATE } />
-			</div>
-		);
-	}
-
 	return (
 		<div { ...blockProps }>
-			<InnerBlocks template={ NO_RESULTS_TEMPLATE } />
+			<InnerBlocks
+				template={
+					props.attributes?.mode === 'error' ? ERROR_FALLBACK_TEMPLATE : NO_RESULTS_TEMPLATE
+				}
+			/>
 		</div>
 	);
 }

--- a/src/blocks/remote-data-no-results/edit.tsx
+++ b/src/blocks/remote-data-no-results/edit.tsx
@@ -20,6 +20,15 @@ const NO_RESULTS_TEMPLATE: Template[] = [
 	],
 ];
 
+const ERROR_FALLBACK_TEMPLATE: Template[] = [
+	[
+		'core/paragraph',
+		{
+			content: __( 'Error loading results.' ),
+		},
+	],
+];
+
 export function Edit( props: BlockEditProps< RemoteDataNoResultsBlockAttributes > ): JSX.Element {
 	const { context } = props;
 	const { remoteData } = useRemoteDataContext( context );
@@ -34,6 +43,14 @@ export function Edit( props: BlockEditProps< RemoteDataNoResultsBlockAttributes 
 					'This block must be placed inside a remote data block. This block will be ignored as currently configured.'
 				) }
 			/>
+		);
+	}
+
+	if ( props.attributes?.mode === 'error' ) {
+		return (
+			<div { ...blockProps }>
+				<InnerBlocks template={ ERROR_FALLBACK_TEMPLATE } />
+			</div>
 		);
 	}
 

--- a/src/blocks/remote-data-no-results/index.ts
+++ b/src/blocks/remote-data-no-results/index.ts
@@ -1,4 +1,4 @@
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, registerBlockVariation } from '@wordpress/blocks';
 import { error } from '@wordpress/icons';
 
 import metadata from './block.json';
@@ -12,4 +12,10 @@ registerBlockType< RemoteDataNoResultsBlockAttributes >( metadata.name, {
 		src: error,
 	},
 	save: Save,
+} );
+
+registerBlockVariation( metadata.name, {
+	name: 'remote-data-blocks/error-fallback',
+	title: 'Error Fallback',
+	attributes: { mode: 'error' },
 } );

--- a/src/blocks/remote-data-no-results/index.ts
+++ b/src/blocks/remote-data-no-results/index.ts
@@ -1,5 +1,4 @@
-import { registerBlockType, registerBlockVariation } from '@wordpress/blocks';
-import { error } from '@wordpress/icons';
+import { registerBlockType } from '@wordpress/blocks';
 
 import metadata from './block.json';
 import { Edit } from './edit';
@@ -8,14 +7,5 @@ import './style.scss';
 
 registerBlockType< RemoteDataNoResultsBlockAttributes >( metadata.name, {
 	edit: Edit,
-	icon: {
-		src: error,
-	},
 	save: Save,
-} );
-
-registerBlockVariation( metadata.name, {
-	name: 'remote-data-blocks/error',
-	title: 'Error Fallback',
-	attributes: { mode: 'error' },
 } );

--- a/src/blocks/remote-data-no-results/index.ts
+++ b/src/blocks/remote-data-no-results/index.ts
@@ -15,7 +15,7 @@ registerBlockType< RemoteDataNoResultsBlockAttributes >( metadata.name, {
 } );
 
 registerBlockVariation( metadata.name, {
-	name: 'remote-data-blocks/error-fallback',
+	name: 'remote-data-blocks/error',
 	title: 'Error Fallback',
 	attributes: { mode: 'error' },
 } );

--- a/src/blocks/remote-data-no-results/render.php
+++ b/src/blocks/remote-data-no-results/render.php
@@ -7,10 +7,10 @@ use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 // $content (string): The block default content.
 // $block (WP_Block): The block instance.
 
-$state = BlockBindings::is_error_or_empty_state( $block->context, $attributes );
+$should_render_fallback_content = BlockBindings::should_render_fallback_content( $block->context, $attributes );
 
-// The state will only be true when the query gives back an error, or no results and the block attribute matched the response.
-if ( ! $state ) {
+// The fallback content should only be rendered if the query errors out, or if the query returns no results.
+if ( ! $should_render_fallback_content ) {
 	return null;
 }
 

--- a/src/blocks/remote-data-no-results/render.php
+++ b/src/blocks/remote-data-no-results/render.php
@@ -7,7 +7,7 @@ use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 // $content (string): The block default content.
 // $block (WP_Block): The block instance.
 
-$state = BlockBindings::is_error_or_empty_state( $block );
+$state = BlockBindings::is_error_or_empty_state( $block->context, $attributes );
 
 // The state will only be true when the query gives back an error, or no results and the block attribute matched the response.
 if ( ! $state ) {

--- a/src/blocks/remote-data-no-results/render.php
+++ b/src/blocks/remote-data-no-results/render.php
@@ -7,10 +7,9 @@ use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 // $content (string): The block default content.
 // $block (WP_Block): The block instance.
 
-$should_render_empty_result = BlockBindings::should_render_empty_result( $block );
+$block_state = BlockBindings::determine_block_state_to_render( $block );
 
-// Skip the rendering if the block's results are not empty.
-if ( ! $should_render_empty_result ) {
+if ( ! $block_state || ! isset( $attributes['mode'] ) || $block_state !== $attributes['mode'] ) {
 	return null;
 }
 

--- a/src/blocks/remote-data-no-results/render.php
+++ b/src/blocks/remote-data-no-results/render.php
@@ -7,10 +7,10 @@ use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 // $content (string): The block default content.
 // $block (WP_Block): The block instance.
 
-$state = BlockBindings::get_empty_or_error_state_for_block( $block );
+$state = BlockBindings::is_error_or_empty_state( $block );
 
-// If the state is not set to empty or error, and that doesn't match the block's attributes, then we don't need to render the block.
-if ( ! $state || ! isset( $attributes['mode'] ) || $state !== $attributes['mode'] ) {
+// The state will only be true when the query gives back an error, or no results and the block attribute matched the response.
+if ( ! $state ) {
 	return null;
 }
 

--- a/src/blocks/remote-data-no-results/render.php
+++ b/src/blocks/remote-data-no-results/render.php
@@ -7,9 +7,10 @@ use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 // $content (string): The block default content.
 // $block (WP_Block): The block instance.
 
-$block_state = BlockBindings::determine_block_state_to_render( $block );
+$state = BlockBindings::get_empty_or_error_state_for_block( $block );
 
-if ( ! $block_state || ! isset( $attributes['mode'] ) || $block_state !== $attributes['mode'] ) {
+// If the state is not set to empty or error, and that doesn't match the block's attributes, then we don't need to render the block.
+if ( ! $state || ! isset( $attributes['mode'] ) || $state !== $attributes['mode'] ) {
 	return null;
 }
 

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -11,6 +11,7 @@ use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 use RemoteDataBlocks\Tests\Mocks\MockQueryRunner;
 use RemoteDataBlocks\Tests\Mocks\MockQuery;
 use RemoteDataBlocks\Tests\Mocks\MockWordPressFunctions;
+use WP_Error;
 
 class BlockBindingsTest extends TestCase {
 	private const MOCK_BLOCK_NAME = 'test/block';
@@ -36,6 +37,117 @@ class BlockBindingsTest extends TestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 		Mockery::close();
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_error_or_empty_state_with_error_mode(): void {
+			/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( 'output_field', new WP_Error( 'test-error', 'Test Error' ) );
+
+		$block_context = [
+			'blockName' => self::MOCK_BLOCK_NAME,
+			'queryInput' => [
+				'test_input_field' => 'test_value',
+			],
+		];
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$this->assertTrue( BlockBindings::is_error_or_empty_state( [
+			BlockBindings::$context_name => [
+				'blockName' => self::MOCK_BLOCK_NAME,
+					'queryInput' => [
+						'test_input_field' => 'test_value',
+						'another_input_field' => 'another_value',
+					],
+			],
+		], [ 'mode' => 'error' ] ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_error_or_empty_state_with_empty_mode(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new class() extends MockQueryRunner {
+			public function execute( HttpQueryInterface $query, array $input_variables ): array {
+				return [
+					'is_collection' => true,
+					'results' => [],
+				];
+			}
+		};
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$this->assertTrue( BlockBindings::is_error_or_empty_state( [
+			BlockBindings::$context_name => [
+				'blockName' => self::MOCK_BLOCK_NAME,
+					'queryInput' => [
+						'test_input_field' => 'test_value',
+						'another_input_field' => 'another_value',
+					],
+			],
+		], [ 'mode' => 'empty' ] ) );
 	}
 
 	/**

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -43,8 +43,57 @@ class BlockBindingsTest extends TestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
+	public function test_should_render_fallback_content_with_unknown_mode_with_error(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( 'output_field', new WP_Error( 'test-error', 'Test Error' ) );
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$this->assertFalse( BlockBindings::should_render_fallback_content( [
+			BlockBindings::$context_name => [
+				'blockName' => self::MOCK_BLOCK_NAME,
+				'queryInput' => [
+					'test_input_field' => 'test_value',
+					'another_input_field' => 'another_value',
+				],
+			],
+		], [ 'mode' => 'unknown' ] ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test_should_render_fallback_content_with_error_mode(): void {
-			/**
+		/**
 		 * Mock the QueryRunner to return a result.
 		 */
 		$mock_qr = new MockQueryRunner();
@@ -86,6 +135,208 @@ class BlockBindingsTest extends TestCase {
 				],
 			],
 		], [ 'mode' => 'error' ] ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_render_fallback_content_with_results_for_error_mode(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( 'output_field', [ 'result' => 'test_result' ] );
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$this->assertFalse( BlockBindings::should_render_fallback_content( [
+			BlockBindings::$context_name => [
+				'blockName' => self::MOCK_BLOCK_NAME,
+				'queryInput' => [
+					'test_input_field' => 'test_value',
+					'another_input_field' => 'another_value',
+				],
+			],
+		], [ 'mode' => 'error' ] ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_render_fallback_content_with_no_results_for_error_mode(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new class() extends MockQueryRunner {
+			public function execute( HttpQueryInterface $query, array $input_variables ): array {
+				return [
+					'is_collection' => true,
+					'results' => [],
+				];
+			}
+		};
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$this->assertFalse( BlockBindings::should_render_fallback_content( [
+			BlockBindings::$context_name => [
+				'blockName' => self::MOCK_BLOCK_NAME,
+				'queryInput' => [
+					'test_input_field' => 'test_value',
+					'another_input_field' => 'another_value',
+				],
+			],
+		], [ 'mode' => 'error' ] ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_render_fallback_content_with_results_for_empty_mode(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( 'output_field', [ 'result' => 'test_result' ] );
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$this->assertFalse( BlockBindings::should_render_fallback_content( [
+			BlockBindings::$context_name => [
+				'blockName' => self::MOCK_BLOCK_NAME,
+				'queryInput' => [
+					'test_input_field' => 'test_value',
+					'another_input_field' => 'another_value',
+				],
+			],
+		], [ 'mode' => 'empty' ] ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_render_fallback_content_with_error_for_empty_mode(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( 'output_field', new WP_Error( 'test-error', 'Test Error' ) );
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$this->assertFalse( BlockBindings::should_render_fallback_content( [
+			BlockBindings::$context_name => [
+				'blockName' => self::MOCK_BLOCK_NAME,
+				'queryInput' => [
+					'test_input_field' => 'test_value',
+					'another_input_field' => 'another_value',
+				],
+			],
+		], [ 'mode' => 'empty' ] ) );
 	}
 
 	/**
@@ -141,6 +392,61 @@ class BlockBindingsTest extends TestCase {
 				],
 			],
 		], [ 'mode' => 'empty' ] ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_render_fallback_content_with_unknown_mode_with_empty_results(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new class() extends MockQueryRunner {
+			public function execute( HttpQueryInterface $query, array $input_variables ): array {
+				return [
+					'is_collection' => true,
+					'results' => [],
+				];
+			}
+		};
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$this->assertFalse( BlockBindings::should_render_fallback_content( [
+			BlockBindings::$context_name => [
+				'blockName' => self::MOCK_BLOCK_NAME,
+				'queryInput' => [
+					'test_input_field' => 'test_value',
+					'another_input_field' => 'another_value',
+				],
+			],
+		], [ 'mode' => 'unknown' ] ) );
 	}
 
 	/**

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -16,6 +16,17 @@ use WP_Error;
 class BlockBindingsTest extends TestCase {
 	private const MOCK_BLOCK_NAME = 'test/block';
 
+	private const MOCK_INPUT_SCHEMA = [
+		'test_input_field' => [
+			'name' => 'Test Input Field',
+			'type' => 'string',
+		],
+		'another_input_field' => [
+			'name' => 'Another Input Field',
+			'type' => 'string',
+		],
+	];
+
 	private const MOCK_OUTPUT_SCHEMA = [
 		'is_collection' => false,
 		'type' => [
@@ -44,7 +55,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_unknown_mode_with_error(): void {
-		$mock_qr = $this->create_mock_query_runner( new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_qr = $this->create_mock_query_runner_with_result( new WP_Error( 'test-error', 'Test Error' ) );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -62,7 +73,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_error_mode(): void {
-		$mock_qr = $this->create_mock_query_runner( new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_qr = $this->create_mock_query_runner_with_result( new WP_Error( 'test-error', 'Test Error' ) );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -80,7 +91,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_results_for_error_mode(): void {
-		$mock_qr = $this->create_mock_query_runner( [ 'result' => 'test_result' ] );
+		$mock_qr = $this->create_mock_query_runner_with_result( [ 'result' => 'test_result' ] );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -98,7 +109,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_no_results_for_error_mode(): void {
-		$mock_qr = $this->create_empty_results_query_runner();
+		$mock_qr = $this->create_mock_query_runner_with_results();
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -116,7 +127,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_results_for_empty_mode(): void {
-		$mock_qr = $this->create_mock_query_runner( [ 'result' => 'test_result' ] );
+		$mock_qr = $this->create_mock_query_runner_with_result( [ 'result' => 'test_result' ] );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -134,7 +145,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_error_for_empty_mode(): void {
-		$mock_qr = $this->create_mock_query_runner( new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_qr = $this->create_mock_query_runner_with_result( new WP_Error( 'test-error', 'Test Error' ) );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -152,7 +163,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_empty_mode(): void {
-		$mock_qr = $this->create_empty_results_query_runner();
+		$mock_qr = $this->create_mock_query_runner_with_results();
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -170,7 +181,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_unknown_mode_with_empty_results(): void {
-		$mock_qr = $this->create_empty_results_query_runner();
+		$mock_qr = $this->create_mock_query_runner_with_results();
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -205,7 +216,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_value_with_overrides(): void {
-		$mock_qr = $this->create_mock_query_runner( self::MOCK_OUTPUT_FIELD_VALUE );
+		$mock_qr = $this->create_mock_query_runner_with_result( self::MOCK_OUTPUT_FIELD_VALUE );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -324,7 +335,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_value(): void {
-		$mock_qr = $this->create_mock_query_runner( self::MOCK_OUTPUT_FIELD_VALUE );
+		$mock_qr = $this->create_mock_query_runner_with_result( self::MOCK_OUTPUT_FIELD_VALUE );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -343,7 +354,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_value_with_non_string(): void {
-		$mock_qr = $this->create_mock_query_runner( 123 );
+		$mock_qr = $this->create_mock_query_runner_with_result( 123 );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -494,40 +505,21 @@ class BlockBindingsTest extends TestCase {
 	 *
 	 * @param mixed $result The result to return from the query runner.
 	 */
-	private function create_mock_query_runner( mixed $result ): MockQueryRunner {
+	private function create_mock_query_runner_with_result( mixed $result ): MockQueryRunner {
 		$mock_qr = new MockQueryRunner();
 		$mock_qr->addResult( self::MOCK_OUTPUT_FIELD_NAME, $result );
 		return $mock_qr;
 	}
 
 	/**
-	 * Creates a mock query runner that returns empty results.
+	 * Creates a mock query runner with the specified results.
+	 *
+	 * @param array $results The results to return from the query runner.
 	 */
-	private function create_empty_results_query_runner(): MockQueryRunner {
-		return new class() extends MockQueryRunner {
-			public function execute( HttpQueryInterface $query, array $input_variables ): array {
-				return [
-					'is_collection' => true,
-					'results' => [],
-				];
-			}
-		};
-	}
-
-	/**
-	 * Creates the standard input schema used in tests.
-	 */
-	private function create_input_schema(): array {
-		return [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
+	private function create_mock_query_runner_with_results( array $results = [] ): MockQueryRunner {
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResults( $results );
+		return $mock_qr;
 	}
 
 	/**
@@ -539,7 +531,7 @@ class BlockBindingsTest extends TestCase {
 		return [
 			'queries' => [
 				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $this->create_input_schema(),
+					'input_schema' => self::MOCK_INPUT_SCHEMA,
 					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
 					'query_runner' => $query_runner,
 				] ),

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -43,7 +43,7 @@ class BlockBindingsTest extends TestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_is_error_or_empty_state_with_error_mode(): void {
+	public function test_should_render_fallback_content_with_error_mode(): void {
 			/**
 		 * Mock the QueryRunner to return a result.
 		 */
@@ -77,7 +77,7 @@ class BlockBindingsTest extends TestCase {
 			->with( self::MOCK_BLOCK_NAME )
 			->andReturn( $mock_block_config );
 
-		$this->assertTrue( BlockBindings::is_error_or_empty_state( [
+		$this->assertTrue( BlockBindings::should_render_fallback_content( [
 			BlockBindings::$context_name => [
 				'blockName' => self::MOCK_BLOCK_NAME,
 				'queryInput' => [
@@ -92,7 +92,7 @@ class BlockBindingsTest extends TestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_is_error_or_empty_state_with_empty_mode(): void {
+	public function test_should_render_fallback_content_with_empty_mode(): void {
 		/**
 		 * Mock the QueryRunner to return a result.
 		 */
@@ -132,7 +132,7 @@ class BlockBindingsTest extends TestCase {
 			->with( self::MOCK_BLOCK_NAME )
 			->andReturn( $mock_block_config );
 
-		$this->assertTrue( BlockBindings::is_error_or_empty_state( [
+		$this->assertTrue( BlockBindings::should_render_fallback_content( [
 			BlockBindings::$context_name => [
 				'blockName' => self::MOCK_BLOCK_NAME,
 				'queryInput' => [

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -327,6 +327,143 @@ class BlockBindingsTest extends TestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
+	public function test_get_value_with_query_input_transformed_by_custom_query_runner(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new class() extends MockQueryRunner {
+			public function execute( HttpQueryInterface $query, array $input_variables ): array {
+				$input_variables['test_input_field'] .= ' ' . $input_variables['another_input_field'];
+				return parent::execute( $query, $input_variables );
+			}
+		};
+		$mock_qr->addResult( 'output_field', 'Test Output Value' );
+
+		$block = [
+			'context' => [
+				BlockBindings::$context_name => [
+					'blockName' => self::MOCK_BLOCK_NAME,
+					'queryInput' => [
+						'test_input_field' => 'test_value',
+						'another_input_field' => 'another_value',
+					],
+				],
+			],
+		];
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
+
+		// Assert that the value is correct.
+		$this->assertSame( $value, 'Test Output Value' );
+
+		/**
+		 * Assert that the query runner received the correct input after transformations were applied.
+		 */
+		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
+			'test_input_field' => 'test_value another_value',
+			'another_input_field' => 'another_value',
+		] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_value_with_query_input_transformations_and_overrides(): void {
+		/**
+		 * Mock the QueryRunner to return a result.
+		 */
+		$mock_qr = new class() extends MockQueryRunner {
+			public function execute( HttpQueryInterface $query, array $input_variables ): array {
+				$input_variables['test_input_field'] .= ' transformed';
+				return parent::execute( $query, $input_variables );
+			}
+		};
+		$mock_qr->addResult( 'output_field', 'Test Output Value' );
+
+		$block = [
+			'context' => [
+				BlockBindings::$context_name => [
+					'blockName' => self::MOCK_BLOCK_NAME,
+					'queryInput' => [
+						'test_input_field' => 'test_value',
+					],
+					'enabledOverrides' => [ 'test_input_field_override' ],
+				],
+			],
+		];
+
+		$input_schema = [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+		];
+
+		$mock_block_config = [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $input_schema,
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $mock_qr,
+				] ),
+			],
+		];
+
+		MockWordPressFunctions::add_mock_filter( 'remote_data_blocks_query_input_variables', [ 'test_input_field' => 'override_value' ] );
+
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $mock_block_config );
+
+		$value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
+		$this->assertSame( 'Test Output Value', $value );
+
+		// Assert that the override was applied.
+		$filter_args = MockWordPressFunctions::get_done_filter( 'remote_data_blocks_query_input_variables' );
+		$this->assertSame( 'test_input_field_override', $filter_args[0][0] ?? null );
+
+		/**
+		 * Assert that the query runner received the correct input after transformations and overrides were applied.
+		 */
+		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
+			'test_input_field' => 'override_value transformed',
+		] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test_get_value(): void {
 		$mock_qr = $this->create_mock_query_runner( self::MOCK_OUTPUT_FIELD_VALUE );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
@@ -503,142 +640,5 @@ class BlockBindingsTest extends TestCase {
 
 		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
 		$this->assertNull( $remote_value );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_get_value_with_query_input_transformed_by_custom_query_runner(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new class() extends MockQueryRunner {
-			public function execute( HttpQueryInterface $query, array $input_variables ): array {
-				$input_variables['test_input_field'] .= ' ' . $input_variables['another_input_field'];
-				return parent::execute( $query, $input_variables );
-			}
-		};
-		$mock_qr->addResult( 'output_field', 'Test Output Value' );
-
-		$block = [
-			'context' => [
-				BlockBindings::$context_name => [
-					'blockName' => self::MOCK_BLOCK_NAME,
-					'queryInput' => [
-						'test_input_field' => 'test_value',
-						'another_input_field' => 'another_value',
-					],
-				],
-			],
-		];
-
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
-
-		// Assert that the value is correct.
-		$this->assertSame( $value, 'Test Output Value' );
-
-		/**
-		 * Assert that the query runner received the correct input after transformations were applied.
-		 */
-		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
-			'test_input_field' => 'test_value another_value',
-			'another_input_field' => 'another_value',
-		] );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_get_value_with_query_input_transformations_and_overrides(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new class() extends MockQueryRunner {
-			public function execute( HttpQueryInterface $query, array $input_variables ): array {
-				$input_variables['test_input_field'] .= ' transformed';
-				return parent::execute( $query, $input_variables );
-			}
-		};
-		$mock_qr->addResult( 'output_field', 'Test Output Value' );
-
-		$block = [
-			'context' => [
-				BlockBindings::$context_name => [
-					'blockName' => self::MOCK_BLOCK_NAME,
-					'queryInput' => [
-						'test_input_field' => 'test_value',
-					],
-					'enabledOverrides' => [ 'test_input_field_override' ],
-				],
-			],
-		];
-
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		MockWordPressFunctions::add_mock_filter( 'remote_data_blocks_query_input_variables', [ 'test_input_field' => 'override_value' ] );
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
-		$this->assertSame( 'Test Output Value', $value );
-
-		// Assert that the override was applied.
-		$filter_args = MockWordPressFunctions::get_done_filter( 'remote_data_blocks_query_input_variables' );
-		$this->assertSame( 'test_input_field_override', $filter_args[0][0] ?? null );
-
-		/**
-		 * Assert that the query runner received the correct input after transformations and overrides were applied.
-		 */
-		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
-			'test_input_field' => 'override_value transformed',
-		] );
 	}
 }

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -40,94 +40,6 @@ class BlockBindingsTest extends TestCase {
 	}
 
 	/**
-	 * Creates a mock query runner with the specified result.
-	 *
-	 * @param mixed $result The result to return from the query runner.
-	 */
-	private function create_mock_query_runner( mixed $result ): MockQueryRunner {
-		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( self::MOCK_OUTPUT_FIELD_NAME, $result );
-		return $mock_qr;
-	}
-
-	/**
-	 * Creates a mock query runner that returns empty results.
-	 */
-	private function create_empty_results_query_runner(): MockQueryRunner {
-		return new class() extends MockQueryRunner {
-			public function execute( HttpQueryInterface $query, array $input_variables ): array {
-				return [
-					'is_collection' => true,
-					'results' => [],
-				];
-			}
-		};
-	}
-
-	/**
-	 * Creates the standard input schema used in tests.
-	 */
-	private function create_input_schema(): array {
-		return [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
-	}
-
-	/**
-	 * Creates a mock block configuration.
-	 *
-	 * @param MockQueryRunner $query_runner The query runner to use.
-	 */
-	private function create_mock_block_config( MockQueryRunner $query_runner ): array {
-		return [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $this->create_input_schema(),
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $query_runner,
-				] ),
-			],
-		];
-	}
-
-	/**
-	 * Creates a mock config store.
-	 *
-	 * @param array|null $block_config The block configuration to return.
-	 */
-	private function create_mock_config_store( ?array $block_config ): \Mockery\MockInterface {
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $block_config );
-		return $mock_config_store;
-	}
-
-	/**
-	 * Creates a block context array.
-	 *
-	 * @param array $query_input The query input to use.
-	 * @param array $enabled_overrides Optional enabled overrides.
-	 */
-	private function create_block_context( array $query_input, array $enabled_overrides = [] ): array {
-		return [
-			BlockBindings::$context_name => [
-				'blockName' => self::MOCK_BLOCK_NAME,
-				'queryInput' => $query_input,
-				'enabledOverrides' => $enabled_overrides,
-			],
-		];
-	}
-
-	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
@@ -567,10 +479,6 @@ class BlockBindingsTest extends TestCase {
 		$this->assertNull( $remote_value );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test_get_value_with_fallback_results_context(): void {
 		$block = [
 			'context' => [
@@ -592,10 +500,6 @@ class BlockBindingsTest extends TestCase {
 		$this->assertSame( $remote_value, 'Stored Output Value' );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test_get_value_with_non_string_fallback_results_context(): void {
 		$block = [
 			'context' => [
@@ -617,10 +521,6 @@ class BlockBindingsTest extends TestCase {
 		$this->assertSame( $remote_value, '456' );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test_get_value_with_null_fallback_results_context(): void {
 		$block = [
 			'context' => [
@@ -640,5 +540,93 @@ class BlockBindingsTest extends TestCase {
 
 		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
 		$this->assertNull( $remote_value );
+	}
+
+	/**
+	 * Creates a mock query runner with the specified result.
+	 *
+	 * @param mixed $result The result to return from the query runner.
+	 */
+	private function create_mock_query_runner( mixed $result ): MockQueryRunner {
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->addResult( self::MOCK_OUTPUT_FIELD_NAME, $result );
+		return $mock_qr;
+	}
+
+	/**
+	 * Creates a mock query runner that returns empty results.
+	 */
+	private function create_empty_results_query_runner(): MockQueryRunner {
+		return new class() extends MockQueryRunner {
+			public function execute( HttpQueryInterface $query, array $input_variables ): array {
+				return [
+					'is_collection' => true,
+					'results' => [],
+				];
+			}
+		};
+	}
+
+	/**
+	 * Creates the standard input schema used in tests.
+	 */
+	private function create_input_schema(): array {
+		return [
+			'test_input_field' => [
+				'name' => 'Test Input Field',
+				'type' => 'string',
+			],
+			'another_input_field' => [
+				'name' => 'Another Input Field',
+				'type' => 'string',
+			],
+		];
+	}
+
+	/**
+	 * Creates a mock block configuration.
+	 *
+	 * @param MockQueryRunner $query_runner The query runner to use.
+	 */
+	private function create_mock_block_config( MockQueryRunner $query_runner ): array {
+		return [
+			'queries' => [
+				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
+					'input_schema' => $this->create_input_schema(),
+					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
+					'query_runner' => $query_runner,
+				] ),
+			],
+		];
+	}
+
+	/**
+	 * Creates a mock config store.
+	 *
+	 * @param array|null $block_config The block configuration to return.
+	 */
+	private function create_mock_config_store( ?array $block_config ): \Mockery\MockInterface {
+		$mock_config_store = Mockery::namedMock( ConfigStore::class );
+		$mock_config_store->shouldReceive( 'get_block_configuration' )
+			->once()
+			->with( self::MOCK_BLOCK_NAME )
+			->andReturn( $block_config );
+		return $mock_config_store;
+	}
+
+	/**
+	 * Creates a block context array.
+	 *
+	 * @param array $query_input The query input to use.
+	 * @param array $enabled_overrides Optional enabled overrides.
+	 */
+	private function create_block_context( array $query_input, array $enabled_overrides = [] ): array {
+		return [
+			BlockBindings::$context_name => [
+				'blockName' => self::MOCK_BLOCK_NAME,
+				'queryInput' => $query_input,
+				'enabledOverrides' => $enabled_overrides,
+			],
+		];
 	}
 }

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -252,43 +252,15 @@ class BlockBindingsTest extends TestCase {
 		$mock_qr->addResult( 'output_field', 'Test Output Value' );
 
 		$block = [
-			'context' => [
-				BlockBindings::$context_name => [
-					'blockName' => self::MOCK_BLOCK_NAME,
-					'queryInput' => [
-						'test_input_field' => 'test_value',
-						'another_input_field' => 'another_value',
-					],
-				],
-			],
+			'context' => $this->create_block_context( [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			] ),
 		];
 
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
+		$this->create_mock_config_store( $mock_block_config );
 
 		$value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
 
@@ -321,41 +293,16 @@ class BlockBindingsTest extends TestCase {
 		$mock_qr->addResult( 'output_field', 'Test Output Value' );
 
 		$block = [
-			'context' => [
-				BlockBindings::$context_name => [
-					'blockName' => self::MOCK_BLOCK_NAME,
-					'queryInput' => [
-						'test_input_field' => 'test_value',
-					],
-					'enabledOverrides' => [ 'test_input_field_override' ],
-				],
-			],
+			'context' => $this->create_block_context( [
+				'test_input_field' => 'test_value',
+			], [ 'test_input_field_override' ] ),
 		];
 
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 
 		MockWordPressFunctions::add_mock_filter( 'remote_data_blocks_query_input_variables', [ 'test_input_field' => 'override_value' ] );
 
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
+		$this->create_mock_config_store( $mock_block_config );
 
 		$value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
 		$this->assertSame( 'Test Output Value', $value );

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -40,17 +40,35 @@ class BlockBindingsTest extends TestCase {
 	}
 
 	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
+	 * Creates a mock query runner with the specified result.
+	 *
+	 * @param mixed $result The result to return from the query runner.
 	 */
-	public function test_should_render_fallback_content_with_unknown_mode_with_error(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
+	private function create_mock_query_runner( mixed $result ): MockQueryRunner {
 		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( 'output_field', new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_qr->addResult( self::MOCK_OUTPUT_FIELD_NAME, $result );
+		return $mock_qr;
+	}
 
-		$input_schema = [
+	/**
+	 * Creates a mock query runner that returns empty results.
+	 */
+	private function create_empty_results_query_runner(): MockQueryRunner {
+		return new class() extends MockQueryRunner {
+			public function execute( HttpQueryInterface $query, array $input_variables ): array {
+				return [
+					'is_collection' => true,
+					'results' => [],
+				];
+			}
+		};
+	}
+
+	/**
+	 * Creates the standard input schema used in tests.
+	 */
+	private function create_input_schema(): array {
+		return [
 			'test_input_field' => [
 				'name' => 'Test Input Field',
 				'type' => 'string',
@@ -60,32 +78,71 @@ class BlockBindingsTest extends TestCase {
 				'type' => 'string',
 			],
 		];
+	}
 
-		$mock_block_config = [
+	/**
+	 * Creates a mock block configuration.
+	 *
+	 * @param MockQueryRunner $query_runner The query runner to use.
+	 */
+	private function create_mock_block_config( MockQueryRunner $query_runner ): array {
+		return [
 			'queries' => [
 				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
+					'input_schema' => $this->create_input_schema(),
 					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
+					'query_runner' => $query_runner,
 				] ),
 			],
 		];
+	}
 
+	/**
+	 * Creates a mock config store.
+	 *
+	 * @param array|null $block_config The block configuration to return.
+	 */
+	private function create_mock_config_store( ?array $block_config ): \Mockery\MockInterface {
 		$mock_config_store = Mockery::namedMock( ConfigStore::class );
 		$mock_config_store->shouldReceive( 'get_block_configuration' )
 			->once()
 			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
+			->andReturn( $block_config );
+		return $mock_config_store;
+	}
 
-		$this->assertFalse( BlockBindings::should_render_fallback_content( [
+	/**
+	 * Creates a block context array.
+	 *
+	 * @param array $query_input The query input to use.
+	 * @param array $enabled_overrides Optional enabled overrides.
+	 */
+	private function create_block_context( array $query_input, array $enabled_overrides = [] ): array {
+		return [
 			BlockBindings::$context_name => [
 				'blockName' => self::MOCK_BLOCK_NAME,
-				'queryInput' => [
-					'test_input_field' => 'test_value',
-					'another_input_field' => 'another_value',
-				],
+				'queryInput' => $query_input,
+				'enabledOverrides' => $enabled_overrides,
 			],
-		], [ 'mode' => 'unknown' ] ) );
+		];
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_render_fallback_content_with_unknown_mode_with_error(): void {
+		$mock_qr = $this->create_mock_query_runner( new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
+
+		$this->assertFalse( BlockBindings::should_render_fallback_content(
+			$this->create_block_context( [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			] ),
+			[ 'mode' => 'unknown' ]
+		) );
 	}
 
 	/**
@@ -93,48 +150,17 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_error_mode(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( 'output_field', new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_qr = $this->create_mock_query_runner( new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
 
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$this->assertTrue( BlockBindings::should_render_fallback_content( [
-			BlockBindings::$context_name => [
-				'blockName' => self::MOCK_BLOCK_NAME,
-				'queryInput' => [
-					'test_input_field' => 'test_value',
-					'another_input_field' => 'another_value',
-				],
-			],
-		], [ 'mode' => 'error' ] ) );
+		$this->assertTrue( BlockBindings::should_render_fallback_content(
+			$this->create_block_context( [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			] ),
+			[ 'mode' => 'error' ]
+		) );
 	}
 
 	/**
@@ -142,48 +168,17 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_results_for_error_mode(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( 'output_field', [ 'result' => 'test_result' ] );
+		$mock_qr = $this->create_mock_query_runner( [ 'result' => 'test_result' ] );
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
 
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$this->assertFalse( BlockBindings::should_render_fallback_content( [
-			BlockBindings::$context_name => [
-				'blockName' => self::MOCK_BLOCK_NAME,
-				'queryInput' => [
-					'test_input_field' => 'test_value',
-					'another_input_field' => 'another_value',
-				],
-			],
-		], [ 'mode' => 'error' ] ) );
+		$this->assertFalse( BlockBindings::should_render_fallback_content(
+			$this->create_block_context( [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			] ),
+			[ 'mode' => 'error' ]
+		) );
 	}
 
 	/**
@@ -191,54 +186,17 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_no_results_for_error_mode(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new class() extends MockQueryRunner {
-			public function execute( HttpQueryInterface $query, array $input_variables ): array {
-				return [
-					'is_collection' => true,
-					'results' => [],
-				];
-			}
-		};
+		$mock_qr = $this->create_empty_results_query_runner();
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
 
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$this->assertFalse( BlockBindings::should_render_fallback_content( [
-			BlockBindings::$context_name => [
-				'blockName' => self::MOCK_BLOCK_NAME,
-				'queryInput' => [
-					'test_input_field' => 'test_value',
-					'another_input_field' => 'another_value',
-				],
-			],
-		], [ 'mode' => 'error' ] ) );
+		$this->assertFalse( BlockBindings::should_render_fallback_content(
+			$this->create_block_context( [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			] ),
+			[ 'mode' => 'error' ]
+		) );
 	}
 
 	/**
@@ -246,48 +204,17 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_results_for_empty_mode(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( 'output_field', [ 'result' => 'test_result' ] );
+		$mock_qr = $this->create_mock_query_runner( [ 'result' => 'test_result' ] );
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
 
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$this->assertFalse( BlockBindings::should_render_fallback_content( [
-			BlockBindings::$context_name => [
-				'blockName' => self::MOCK_BLOCK_NAME,
-				'queryInput' => [
-					'test_input_field' => 'test_value',
-					'another_input_field' => 'another_value',
-				],
-			],
-		], [ 'mode' => 'empty' ] ) );
+		$this->assertFalse( BlockBindings::should_render_fallback_content(
+			$this->create_block_context( [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			] ),
+			[ 'mode' => 'empty' ]
+		) );
 	}
 
 	/**
@@ -295,48 +222,17 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_error_for_empty_mode(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( 'output_field', new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_qr = $this->create_mock_query_runner( new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
 
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$this->assertFalse( BlockBindings::should_render_fallback_content( [
-			BlockBindings::$context_name => [
-				'blockName' => self::MOCK_BLOCK_NAME,
-				'queryInput' => [
-					'test_input_field' => 'test_value',
-					'another_input_field' => 'another_value',
-				],
-			],
-		], [ 'mode' => 'empty' ] ) );
+		$this->assertFalse( BlockBindings::should_render_fallback_content(
+			$this->create_block_context( [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			] ),
+			[ 'mode' => 'empty' ]
+		) );
 	}
 
 	/**
@@ -344,54 +240,17 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_empty_mode(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new class() extends MockQueryRunner {
-			public function execute( HttpQueryInterface $query, array $input_variables ): array {
-				return [
-					'is_collection' => true,
-					'results' => [],
-				];
-			}
-		};
+		$mock_qr = $this->create_empty_results_query_runner();
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
 
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$this->assertTrue( BlockBindings::should_render_fallback_content( [
-			BlockBindings::$context_name => [
-				'blockName' => self::MOCK_BLOCK_NAME,
-				'queryInput' => [
-					'test_input_field' => 'test_value',
-					'another_input_field' => 'another_value',
-				],
-			],
-		], [ 'mode' => 'empty' ] ) );
+		$this->assertTrue( BlockBindings::should_render_fallback_content(
+			$this->create_block_context( [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			] ),
+			[ 'mode' => 'empty' ]
+		) );
 	}
 
 	/**
@@ -399,54 +258,17 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_unknown_mode_with_empty_results(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new class() extends MockQueryRunner {
-			public function execute( HttpQueryInterface $query, array $input_variables ): array {
-				return [
-					'is_collection' => true,
-					'results' => [],
-				];
-			}
-		};
+		$mock_qr = $this->create_empty_results_query_runner();
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
 
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-			'another_input_field' => [
-				'name' => 'Another Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$this->assertFalse( BlockBindings::should_render_fallback_content( [
-			BlockBindings::$context_name => [
-				'blockName' => self::MOCK_BLOCK_NAME,
-				'queryInput' => [
-					'test_input_field' => 'test_value',
-					'another_input_field' => 'another_value',
-				],
-			],
-		], [ 'mode' => 'unknown' ] ) );
+		$this->assertFalse( BlockBindings::should_render_fallback_content(
+			$this->create_block_context( [
+				'test_input_field' => 'test_value',
+				'another_input_field' => 'another_value',
+			] ),
+			[ 'mode' => 'unknown' ]
+		) );
 	}
 
 	/**
@@ -454,21 +276,10 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_value_with_no_config(): void {
-		/**
-		 * Mock the ConfigStore to return null.
-		 */
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( null );
+		$this->create_mock_config_store( null );
 
 		$block = [
-			'context' => [
-				BlockBindings::$context_name => [
-					'blockName' => self::MOCK_BLOCK_NAME,
-				],
-			],
+			'context' => $this->create_block_context( [] ),
 		];
 
 		$value = BlockBindings::get_value( [ 'field' => 'test' ], $block, 'content' );
@@ -482,48 +293,18 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_value_with_overrides(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( self::MOCK_OUTPUT_FIELD_NAME, self::MOCK_OUTPUT_FIELD_VALUE );
+		$mock_qr = $this->create_mock_query_runner( self::MOCK_OUTPUT_FIELD_VALUE );
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
 
 		$block = [
-			'context' => [
-				BlockBindings::$context_name => [
-					'blockName' => self::MOCK_BLOCK_NAME,
-					'enabledOverrides' => [ 'test_input_field_override' ],
-					'queryInput' => [
-						'test_input_field' => 'test_value',
-					],
-				],
-			],
-		];
-
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
+			'context' => $this->create_block_context(
+				[ 'test_input_field' => 'test_value' ],
+				[ 'test_input_field_override' ]
+			),
 		];
 
 		MockWordPressFunctions::add_mock_filter( 'remote_data_blocks_query_input_variables', [ 'test_input_field' => 'override_value' ] );
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
 
 		$value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
 
@@ -540,6 +321,188 @@ class BlockBindingsTest extends TestCase {
 		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
 			'test_input_field' => 'override_value',
 		] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_value(): void {
+		$mock_qr = $this->create_mock_query_runner( self::MOCK_OUTPUT_FIELD_VALUE );
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
+
+		$block = [
+			'context' => $this->create_block_context( [
+				'test_input_field' => 'test_value',
+			] ),
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
+		$this->assertSame( $remote_value, self::MOCK_OUTPUT_FIELD_VALUE );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_value_with_non_string(): void {
+		$mock_qr = $this->create_mock_query_runner( 123 );
+		$mock_block_config = $this->create_mock_block_config( $mock_qr );
+		$this->create_mock_config_store( $mock_block_config );
+
+		$block = [
+			'context' => $this->create_block_context( [
+				'test_input_field' => 'test_value',
+			] ),
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
+		$this->assertSame( $remote_value, '123' );
+	}
+
+	public function test_get_value_with_fallback_content_attribute(): void {
+		$block = [
+			'attributes' => [
+				'content' => 'Fallback Content',
+			],
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'content' );
+		$this->assertSame( $remote_value, 'Fallback Content' );
+	}
+
+	public function test_get_value_with_non_string_fallback_content_attribute(): void {
+		$block = [
+			'attributes' => [
+				'content' => 123,
+			],
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'content' );
+		$this->assertSame( $remote_value, '123' );
+	}
+
+	public function test_get_value_with_null_fallback_content_attribute(): void {
+		$block = [
+			'attributes' => [
+				'content' => null,
+			],
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'content' );
+		$this->assertNull( $remote_value );
+	}
+
+	public function test_get_value_with_fallback_url_attribute(): void {
+		$block = [
+			'attributes' => [
+				'content' => 'Fallback Content',
+				'url' => 'https://example.com/hello-world',
+			],
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'url' );
+		$this->assertSame( $remote_value, 'https://example.com/hello-world' );
+	}
+
+	public function test_get_value_with_non_string_fallback_url_attribute(): void {
+		$block = [
+			'attributes' => [
+				'content' => 'Fallback Content',
+				'url' => 123,
+			],
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'url' );
+		$this->assertSame( $remote_value, '123' );
+	}
+
+	public function test_get_value_with_null_fallback_url_attribute(): void {
+		$block = [
+			'attributes' => [
+				'content' => 'Fallback Content',
+				'url' => null,
+			],
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'url' );
+		$this->assertNull( $remote_value );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_value_with_fallback_results_context(): void {
+		$block = [
+			'context' => [
+				BlockBindings::$context_name => [
+					'blockName' => self::MOCK_BLOCK_NAME,
+					'queryInput' => [],
+					'results' => [
+						[
+							'result' => [
+								self::MOCK_OUTPUT_FIELD_NAME => 'Stored Output Value',
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
+		$this->assertSame( $remote_value, 'Stored Output Value' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_value_with_non_string_fallback_results_context(): void {
+		$block = [
+			'context' => [
+				BlockBindings::$context_name => [
+					'blockName' => self::MOCK_BLOCK_NAME,
+					'queryInput' => [],
+					'results' => [
+						[
+							'result' => [
+								self::MOCK_OUTPUT_FIELD_NAME => 456,
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
+		$this->assertSame( $remote_value, '456' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_value_with_null_fallback_results_context(): void {
+		$block = [
+			'context' => [
+				BlockBindings::$context_name => [
+					'blockName' => self::MOCK_BLOCK_NAME,
+					'queryInput' => [],
+					'results' => [
+						[
+							'result' => [
+								self::MOCK_OUTPUT_FIELD_NAME => null,
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
+		$this->assertNull( $remote_value );
 	}
 
 	/**
@@ -619,9 +582,6 @@ class BlockBindingsTest extends TestCase {
 		/**
 		 * Mock the QueryRunner to return a result.
 		 */
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
 		$mock_qr = new class() extends MockQueryRunner {
 			public function execute( HttpQueryInterface $query, array $input_variables ): array {
 				$input_variables['test_input_field'] .= ' transformed';
@@ -680,247 +640,5 @@ class BlockBindingsTest extends TestCase {
 		$this->assertSame( $mock_qr->getLastExecuteCallInput(), [
 			'test_input_field' => 'override_value transformed',
 		] );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_get_value(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( 'output_field', 'Test Output Value' );
-
-		$block_context = [
-			'blockName' => self::MOCK_BLOCK_NAME,
-			'queryInput' => [
-				'test_input_field' => 'test_value',
-			],
-		];
-
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$source_args = [
-			'field' => self::MOCK_OUTPUT_FIELD_NAME,
-		];
-
-		$block = [
-			'context' => [
-				BlockBindings::$context_name => $block_context,
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( $source_args, $block, 'content' );
-		$this->assertSame( $remote_value, self::MOCK_OUTPUT_FIELD_VALUE );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_get_value_with_non_string(): void {
-		/**
-		 * Mock the QueryRunner to return a result.
-		 */
-		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( 'output_field', 123 );
-
-		$block_context = [
-			'blockName' => self::MOCK_BLOCK_NAME,
-			'queryInput' => [
-				'test_input_field' => 'test_value',
-			],
-		];
-
-		$input_schema = [
-			'test_input_field' => [
-				'name' => 'Test Input Field',
-				'type' => 'string',
-			],
-		];
-
-		$mock_block_config = [
-			'queries' => [
-				ConfigRegistry::DISPLAY_QUERY_KEY => MockQuery::create( [
-					'input_schema' => $input_schema,
-					'output_schema' => self::MOCK_OUTPUT_SCHEMA,
-					'query_runner' => $mock_qr,
-				] ),
-			],
-		];
-
-		$mock_config_store = Mockery::namedMock( ConfigStore::class );
-		$mock_config_store->shouldReceive( 'get_block_configuration' )
-			->once()
-			->with( self::MOCK_BLOCK_NAME )
-			->andReturn( $mock_block_config );
-
-		$source_args = [
-			'field' => self::MOCK_OUTPUT_FIELD_NAME,
-		];
-
-		$block = [
-			'context' => [
-				BlockBindings::$context_name => $block_context,
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( $source_args, $block, 'content' );
-		$this->assertSame( $remote_value, '123' );
-	}
-
-	public function test_get_value_with_fallback_content_attribute(): void {
-		$block = [
-			'attributes' => [
-				'content' => 'Fallback Content',
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'content' );
-		$this->assertSame( $remote_value, 'Fallback Content' );
-	}
-
-	public function test_get_value_with_non_string_fallback_content_attribute(): void {
-		$block = [
-			'attributes' => [
-				'content' => 123,
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'content' );
-		$this->assertSame( $remote_value, '123' );
-	}
-
-	public function test_get_value_with_null_fallback_content_attribute(): void {
-		$block = [
-			'attributes' => [
-				'content' => null,
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'content' );
-		$this->assertNull( $remote_value );
-	}
-
-	public function test_get_value_with_fallback_url_attribute(): void {
-		$block = [
-			'attributes' => [
-				'content' => 'Fallback Content',
-				'url' => 'https://example.com/hello-world',
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'url' );
-		$this->assertSame( $remote_value, 'https://example.com/hello-world' );
-	}
-
-	public function test_get_value_with_non_string_fallback_url_attribute(): void {
-		$block = [
-			'attributes' => [
-				'content' => 'Fallback Content',
-				'url' => 123,
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'url' );
-		$this->assertSame( $remote_value, '123' );
-	}
-
-	public function test_get_value_with_null_fallback_url_attribute(): void {
-		$block = [
-			'attributes' => [
-				'content' => 'Fallback Content',
-				'url' => null,
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( [ 'field' => 'non_existent' ], $block, 'url' );
-		$this->assertNull( $remote_value );
-	}
-
-	public function test_get_value_with_fallback_results_context(): void {
-		$block = [
-			'context' => [
-				BlockBindings::$context_name => [
-					'blockName' => self::MOCK_BLOCK_NAME,
-					'queryInput' => [],
-					'results' => [
-						[
-							'result' => [
-								self::MOCK_OUTPUT_FIELD_NAME => 'Stored Output Value',
-							],
-						],
-					],
-				],
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
-		$this->assertSame( $remote_value, 'Stored Output Value' );
-	}
-
-	public function test_get_value_with_non_string_fallback_results_context(): void {
-		$block = [
-			'context' => [
-				BlockBindings::$context_name => [
-					'blockName' => self::MOCK_BLOCK_NAME,
-					'queryInput' => [],
-					'results' => [
-						[
-							'result' => [
-								self::MOCK_OUTPUT_FIELD_NAME => 456,
-							],
-						],
-					],
-				],
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
-		$this->assertSame( $remote_value, '456' );
-	}
-
-	public function test_get_value_with_null_fallback_results_context(): void {
-		$block = [
-			'context' => [
-				BlockBindings::$context_name => [
-					'blockName' => self::MOCK_BLOCK_NAME,
-					'queryInput' => [],
-					'results' => [
-						[
-							'result' => [
-								self::MOCK_OUTPUT_FIELD_NAME => null,
-							],
-						],
-					],
-				],
-			],
-		];
-
-		$remote_value = BlockBindings::get_value( [ 'field' => self::MOCK_OUTPUT_FIELD_NAME ], $block, 'content' );
-		$this->assertNull( $remote_value );
 	}
 }

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -50,13 +50,6 @@ class BlockBindingsTest extends TestCase {
 		$mock_qr = new MockQueryRunner();
 		$mock_qr->addResult( 'output_field', new WP_Error( 'test-error', 'Test Error' ) );
 
-		$block_context = [
-			'blockName' => self::MOCK_BLOCK_NAME,
-			'queryInput' => [
-				'test_input_field' => 'test_value',
-			],
-		];
-
 		$input_schema = [
 			'test_input_field' => [
 				'name' => 'Test Input Field',

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -87,10 +87,10 @@ class BlockBindingsTest extends TestCase {
 		$this->assertTrue( BlockBindings::is_error_or_empty_state( [
 			BlockBindings::$context_name => [
 				'blockName' => self::MOCK_BLOCK_NAME,
-					'queryInput' => [
-						'test_input_field' => 'test_value',
-						'another_input_field' => 'another_value',
-					],
+				'queryInput' => [
+					'test_input_field' => 'test_value',
+					'another_input_field' => 'another_value',
+				],
 			],
 		], [ 'mode' => 'error' ] ) );
 	}
@@ -142,10 +142,10 @@ class BlockBindingsTest extends TestCase {
 		$this->assertTrue( BlockBindings::is_error_or_empty_state( [
 			BlockBindings::$context_name => [
 				'blockName' => self::MOCK_BLOCK_NAME,
-					'queryInput' => [
-						'test_input_field' => 'test_value',
-						'another_input_field' => 'another_value',
-					],
+				'queryInput' => [
+					'test_input_field' => 'test_value',
+					'another_input_field' => 'another_value',
+				],
 			],
 		], [ 'mode' => 'empty' ] ) );
 	}

--- a/tests/inc/Mocks/MockQueryRunner.php
+++ b/tests/inc/Mocks/MockQueryRunner.php
@@ -33,7 +33,7 @@ class MockQueryRunner extends QueryRunner {
 
 	public function addResults( array $results ): void {
 		array_push( $this->query_results, [
-			'is_collection' => false,
+			'is_collection' => true,
 			'results' => $results,
 		] );
 	}

--- a/tests/inc/Mocks/MockQueryRunner.php
+++ b/tests/inc/Mocks/MockQueryRunner.php
@@ -31,6 +31,13 @@ class MockQueryRunner extends QueryRunner {
 		] );
 	}
 
+	public function addResults( array $results ): void {
+		array_push( $this->query_results, [
+			'is_collection' => false,
+			'results' => $results,
+		] );
+	}
+
 	public function execute( HttpQueryInterface $query, array $input_variables ): array|WP_Error {
 		array_push( $this->execute_call_inputs, $input_variables );
 		return array_shift( $this->query_results ) ?? new WP_Error( 'no-results', 'No results available.' );

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -44,7 +44,9 @@ interface RemoteDataBlockAttributes {
 	remoteData?: RemoteData;
 }
 
-interface RemoteDataNoResultsBlockAttributes {}
+interface RemoteDataNoResultsBlockAttributes {
+	mode?: 'error' | 'empty';
+}
 
 interface RemoteDataPaginationBlockAttributes {}
 


### PR DESCRIPTION
### Description

The purpose of this block variation is to have a block that can be shown when a query errors out. This is a variation of the existing empty block as that ensures no duplication of blocks.

![CleanShot 2025-05-02 at 17 22 04](https://github.com/user-attachments/assets/b16d91f9-bb8c-43ff-a562-a1fc2ff94803)

![CleanShot 2025-05-02 at 17 49 57](https://github.com/user-attachments/assets/2a428728-7e67-429d-9fb4-237a09838ba2)


There are going to be 2 blocks now:

- No results
- Error

There is a mode attribute set based on what block it is, that will decide what's rendered.