### PR TITLE
fix the configs dedup key

### DIFF
--- a/inc/Store/DataSource/DataSourceConfigManager.php
+++ b/inc/Store/DataSource/DataSourceConfigManager.php
@@ -49,7 +49,7 @@ class DataSourceConfigManager {
 			$configs,
 			function ( array $acc, array $item ) {
 				$identifier = $item['uuid'] ?? md5(
-					sprintf( '%s_%s', $item['service_config']['display_name'], $item['service'] )
+					sprintf( '%s_%s', $item['display_name'], $item['service'] ?? 'code-configured' )
 				);
 				$acc[ $identifier ] = $item;
 				return $acc;


### PR DESCRIPTION
With schema changes for `HttpDataSource` in #495, the code configured data sources won't have `service_config`. The dedup key generation is fixed to account for the schema change.