### PR TITLE
Add missing config schema to generic http data source

### DIFF
--- a/inc/Integrations/GenericHttp/GenericHttpDataSource.php
+++ b/inc/Integrations/GenericHttp/GenericHttpDataSource.php
@@ -5,6 +5,7 @@ namespace RemoteDataBlocks\Integrations\GenericHttp;
 use RemoteDataBlocks\Config\DataSource\HttpDataSource;
 use RemoteDataBlocks\Validation\Types;
 use RemoteDataBlocks\Validation\Validator;
+use RemoteDataBlocks\Validation\ConfigSchemas;
 use WP_Error;
 
 class GenericHttpDataSource extends HttpDataSource {
@@ -109,5 +110,12 @@ class GenericHttpDataSource extends HttpDataSource {
 			'service_config' => $this->config['service_config'],
 			'uuid' => $this->config['uuid'],
 		];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_config_schema(): array {
+		return ConfigSchemas::get_generic_http_data_source_config_schema();
 	}
 }

--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -43,6 +43,16 @@ final class ConfigSchemas {
 		return $schema;
 	}
 
+	public static function get_generic_http_data_source_config_schema(): array {
+		static $schema = null;
+
+		if ( null === $schema ) {
+			$schema = self::generate_generic_http_data_source_config_schema();
+		}
+
+		return $schema;
+	}
+
 	public static function get_http_query_config_schema(): array {
 		static $schema = null;
 
@@ -133,6 +143,15 @@ final class ConfigSchemas {
 			),
 			'uuid' => Types::nullable( Types::uuid() ),
 		] );
+	}
+
+	private static function generate_generic_http_data_source_config_schema(): array {
+		return Types::merge_object_types(
+			self::generate_http_data_source_config_schema(),
+			Types::object( [
+				'service_config' => Types::nullable( Types::record( Types::string(), Types::not( Types::callable() ) ) ),
+			] )
+		);
 	}
 
 	private static function generate_http_query_config_schema(): array {

--- a/tests/inc/Integrations/GenericHttp/GenericHttpDataSourceTest.php
+++ b/tests/inc/Integrations/GenericHttp/GenericHttpDataSourceTest.php
@@ -25,7 +25,7 @@ class GenericHttpDataSourceTest extends TestCase {
 			'service_config' => [
 				'__version' => 1,
 				'display_name' => 'Mock Data Source',
-				'endpoint' => 'http://example.com'
+				'endpoint' => 'http://example.com',
 			],
 		];
 

--- a/tests/inc/Integrations/GenericHttp/GenericHttpDataSourceTest.php
+++ b/tests/inc/Integrations/GenericHttp/GenericHttpDataSourceTest.php
@@ -25,12 +25,7 @@ class GenericHttpDataSourceTest extends TestCase {
 			'service_config' => [
 				'__version' => 1,
 				'display_name' => 'Mock Data Source',
-				'endpoint' => 'http://example.com',
-				'auth' => [
-					'type' => 'basic',
-					'key' => 'api_key',
-					'value' => '1234567890',
-				],
+				'endpoint' => 'http://example.com'
 			],
 		];
 
@@ -40,9 +35,6 @@ class GenericHttpDataSourceTest extends TestCase {
 		$data_source_array = $data_source->to_array();
 
 		$this->assertEquals( 'generic-http', $data_source_array['service'] );
-		$this->assertEquals( 'http://example.com', $data_source_array['endpoint'] );
-		$this->assertEquals( [
-			'Authorization' => 'Basic MTIzNDU2Nzg5MA==',
-		], $data_source_array['request_headers'] );
+		$this->assertEquals( 'http://example.com', $data_source_array['service_config']['endpoint'] );
 	}
 }

--- a/tests/inc/Integrations/GenericHttp/GenericHttpDataSourceTest.php
+++ b/tests/inc/Integrations/GenericHttp/GenericHttpDataSourceTest.php
@@ -6,7 +6,8 @@ use PHPUnit\Framework\TestCase;
 use RemoteDataBlocks\Integrations\GenericHttp\GenericHttpDataSource;
 
 class GenericHttpDataSourceTest extends TestCase {
-	public function testGetServiceMethodReturnsCorrectValue(): void {
+
+	public function test_get_service_method_returns_correct_value(): void {
 		$config = [
 			'service_config' => [
 				'__version' => 1,
@@ -17,5 +18,31 @@ class GenericHttpDataSourceTest extends TestCase {
 		$data_source = GenericHttpDataSource::from_array( $config );
 
 		$this->assertEquals( 'generic-http', $data_source->get_service_name() );
+	}
+
+	public function test_to_array_returns_correctly_mapped_values(): void {
+		$config = [
+			'service_config' => [
+				'__version' => 1,
+				'display_name' => 'Mock Data Source',
+				'endpoint' => 'http://example.com',
+				'auth' => [
+					'type' => 'basic',
+					'key' => 'api_key',
+					'value' => '1234567890',
+				],
+			],
+		];
+
+		// By calling to_array, we can ensure that the config schema is correctly defined,
+		// and that values haven't been sanitized due to them missing from the schema.
+		$data_source = GenericHttpDataSource::from_array( $config );
+		$data_source_array = $data_source->to_array();
+
+		$this->assertEquals( 'generic-http', $data_source_array['service'] );
+		$this->assertEquals( 'http://example.com', $data_source_array['endpoint'] );
+		$this->assertEquals( [
+			'Authorization' => 'Basic MTIzNDU2Nzg5MA==',
+		], $data_source_array['request_headers'] );
 	}
 }


### PR DESCRIPTION
### Description

The config schema for `GenericHttpDataSource` hasn't been defined, and so it's pulling the config schema from it's parent that doesn't `service_config` which is why it gets sanitized from data sources leveraging this class. I've extended the parent schema, and added `service_config` to it while ensuring that it's nullable.

I've also added a test for it to ensure that it can be caught next time. A follow up to this would be try and add more integration tests to catch this in an end to end test with a real data source.

### Testing

- Pul down trunk and configure any data source. You'll notice the blocks aren't registering and there are errors in the logs related to a bad `service_config` access.
- Pull down this branch and all of that will now go away.