### PR TITLE
Stop using the github proxy

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -32,7 +32,7 @@
       "pluginData": {
         "caption": "Installing Remote Data Blocks",
         "resource": "url",
-        "url": "https://github-proxy.com/proxy/?repo=Automattic/remote-data-blocks&release=latest&asset=remote-data-blocks.zip"
+        "url": "https://wordpress-playground.atomicsites.blog/plugin-proxy.php?repo=Automattic/remote-data-blocks&name=remote-data-blocks.zip"
       }
     }
   ]


### PR DESCRIPTION
### Description

The private playground deployment now has support for our repo, so we can stop using the GitHub proxy and default to their proxy. It'll automatically pull whatever name we provide as the release zip. So this will pull in the latest RDB release, that we can use to power the playground instance