### PR TITLE
Switch to workflow_dispatch since PRs created by tokens cannot spawn workflow runs

### DIFF
--- a/.github/workflows/ai-docs.yml
+++ b/.github/workflows/ai-docs.yml
@@ -1,9 +1,7 @@
 name: Update AI documentation
 
 on:
-  push:
-    branches:
-      - trunk
+  workflow_dispatch:
 
 jobs:
   generate-ai-docs:


### PR DESCRIPTION
These workflow runs will need to be manual, since PRs created using the `GITHUB_TOKEN` via a workflow will not trigger a workflow (to prevent accidental infinite recursion):

https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow