### PR TITLE
Fix `block.json` attribute definition

### DIFF
--- a/src/blocks/remote-data-no-results/block.json
+++ b/src/blocks/remote-data-no-results/block.json
@@ -12,7 +12,8 @@
   "attributes": {
     "mode": {
       "enum": [ "empty", "error" ],
-      "default": "empty"
+      "default": "empty",
+      "type": "string"
     }
   },
   "supports": {


### PR DESCRIPTION
Fix `block.json` attribute definition for the `mode` attribute of the `no-results` block, which resulted in the following warnings when the corresponding core REST endpoints were registered:

```
Function rest_validate_value_from_schema was called incorrectly. The "type" schema keyword for mode is required. (This message was added in version 5.5.0.)
Function rest_validate_value_from_schema was called incorrectly. The "type" schema keyword for mode can only be one of the built-in types: array, object, string, number, integer, boolean, and null. (This message was added in version 5.5.0.)
```