### PR TITLE
Disable block controls when multiple blocks are selected

### DIFF
--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -114,11 +114,6 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 			return <BlockEdit { ...props } />;
 		}
 
-		// If multiple blocks are being selected, render it as usual.
-		if ( hasMultiSelection() ) {
-			return <BlockEdit { ...props } />;
-		}
-
 		// Synced pattern overrides are provided via context and the value can be:
 		//
 		// - undefined (block is not in a synced pattern)
@@ -146,6 +141,11 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 			...attributes,
 			...getMismatchedAttributes( attributes, remoteData.results, remoteData.blockName, index ),
 		};
+
+		// If multiple blocks are being selected, render it as usual.
+		if ( hasMultiSelection() ) {
+			return <BlockEdit { ...props } attributes={ mergedAttributes } />;
+		}
 
 		// If the block is not writable, render it as usual.
 		if ( isInSyncedPattern && ! hasEnabledOverrides ) {

--- a/src/block-editor/filters/withBlockBinding.tsx
+++ b/src/block-editor/filters/withBlockBinding.tsx
@@ -1,7 +1,12 @@
-import { InspectorControls } from '@wordpress/block-editor';
+import {
+	BlockEditorStoreSelectors,
+	InspectorControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { BlockConfiguration, BlockEditProps } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 
 import { BlockBindingControls } from '@/blocks/remote-data-container/components/BlockBindingControls';
@@ -102,9 +107,15 @@ export const withBlockBinding = createHigherOrderComponent( BlockEdit => {
 		const { remoteData } = useRemoteDataContext( context );
 		const availableBindings = getBlockAvailableBindings( remoteData?.blockName ?? '' );
 		const hasAvailableBindings = Boolean( Object.keys( availableBindings ).length );
+		const { hasMultiSelection } = useSelect< BlockEditorStoreSelectors >( blockEditorStore );
 
 		// If the block does not have a remote data context, render it as usual.
 		if ( ! remoteData || ! hasAvailableBindings ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		// If multiple blocks are being selected, render it as usual.
+		if ( hasMultiSelection() ) {
 			return <BlockEdit { ...props } />;
 		}
 

--- a/src/blocks/remote-data-container/edit.tsx
+++ b/src/blocks/remote-data-container/edit.tsx
@@ -1,6 +1,13 @@
-import { BlockPattern, InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	BlockEditorStoreSelectors,
+	BlockPattern,
+	InspectorControls,
+	store as blockEditorStore,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { Spinner } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
 import { QueryInputsPanel } from './components/panels/QueryInputsPanel';
@@ -42,6 +49,7 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 		queryKey: DISPLAY_QUERY_KEY,
 	} );
 
+	const { hasMultiSelection } = useSelect< BlockEditorStoreSelectors >( blockEditorStore );
 	const [ showPatternSelection, setShowPatternSelection ] = useState< boolean >( false );
 
 	function refreshRemoteData(): void {
@@ -119,23 +127,25 @@ export function Edit( props: BlockEditProps< RemoteDataBlockAttributes > ) {
 
 	return (
 		<>
-			<InspectorControls>
-				<OverridesPanel
-					blockConfig={ blockConfig }
-					remoteData={ data }
-					updateRemoteData={ updateRemoteData }
-				/>
-				<DataPanel
-					refreshRemoteData={ refreshRemoteData }
-					remoteData={ data }
-					resetRemoteData={ resetRemoteData }
-				/>
-				<QueryInputsPanel
-					onUpdateQueryInputs={ onUpdateQueryInputs }
-					remoteData={ data }
-					selectors={ blockConfig.selectors }
-				/>
-			</InspectorControls>
+			{ ! hasMultiSelection() && (
+				<InspectorControls>
+					<OverridesPanel
+						blockConfig={ blockConfig }
+						remoteData={ data }
+						updateRemoteData={ updateRemoteData }
+					/>
+					<DataPanel
+						refreshRemoteData={ refreshRemoteData }
+						remoteData={ data }
+						resetRemoteData={ resetRemoteData }
+					/>
+					<QueryInputsPanel
+						onUpdateQueryInputs={ onUpdateQueryInputs }
+						remoteData={ data }
+						selectors={ blockConfig.selectors }
+					/>
+				</InspectorControls>
+			) }
 
 			<div { ...blockProps }>
 				{ loading && (

--- a/tests/src/block-editor/filters/withBlockBinding.test.tsx
+++ b/tests/src/block-editor/filters/withBlockBinding.test.tsx
@@ -238,4 +238,47 @@ describe( 'withBlockBinding', () => {
 		expect( hasMultiSelection ).toHaveBeenCalledTimes( 1 );
 		expect( mockSetAttributes ).not.toHaveBeenCalled();
 	} );
+
+	it( 'updates attributes even when binding ui is hidden', () => {
+		const mockSetAttributes = vi.fn();
+		const props = {
+			attributes: {
+				content: 'Old Title',
+				metadata: {
+					bindings: {
+						content: {
+							source: BLOCK_BINDING_SOURCE,
+							args: { block: 'test/block', field: 'title' },
+						},
+					},
+				},
+			},
+			context: {
+				[ REMOTE_DATA_CONTEXT_KEY ]: {
+					blockName: 'test/block',
+					results: createResults( [ { title: 'New Title' } ] ),
+				},
+			},
+			name: 'test/block',
+			setAttributes: mockSetAttributes,
+			clientId: 'test-client-id',
+			isSelected: false,
+			className: '',
+		};
+
+		hasMultiSelection.mockReturnValueOnce( true );
+
+		render( <WrappedComponent { ...props } /> );
+
+		expect( MockBlockEdit ).toHaveBeenCalledTimes( 1 );
+		expect( MockBlockEdit ).toHaveBeenCalledWith(
+			{
+				...props,
+				attributes: { ...props.attributes, content: 'New Title' },
+			},
+			{}
+		);
+		expect( hasMultiSelection ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetAttributes ).not.toHaveBeenCalled();
+	} );
 } );

--- a/tests/src/block-editor/filters/withBlockBinding.test.tsx
+++ b/tests/src/block-editor/filters/withBlockBinding.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { withBlockBinding } from '@/block-editor/filters/withBlockBinding';
@@ -15,6 +16,7 @@ vi.mock( '@wordpress/block-editor', () => ( {
 	InspectorControls: ( { children }: { children: React.ReactNode } ) => (
 		<div data-testid="inspector-controls">{ children }</div>
 	),
+	store: {},
 } ) );
 
 vi.mock( '@wordpress/components', () => ( {
@@ -25,6 +27,8 @@ vi.mock( '@wordpress/components', () => ( {
 	),
 } ) );
 
+vi.mock( '@wordpress/data' );
+
 vi.mock( '@/hooks/useEditedPostAttribute', () => ( {
 	useEditedPostAttribute: () => ( {
 		postType: '',
@@ -32,6 +36,7 @@ vi.mock( '@/hooks/useEditedPostAttribute', () => ( {
 } ) );
 
 describe( 'withBlockBinding', () => {
+	const hasMultiSelection = vi.fn().mockReturnValue( false );
 	const MockBlockEdit = vi.fn( () => <div data-testid="mock-block-edit" /> );
 	const WrappedComponent = withBlockBinding( MockBlockEdit );
 	const testBlockConfig: LocalizedBlockData = {
@@ -54,11 +59,13 @@ describe( 'withBlockBinding', () => {
 
 	beforeEach( () => {
 		vi.useFakeTimers();
+		vi.mocked( useSelect ).mockImplementation( () => ( { hasMultiSelection } ) );
 		window.REMOTE_DATA_BLOCKS = testBlockConfig;
 	} );
 
 	afterEach( () => {
 		vi.useRealTimers();
+		hasMultiSelection.mockClear();
 		MockBlockEdit.mockClear();
 		cleanup();
 	} );
@@ -76,6 +83,32 @@ describe( 'withBlockBinding', () => {
 			/>
 		);
 
+		expect( hasMultiSelection ).not.toHaveBeenCalled();
+		expect( screen.getByTestId( 'mock-block-edit' ) ).toBeDefined();
+		expect( screen.queryByTestId( 'inspector-controls' ) ).toBeNull();
+	} );
+
+	it( 'renders original BlockEdit when multiple blocks are selected', () => {
+		hasMultiSelection.mockReturnValueOnce( true );
+
+		const remoteData = {
+			blockName: 'test/block',
+			results: createResults( [ { field1: 'value1' } ] ),
+		};
+
+		render(
+			<WrappedComponent
+				attributes={ {} }
+				context={ { [ REMOTE_DATA_CONTEXT_KEY ]: remoteData } }
+				name="test/block"
+				setAttributes={ () => {} }
+				clientId="test-client-id"
+				isSelected={ false }
+				className=""
+			/>
+		);
+
+		expect( hasMultiSelection ).toHaveBeenCalledTimes( 1 );
 		expect( screen.getByTestId( 'mock-block-edit' ) ).toBeDefined();
 		expect( screen.queryByTestId( 'inspector-controls' ) ).toBeNull();
 	} );
@@ -99,6 +132,7 @@ describe( 'withBlockBinding', () => {
 
 		await vi.runAllTimersAsync();
 
+		expect( hasMultiSelection ).toHaveBeenCalledTimes( 1 );
 		expect( screen.getByTestId( 'mock-block-edit' ) ).toBeDefined();
 		expect( screen.getByTestId( 'inspector-controls' ) ).toBeDefined();
 		expect( screen.getByTestId( 'panel-body' ) ).toBeDefined();
@@ -124,6 +158,7 @@ describe( 'withBlockBinding', () => {
 			/>
 		);
 
+		expect( hasMultiSelection ).toHaveBeenCalledTimes( 1 );
 		expect( screen.getByTestId( 'mock-block-edit' ) ).toBeDefined();
 		expect( screen.queryByTestId( 'inspector-controls' ) ).toBeNull();
 	} );
@@ -165,6 +200,7 @@ describe( 'withBlockBinding', () => {
 			},
 			{}
 		);
+		expect( hasMultiSelection ).toHaveBeenCalledTimes( 1 );
 		expect( mockSetAttributes ).not.toHaveBeenCalled();
 	} );
 
@@ -199,6 +235,7 @@ describe( 'withBlockBinding', () => {
 
 		expect( MockBlockEdit ).toHaveBeenCalledTimes( 1 );
 		expect( MockBlockEdit ).toHaveBeenCalledWith( props, {} );
+		expect( hasMultiSelection ).toHaveBeenCalledTimes( 1 );
 		expect( mockSetAttributes ).not.toHaveBeenCalled();
 	} );
 } );

--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -48,5 +48,6 @@ declare module '@wordpress/block-editor' {
 		getBlocksByName: ( name: string ) => string[];
 		getPatternsByBlockTypes: ( name: string | string[], clientId?: string ) => BlockPattern[];
 		getSettings: () => EditorSettings;
+		hasMultiSelection: () => boolean;
 	}
 }


### PR DESCRIPTION
Selecting multiple blocks in the list view can give the impression that any applied settings during that selection will be applied to all selected blocks.

<img width="1180" alt="Screenshot 2025-05-08 at 17 57 18" src="https://github.com/user-attachments/assets/1ced14ab-5eec-47b1-afd7-665eafd04191" />

However, there is no affordance for this behavior and implementing it would likely be very confusing and error prone. Why, for example, would you want to update the query inputs for multiple blocks? If there were multiple query inputs, would such an update mutate them all? Or just one?

Accordingly, this PR disables (hides) our block controls when multiple blocks are selected:

<img width="1177" alt="Screenshot 2025-05-08 at 17 56 50" src="https://github.com/user-attachments/assets/dc2f830b-0aa2-4d00-833f-8e9afda39f56" />

Fixes VIPCMS-91.