### PR TITLE
Provide logs in REST API requests

### DIFF
--- a/inc/Logging/QueryMonitor/QueryMonitor.php
+++ b/inc/Logging/QueryMonitor/QueryMonitor.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class QueryMonitor {
 	public static function init(): void {
 		add_filter( 'qm/collectors', [ __CLASS__, 'add_collectors' ], 90, 1 );
-		add_filter( 'qm/outputter/html', [ __CLASS__, 'add_outputters' ], 90, 1 );
+		add_filter( 'qm/outputter/html', [ __CLASS__, 'add_html_outputters' ], 90, 1 );
+		add_filter( 'qm/outputter/raw', [ __CLASS__, 'add_raw_outputters' ], 90, 1 );
 		add_filter( 'qm/trace/ignore_class', [ __CLASS__, 'ignore_classes' ], 10, 1 );
 	}
 
@@ -37,13 +38,32 @@ class QueryMonitor {
 		return $collectors;
 	}
 
-	public static function add_outputters( array $outputters ): array {
+	public static function add_html_outputters( array $outputters ): array {
 		$outputter_classes = [
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbMainOutputHtml',
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbBlockBindingOutputHtml',
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbHttpRequestOutputHtml',
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbLogOutputHtml',
 			'RemoteDataBlocks\Logging\QueryMonitor\RdbValidationOutputHtml',
+		];
+
+		foreach ( $outputter_classes as $class ) {
+			if ( class_exists( $class ) ) {
+				/**
+				 * @psalm-suppress UndefinedClass
+				 */
+				$collector = QM_Collectors::get( $class::$collector_id );
+				$instance = new $class( $collector );
+				$outputters[ $collector->id ] = $instance;
+			}
+		}
+
+		return $outputters;
+	}
+
+	public static function add_raw_outputters( array $outputters ): array {
+		$outputter_classes = [
+			'RemoteDataBlocks\Logging\QueryMonitor\RdbLogOutputRaw',
 		];
 
 		foreach ( $outputter_classes as $class ) {

--- a/inc/Logging/QueryMonitor/RdbLogCollector.php
+++ b/inc/Logging/QueryMonitor/RdbLogCollector.php
@@ -8,6 +8,7 @@ use QM_Data_Logger;
 use RemoteDataBlocks\Editor\DataBinding\BlockBindings;
 use RemoteDataBlocks\Logging\Logger;
 use function get_post;
+use function wp_is_serving_rest_request;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -65,7 +66,11 @@ if ( class_exists( 'QM_Collector_Logger' ) ) {
 		public function log_event( string $_namespace, string $level, string $message, array $context ): void {
 			$event_type = $context['type'] ?? 'generic';
 
-			if ( $this->log_type !== $event_type ) {
+			// If the log type does not match the event type, do not log. Exception:
+			// During REST API requests, we want to funnel all events to the main
+			// log collector, so that we can see all logs in one place on the REST
+			// response.
+			if ( $this->log_type !== $event_type && ! wp_is_serving_rest_request() ) {
 				return;
 			}
 

--- a/inc/Logging/QueryMonitor/RdbLogOutputRaw.php
+++ b/inc/Logging/QueryMonitor/RdbLogOutputRaw.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Logging\QueryMonitor;
+
+use QM_Output_Raw_Logger;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'QM_Output_Raw_Logger' ) ) {
+	class RdbLogOutputRaw extends QM_Output_Raw_Logger {
+		public static string $collector_id = 'remote-data-blocks-logs';
+
+		public function get_output(): array {
+			/** @var QM_Data_Logger $data */
+			$data = $this->collector->get_data();
+
+			return $data->logs ?? [];
+		}
+	}
+}

--- a/types/query-monitor.d.ts
+++ b/types/query-monitor.d.ts
@@ -1,0 +1,26 @@
+interface RemoteDataBlockLog {
+	block_name: string;
+	context: {
+		query_key: string;
+		query_inputs: RemoteDataQueryInput[];
+	};
+	filtered_trace: QueryMonitorTrace[];
+	level: string;
+	message: string;
+}
+
+interface QueryMonitorData {
+	'remote-data-blocks-logs'?: RemoteDataBlockLog[];
+}
+
+interface QueryMonitorTrace {
+	file: string;
+	line: number;
+	function: string;
+	class: string;
+	type: string;
+	id: string;
+	display: string;
+	calling_file: string;
+	calling_line: number;
+}

--- a/types/remote-data.d.ts
+++ b/types/remote-data.d.ts
@@ -111,7 +111,14 @@ interface RemoteDataApiResponseBody {
 	results: RemoteDataApiResult[];
 }
 
+// This response shape reflects the use of _envelope=true, which forces a 200
+// status code on the actual request. The actual status code is in the envelope,
+// along the with actual response body. We do this so that Query Monitor can
+// amend the response without disturbing the response body.
+//
+// https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_envelope
 interface RemoteDataApiResponse {
 	body?: RemoteDataApiResponseBody;
+	qm?: QueryMonitorData;
 	status?: number;
 }


### PR DESCRIPTION
Provide logs in REST API requests via Query Monitor. This is a first step towards surfacing those errors in the UI.

<img width="1647" alt="Screenshot 2025-05-12 at 17 53 10" src="https://github.com/user-attachments/assets/85a0bbd3-d895-4695-b3a0-44e77b915b46" />
