### PR TITLE
Run E2E and integration tests at minimum version

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,8 +38,16 @@ jobs:
           npx playwright install chromium --with-deps
 
       - name: Start up WordPress environment
+        env:
+          WP_ENV_CORE: WordPress/WordPress#6.7
+          WP_ENV_PHP_VERSION: 8.1
         run: |
           npm run dev:build
+
+      - name: Output WordPress and PHP version
+        run: |
+          npm run wp-cli cli info
+          npm run wp-cli core version
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,15 @@ jobs:
         run: npm ci
 
       - name: Start up WordPress environment
+        env:
+          WP_ENV_CORE: WordPress/WordPress#6.7
+          WP_ENV_PHP_VERSION: 8.1
         run: npm run dev:build
+
+      - name: Output WordPress and PHP version
+        run: |
+          npm run wp-cli cli info
+          npm run wp-cli core version
 
       - name: Run Integration tests
         run: npm run test:integration


### PR DESCRIPTION
Run E2E and integration tests at minimum version instead of latest versions.