### PR TITLE
Update wp-env plugins URLs to be latest, rather than outdated ones

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -12,7 +12,7 @@
   },
   "plugins": [
     ".",
-    "https://downloads.wordpress.org/plugin/query-monitor.3.16.4.zip",
-    "https://downloads.wordpress.org/plugin/redis-cache.2.5.3.zip"
+    "https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip",
+    "https://downloads.wordpress.org/plugin/redis-cache.latest-stable.zip"
   ]
 }


### PR DESCRIPTION
This allow local environments to stay up to date with the latest version of a WP.org plugin.

The change forces a latest version to be used via a seamless 301 redirect on downloads.wp.org, and avoids the need to keep changing this file.