### PR TITLE
Update example API to produce distinct cache keys

### DIFF
--- a/inc/ExampleApi/ExampleApi.php
+++ b/inc/ExampleApi/ExampleApi.php
@@ -47,6 +47,11 @@ class ExampleApi {
 
 		$get_record_query = HttpQuery::from_array( [
 			'data_source' => $data_source,
+			'endpoint' => function ( array $input_variables ) use ( $data_source ): string {
+				// This is not a real API, but we want to make sure to generate
+				// valid cache keys that do not collide with other queries.
+				return sprintf( '%s/%s', $data_source->get_endpoint(), $input_variables['record_id'] ?? '' );
+			},
 			'input_schema' => [
 				'record_id' => [
 					'name' => 'Record ID',


### PR DESCRIPTION
Update example API to produce distinct cache keys. Since the cache key is computed deterministically from the request, requests for distinct resources must also be distinct, or they may collide with an existing cache entry. Despite the fact that this is not a real API and no HTTP requests are sent!

We could opt-out the example API from caching entirely, but there is probably value in keeping it as close to "real" as possible.

Fixes VIPCMS-1275