### PR TITLE
fix the HTTP data source config creation

### DIFF
--- a/src/data-sources/http/HttpSettings.tsx
+++ b/src/data-sources/http/HttpSettings.tsx
@@ -33,13 +33,6 @@ function computeAuthState( updatedAuth: Partial< HttpServiceConfig[ 'auth' ] > )
 }
 
 export const HttpSettings = ( { mode, uuid, config }: SettingsComponentProps< HttpConfig > ) => {
-	const cardStyles: React.CSSProperties =
-		mode === 'edit'
-			? {
-					marginTop: '16px',
-			  }
-			: {};
-
 	const { state, handleOnChange, validState } = useForm< HttpServiceConfig >( {
 		initialValues: config?.service_config ?? {
 			__version: SERVICE_CONFIG_VERSION,
@@ -100,17 +93,17 @@ export const HttpSettings = ( { mode, uuid, config }: SettingsComponentProps< Ht
 				/>
 
 				<HttpAuthSettingsInput auth={ state.auth } onChange={ handleAuthOnChange } />
+				<Card style={ { marginTop: '16px' } }>
+					<CardBody>
+						<Tip>
+							This data source requires additional code.&nbsp;
+							<ExternalLink href="https://remotedatablocks.com/docs/extending/block-registration/">
+								Learn more
+							</ExternalLink>
+						</Tip>
+					</CardBody>
+				</Card>
 			</DataSourceForm.Setup>
-			<Card style={ cardStyles }>
-				<CardBody>
-					<Tip>
-						This data source requires additional code.&nbsp;
-						<ExternalLink href="https://remotedatablocks.com/docs/extending/block-registration/">
-							Learn more
-						</ExternalLink>
-					</Tip>
-				</CardBody>
-			</Card>
 		</DataSourceForm>
 	);
 };


### PR DESCRIPTION
# Description

Moves informational card inside setup step component to fix form structure. Previously the card was outside which made [`DataSourceForm`](https://github.com/Automattic/remote-data-blocks/blob/3eb237b62d3071b2d7e6bc6484ca6661e2bd75e0/src/data-sources/components/DataSourceForm.tsx#L71-L72) think there was a second empty step, preventing the save button from being enabled.

I considered moving the notice to the second step for consistency with other data sources, but chose to keep it in the setup step since HTTP data sources don't support block auto-registration. Open to revisiting this decision.

## Screenshots

### Bug Video

https://github.com/user-attachments/assets/2004cffc-cdcc-49a5-99f8-f12870375add




### Fix

<img width="1590" alt="Screenshot 2025-05-15 at 2 36 49 PM" src="https://github.com/user-attachments/assets/ee429f6f-cd77-4b99-ab9b-87d3122aa43b" />

# How to test

## Bug

1. Checkout the `trunk` branch
2. Run `npm install`
3. Run `npm run dev`
4. Go to "Remote Data Blocks" under the "Settings" menu in WP-Admin
5. Try to create a new HTTP data source
6. After first "Setup" step, second step shows the notice, but the "Save" button is disabled

## Fix

1. Checkout this branch
2. Run `npm install`
3. Run `npm run dev`
4. Go to "Remote Data Blocks" under the "Settings" menu in WP-Admin
5. Try to create a new HTTP data source
6. Now, the only step is the "Setup" step, and the "Save" button is enabled.