### PR TITLE
Improve jitter placement

### DIFF
--- a/docs/extending/query.md
+++ b/docs/extending/query.md
@@ -154,11 +154,9 @@ The `cache_ttl` property defines how long the query response should be cached in
 
 A value of `-1` indicates the query should not be cached. A value of `null` indicates the default TTL should be used (300 seconds). If omitted, the default TTL is used.
 
-Remote data blocks utilize the WordPress object cache (`wp_cache_get()` / `wp_cache_set()`) for response caching. Ensure that your platform provides or installs a persistent object cache plugin so that this value is respected.
+Remote data blocks utilize the WordPress object cache (`wp_cache_get()` / `wp_cache_set()`) for response caching. Ensure that your platform provides or installs a persistent object cache plugin so that this value is respected. If you do not have a peristent object cache, this property will be ignored and responses will only be cached in-memory. We do not recommend running the Remote Data Blocks plugin in this configuration.
 
-If you do not have a peristent object cache, this property will be ignored and responses will only be cached in-memory. We do not recommend running the Remote Data Blocks plugin in this configuration.
-
-Note that error responses are cached for 30 seconds to avoid overwhelming the remote data source with repeated requests under error conditions.
+Note that error responses are cached for 30 seconds to avoid overwhelming the remote data source with repeated requests under error conditions. Additionally, a small random jitter is added to the cache TTL to avoid cache stampedes.
 
 #### Example
 

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -93,12 +93,6 @@ class QueryRunner implements QueryRunnerInterface {
 
 		$cache_headers = [];
 		if ( intval( $cache_ttl ) > 0 ) {
-			// Add a random jitter to the TTL to avoid simultaneous cache invalidation.
-			// The upper bound of the jitter should be 10% of the TTL or 20 seconds,
-			// whichever is smaller.
-			$jitter = intval( min( $cache_ttl * 0.1, 20 ) );
-			$cache_ttl = intval( $cache_ttl ) + wp_rand( 0, $jitter );
-
 			$cache_headers[ RdbCacheStrategy::CACHE_TTL_REQUEST_HEADER ] = $cache_ttl;
 		}
 		if ( intval( $cache_ttl ) < 0 ) {

--- a/inc/HttpClient/RdbCacheStrategy.php
+++ b/inc/HttpClient/RdbCacheStrategy.php
@@ -11,6 +11,7 @@ use Kevinrob\GuzzleCache\Storage\WordPressObjectCacheStorage;
 use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use function wp_rand;
 
 class RdbCacheStrategy extends GreedyCacheStrategy {
 	public const CACHE_AGE_RESPONSE_HEADER = 'Age';
@@ -73,6 +74,12 @@ class RdbCacheStrategy extends GreedyCacheStrategy {
 			// Cache it for a short time period to prevent error floods.
 			$ttl = self::ERROR_CACHE_TTL_IN_SECONDS;
 		}
+
+		// Add a random jitter to the TTL to avoid simultaneous cache invalidation.
+		// The upper bound of the jitter should be 10% of the TTL or 20 seconds,
+		// whichever is smaller.
+		$jitter = intval( ceil( min( $ttl * 0.1, 20 ) ) );
+		$ttl = intval( $ttl ) + wp_rand( 0, $jitter );
 
 		// NOTE: We skip the vary headers '*' check from the parent method
 		// since our defined vary headers cannot accept a '*' value.

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -21,7 +21,7 @@ final class Validator implements ValidatorInterface {
 	) {}
 
 	public function validate( mixed $data ): bool|WP_Error {
-		$validation = $this->check_type( $this->schema, $this->root_path_name, $data );
+		$validation = $this->validate_value( $this->schema, $this->root_path_name, $data );
 
 		if ( is_wp_error( $validation ) ) {
 			$error_data = $validation->get_error_data();
@@ -44,14 +44,14 @@ final class Validator implements ValidatorInterface {
 	 * @param mixed $value The value to validate.
 	 * @return bool|WP_Error Returns true if the data is valid, otherwise a WP_Error.
 	 */
-	private function check_type( array $type, string $path, mixed $value = null ): bool|WP_Error {
+	private function validate_value( array $type, string $path, mixed $value = null ): bool|WP_Error {
 		if ( Types::is_nullable( $type ) && is_null( $value ) ) {
 			return true;
 		}
 
 		if ( Types::is_primitive( $type ) ) {
 			$type_name = Types::get_type_name( $type );
-			$result = $this->check_primitive_type( $type_name, $path, $value );
+			$result = $this->validate_primitive_value( $type_name, $path, $value );
 
 			if ( true === $result ) {
 				return true;
@@ -64,7 +64,7 @@ final class Validator implements ValidatorInterface {
 			return $this->create_error( sprintf( 'must be a %s', $type_name ), $path );
 		}
 
-		return $this->check_non_primitive_type( $type, $path, $value );
+		return $this->validate_non_primitive_value( $type, $path, $value );
 	}
 
 	/**
@@ -77,7 +77,7 @@ final class Validator implements ValidatorInterface {
 	 * @param mixed $value The value to validate.
 	 * @return bool|WP_Error Returns true if the data is valid, otherwise a WP_Error.
 	 */
-	private function check_non_primitive_type( array $type, string $path, mixed $value ): bool|WP_Error {
+	private function validate_non_primitive_value( array $type, string $path, mixed $value ): bool|WP_Error {
 		switch ( Types::get_type_name( $type ) ) {
 			case 'callable':
 				if ( is_callable( $value ) ) {
@@ -119,7 +119,7 @@ final class Validator implements ValidatorInterface {
 
 				foreach ( $value as $index => $item ) {
 					$child_path = sprintf( '%s[%s]', $path, strval( $index ) );
-					$validated = $this->check_type( $member_type, $child_path, $item );
+					$validated = $this->validate_value( $member_type, $child_path, $item );
 					if ( is_wp_error( $validated ) ) {
 						return $validated;
 					}
@@ -132,7 +132,7 @@ final class Validator implements ValidatorInterface {
 				$excluded_types = Types::get_type_args( $type );
 
 				foreach ( $excluded_types as $excluded_type ) {
-					$validated = $this->check_type( $excluded_type, $path, $value );
+					$validated = $this->validate_value( $excluded_type, $path, $value );
 					if ( true === $validated ) {
 						$excluded_type_names = array_map( static function ( array $type ): string {
 							return Types::get_type_name( $type );
@@ -152,7 +152,7 @@ final class Validator implements ValidatorInterface {
 
 				$member_types = Types::get_type_args( $type );
 				foreach ( $member_types as $member_type ) {
-					$validated = $this->check_type( $member_type, $path, $value );
+					$validated = $this->validate_value( $member_type, $path, $value );
 					if ( true === $validated ) {
 						return true;
 					}
@@ -174,7 +174,7 @@ final class Validator implements ValidatorInterface {
 				foreach ( Types::get_type_args( $type ) as $key => $property_type ) {
 					$child_path = sprintf( '%s[\'%s\']', $path, $key );
 					$property_value = $this->get_object_key( $value, $key );
-					$validated = $this->check_type( $property_type, $child_path, $property_value );
+					$validated = $this->validate_value( $property_type, $child_path, $property_value );
 					if ( is_wp_error( $validated ) ) {
 						return $validated;
 					}
@@ -193,13 +193,13 @@ final class Validator implements ValidatorInterface {
 
 				foreach ( $value as $key => $record_value ) {
 					$child_path = sprintf( 'Key %s of %s', $key, $path );
-					$validated = $this->check_type( $key_type, $child_path, $key );
+					$validated = $this->validate_value( $key_type, $child_path, $key );
 					if ( is_wp_error( $validated ) ) {
 						return $validated;
 					}
 
 					$child_path = sprintf( '%s[\'%s\']', $path, $key );
-					$validated = $this->check_type( $value_type, $child_path, $record_value );
+					$validated = $this->validate_value( $value_type, $child_path, $record_value );
 					if ( is_wp_error( $validated ) ) {
 						return $validated;
 					}
@@ -208,7 +208,7 @@ final class Validator implements ValidatorInterface {
 				return true;
 
 			case 'ref':
-				return $this->check_type( Types::load_ref_type( $type ), $path, $value );
+				return $this->validate_value( Types::load_ref_type( $type ), $path, $value );
 
 			case 'serialized_config_for':
 				if ( ! self::check_iterable_object( $value ) ) {
@@ -258,7 +258,7 @@ final class Validator implements ValidatorInterface {
 			case 'string_matching':
 				$regex = Types::get_type_args( $type );
 
-				if ( $this->check_primitive_type( 'string', $path, $value ) && $this->check_primitive_type( 'string', $path, $regex ) && preg_match( $regex, $value ) ) {
+				if ( $this->validate_primitive_value( 'string', $path, $value ) && $this->validate_primitive_value( 'string', $path, $regex ) && preg_match( $regex, $value ) ) {
 					return true;
 				}
 
@@ -279,7 +279,7 @@ final class Validator implements ValidatorInterface {
 	 * @param mixed $value The value to validate.
 	 * @return bool|WP_Error Returns true if the data is valid, otherwise a WP_Error.
 	 */
-	private function check_primitive_type( string $type_name, string $path, mixed $value ): bool|WP_Error {
+	private function validate_primitive_value( string $type_name, string $path, mixed $value ): bool|WP_Error {
 		switch ( $type_name ) {
 			case 'any':
 				return true;

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -92,6 +92,10 @@ function wp_cache_set(): bool {
 	return true;
 }
 
+function wp_rand( int $min = 0 /* ignored $max */ ): int {
+	return $min;
+}
+
 function update_option( string $option, mixed $value ): bool {
 	MockWordPressFunctions::set_mock_option( $option, $value );
 	return true;


### PR DESCRIPTION
Move TTL jitter code to `RdbCacheStrategy` as a more authoritative placement. This also allows us to add jitter to error response caching.

This PR also renames private methods in `Validator` so that they have distinct names. (The `Types` class also has a `check_type` method.) This makes New Relic stack traces easier to read.

Both changes will help our performance testing re-run.