### PR TITLE
Bugfix: Hide bulk selection and actions for inline bindings

### DIFF
--- a/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
@@ -54,6 +54,10 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 	const selectionIds = selection.map( item => item.uuid );
 	const allIdsFromCurrentPage = data?.results?.map( result => result.uuid ) ?? [];
 
+	// This value indicates whether the modal is being used to select an entire
+	// item / result or just a specific field from the result.
+	const supportsItemSelection = Boolean( onSelect );
+
 	function setSelectionIds( uuids: string[] ): void {
 		const selectionIdsFromOtherPages = selectionIds.filter(
 			uuid => ! allIdsFromCurrentPage.includes( uuid )
@@ -73,7 +77,7 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 	}
 
 	function save( results: RemoteDataApiResult[] ): void {
-		if ( ! results.length ) {
+		if ( ! supportsItemSelection || ! results.length ) {
 			return;
 		}
 
@@ -99,7 +103,9 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 			{ triggerElement }
 			{ isOpen && (
 				<Modal
-					className={ `${ className } rdb-dataviews-bulk-actions-modal` }
+					className={
+						supportsItemSelection ? `${ className } rdb-dataviews-bulk-actions-modal` : className
+					}
 					isFullScreen
 					onRequestClose={ close }
 					title={ blockConfig?.settings?.title ?? title }
@@ -108,7 +114,7 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 						blockName={ blockName }
 						hasNextPage={ hasNextPage ?? false }
 						loading={ loading }
-						onSelect={ save }
+						onSelect={ supportsItemSelection ? save : undefined }
 						onSelectField={ onSelectField }
 						page={ page }
 						results={ loading ? undefined : data?.results }
@@ -122,7 +128,7 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 						totalItems={ totalItems }
 						totalPages={ totalPages }
 					/>
-					{ onSelect && ! loading && (
+					{ supportsItemSelection && ! loading && (
 						<>
 							{ selection.length > 1 && (
 								<BaseControl


### PR DESCRIPTION
Inline bindings incorrectly offers bulk selection and an item-level "Choose" action:


https://github.com/user-attachments/assets/7fb57cc2-0e3f-454d-a8d1-b635f996d3bf



## After fix:


https://github.com/user-attachments/assets/91aabce6-72c7-473b-8cfa-62e5fa2b088d

