### PR TITLE
Add API integration issue template and link from docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/api_integration_issue.md
+++ b/.github/ISSUE_TEMPLATE/api_integration_issue.md
@@ -1,0 +1,45 @@
+---
+name: API integration issue
+about: Report an issue integrating an API with Remote Data Blocks.
+title: ''
+labels: bug
+assignees: smithjw1
+---
+
+## API information
+
+Please describe the API you are trying to integrate with Remote Data Blocks. Include the name, endpoint, version, and any relevant documentation links.
+
+## Query information
+
+A brief description of the query or mutation you are trying to execute. If possible, include a sample request and response. Reproductions using cURL are preferred.
+
+## Block information
+
+A brief description of the remote data block you are trying to create and its intended purpose.
+
+## What went wrong
+
+A clear and concise description of the problem you encountered while integrating the API with Remote Data Blocks. If applicable, include any error messages or unexpected behavior you observed.
+
+### Screenshots or logs
+
+If applicable, please add screenshots or logs to help explain your bug report.
+
+### Environment
+
+Provide details about your environment:
+
+- Remote Data Blocks plugin version:
+- WordPress version:
+- PHP version:
+- Browser and version:
+- Operating system:
+
+### Additional context
+
+Add any other context about the problem here. GitHub issues are public! Please be careful to not share any confidential information.\
+
+## What could have helped
+
+Suggestions are welcome for specific debugging information that would have been useful, and how you expect that information to be surfaced.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,41 +1,45 @@
 ---
-name: Bug report
-about: When something has gone wrong.
+name: General bug report
+about: Report an issue not related to integrating an API.
 title: ''
 labels: bug
 assignees: smithjw1
 ---
 
-**Describe the bug**
-A one sentence description of what the bug is.
+## Describe the bug
 
-**To reproduce**
+A one sentence description of the bug.
 
-- Include the steps you took when you encountered the bug.
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual behavior
+
+A clear and concise description of what actually happened.
+
+## Reproduction
+
+Steps to reproduce the bug.
 
 1. Step one
 2. Step two
 3. Step three
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Screenshots or logs
 
-**Actual behavior**
-A clear and concise description of what actually happened.
+If applicable, please add screenshots or logs to help explain your bug report.
 
-**Screenshots or logs (if applicable)**
-If applicable, add screenshots or logs to help explain your bug report.
+### Environment
 
-**Version of the plugin**
-Version of the plugin
-
-**Environment**
 Provide details about your environment:
 
+- Remote Data Blocks plugin version:
 - WordPress version:
 - PHP version:
 - Browser and version:
 - Operating system:
 
-**Additional context**
-Add any other context about the problem here. Issues are public, please be careful to not share any confidential information.
+### Additional context
+
+Add any other context about the problem here. GitHub issues are public! Please be careful to not share any confidential information.

--- a/.github/ISSUE_TEMPLATE/general_feedback.md
+++ b/.github/ISSUE_TEMPLATE/general_feedback.md
@@ -6,11 +6,14 @@ labels: feedback
 assignees: smithjw1
 ---
 
-**Summarize your feedback**
+## Summarize your feedback
+
 Provide a one-sentence summary of your feedback.
 
-**Detailed Feedback**
+## Detailed Feedback
+
 Please provide your full feedback here. Be as detailed as possible. Issues are public, so please do not share any confidential information.
 
-**Version of the plugin**
+## Version of the plugin
+
 Specify the version of the plugin you are using.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,6 +15,12 @@ The provided local development environment includes Query Monitor by default. Yo
 
 The [local development environment](local-development.md) includes Xdebug for debugging PHP code and a Node.js debugging port for debugging block editor scripts.
 
+## Support
+
+Our goal is to ensure that Remote Data Blocks works with as many APIs as possible. While we cannot guarantee that we can support every API, we are happy to receive detailed reports of any issues you encounter. Please [create a GitHub issue using the "API integration issue" template](https://github.com/Automattic/remote-data-blocks/issues/new?template=api_integration_issue.md) and we will do our best to assist you.
+
+For general bugs, please [use the "General bug report" template](https://github.com/Automattic/remote-data-blocks/issues/new?template=bug_report.md). If you have feedback or suggestions for improvement, please [use the "Feedback" template](https://github.com/Automattic/remote-data-blocks/issues/new?template=general_feedback.md).
+
 ## Resetting config
 
 If you need to reset the Remote Data Blocks configuration in your local development environment, you can use WP-CLI to delete the configuration option. This will permanently delete all configuration values, including access tokens and API keys.


### PR DESCRIPTION
Add a GitHub issue template specific to API integration issues and link it from docs. Apply consistent formatting to existing templates.