### PR TITLE
refencing global telemetry class

### DIFF
--- a/inc/Telemetry/Telemetry.php
+++ b/inc/Telemetry/Telemetry.php
@@ -66,8 +66,8 @@ class Telemetry {
 		add_action( 'remote_data_blocks_track_event', [ $this, 'record_event' ], 10, 2 );
 
 		// Enable the Pendo JavaScript library for tracking.
-		if ( class_exists( 'Automattic\VIP\Telemetry\Pendo' ) ) {
-			add_action( 'admin_init', [ Automattic\VIP\Telemetry\Pendo::class, 'enable_javascript_library' ] );
+		if ( class_exists( '\Automattic\VIP\Telemetry\Pendo' ) ) {
+			add_action( 'admin_init', [ \Automattic\VIP\Telemetry\Pendo::class, 'enable_javascript_library' ] );
 		}
 	}
 


### PR DESCRIPTION
I tried to load v17 on the load testing instance, and I received an error about not being able to find the Telemetry class.

I think we may need to reference it differently, making this change on the load testing instance fixed the issue, but I'm not 100 percent sure it's the right route.

But we should fix this soon as v17 as is will fail on VIP.