### PR TITLE
Implement code snippets for Generic HTTP data sources

### DIFF
--- a/inc/Integrations/GenericHttp/GenericHttpIntegration.php
+++ b/inc/Integrations/GenericHttp/GenericHttpIntegration.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Integrations\GenericHttp;
+
+use RemoteDataBlocks\Snippet\Snippet;
+
+class GenericHttpIntegration {
+	/**
+	 * Get the code snippets for the Generic HTTP integration.
+	 *
+	 * @param array $data_source_config The data source configuration.
+	 * @return array<Snippet> The block registration snippets.
+	 */
+	public static function get_code_snippets( array $data_source_config ): array {
+		$snippets = [];
+		$raw_snippet = file_get_contents( __DIR__ . '/templates/block_registration.template' );
+
+		$code = strtr( $raw_snippet, [
+			'{{DATA_SOURCE_UUID}}' => $data_source_config['uuid'],
+		] );
+
+		$snippets[] = new Snippet( 'Block registration', $code );
+
+		return $snippets;
+	}
+}

--- a/inc/Integrations/GenericHttp/templates/block_registration.template
+++ b/inc/Integrations/GenericHttp/templates/block_registration.template
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+/**
+ * @template-name Generic HTTP Data Source
+ * @template-version 1.0.0
+ * @template-description Gets a Generic HTTP data source to be used for queries and block registation.
+ *
+ * Template variables:
+ * - DATA_SOURCE_UUID: The UUID of the data source.
+ */
+
+namespace RemoteDataBlocks\Snippets\GenericHttp;
+
+use RemoteDataBlocks\WpdbStorage\DataSourceCrud;
+use RemoteDataBlocks\Config\Query\HttpQuery;
+
+function register_http_remote_data_block(): void {
+	$data_source = DataSourceCrud::get_config_by_uuid( '{{DATA_SOURCE_UUID}}' );
+
+	$query = HttpQuery::from_array( [
+		'data_source' => $data_source,
+		'input_schema' => [
+			/* Input schema */
+		],
+		'output_schema' => [
+			/* Output schema */
+		],
+	] );
+
+	register_remote_data_block( [
+		'title' => $block_title,
+		'render_query' => [
+			'query' => $query,
+		],
+	] );
+}
+
+add_action( 'init', __NAMESPACE__ . '\\register_http_remote_data_block' );
+

--- a/inc/Snippet/Snippet.php
+++ b/inc/Snippet/Snippet.php
@@ -5,6 +5,7 @@ namespace RemoteDataBlocks\Snippet;
 use JsonSerializable;
 use RemoteDataBlocks\WpdbStorage\DataSourceCrud;
 use RemoteDataBlocks\Integrations\Airtable\AirtableIntegration;
+use RemoteDataBlocks\Integrations\GenericHttp\GenericHttpIntegration;
 use RemoteDataBlocks\Integrations\Google\Sheets\GoogleSheetsIntegration;
 use RemoteDataBlocks\Integrations\Shopify\ShopifyIntegration;
 use WP_Error;
@@ -39,6 +40,9 @@ class Snippet implements JsonSerializable {
 		$service = $data_source_config['service'];
 
 		switch ( $service ) {
+			case REMOTE_DATA_BLOCKS_GENERIC_HTTP_SERVICE:
+				$snippets = GenericHttpIntegration::get_code_snippets( $data_source_config );
+				break;
 			case REMOTE_DATA_BLOCKS_SHOPIFY_SERVICE:
 				$snippets = ShopifyIntegration::get_block_registration_snippets( $data_source_config );
 				break;

--- a/src/data-sources/DataSourceList.tsx
+++ b/src/data-sources/DataSourceList.tsx
@@ -319,7 +319,7 @@ const DataSourceList = () => {
 					className="rdb-settings-page_data-source-code-snippet-modal"
 					icon={ getServiceIcon( currentSource?.service ?? 'generic-http' ) }
 					title={ __(
-						`${ getDataSourceName( currentSource ) }: Data Source Code`,
+						`Code Snippets: ${ getDataSourceName( currentSource ) }`,
 						'remote-data-blocks'
 					) }
 					onClose={ () => {
@@ -330,7 +330,7 @@ const DataSourceList = () => {
 					<>
 						<p style={ { marginBottom: '16px', padding: '0 8px' } }>
 							{ __(
-								"Below, you'll find the code used to register the block(s) for this data source, which can be used as a reference for extending the data source.\nTo get started, copy the code below and add it to your plugin directory. "
+								"Below, you'll find code snippets for this data source which can be used as a reference.\nTo get started, copy the code below and add it to your plugin directory. "
 							) }
 							<ExternalLink href="https://remotedatablocks.com/docs/extending/index/">
 								{ __( 'Learn more about extending', 'remote-data-blocks' ) }


### PR DESCRIPTION
Implement code snippets for Generic HTTP data sources, along with a few copy tweaks that more generally position these as code snippets instead of specifically scoping them to block registration code.

This probably deserves an abstract class to reduce code duplication, but I'll leave that for another day.

<img width="1421" alt="Screenshot 2025-05-19 at 13 25 55" src="https://github.com/user-attachments/assets/33f123fd-c765-4c68-a79f-800dce23a444" />

Fixes https://github.com/Automattic/remote-data-blocks/issues/541

