### PR TITLE
Docs: fix broken screen recording

### DIFF
--- a/docs/concepts/helper-blocks.md
+++ b/docs/concepts/helper-blocks.md
@@ -6,7 +6,7 @@ Remote Data Blocks adds some accessory blocks for bindings, listed below.
 
 Use this block to bind to HTML from a remote data source. This block only works when placed inside a remote data block container and bound to a field containing HTML.
 
-![Screen recording showing the insertion and binding of a Remote HTML Block in the editor](./block-insert-remote-html.gif)
+![Screen recording showing the insertion and binding of a Remote HTML Block in the editor](https://raw.githubusercontent.com/Automattic/remote-data-blocks/trunk/docs/concepts/block-insert-remote-html.gif)
 
 Fields defined by a query’s `output_schema` must have type `html` in order to be available to Remote HTML blocks:
 


### PR DESCRIPTION
While the gif works within github, it fails when viewed through: https://remotedatablocks.com/docs/concepts/helper-blocks/

See:

![Screenshot 2025-05-20 at 10 29 46](https://github.com/user-attachments/assets/e0103744-157a-4d81-b1cc-79bcf1750e8e)
