### PR TITLE
Remove whitespace

### DIFF
--- a/inc/Integrations/GenericHttp/templates/block_registration.template
+++ b/inc/Integrations/GenericHttp/templates/block_registration.template
@@ -36,4 +36,3 @@ function register_http_remote_data_block(): void {
 }
 
 add_action( 'init', __NAMESPACE__ . '\\register_http_remote_data_block' );
-


### PR DESCRIPTION
Otherwise, the output generate looks like this:

![Screenshot 2025-05-20 at 16 59 17](https://github.com/user-attachments/assets/5e95c21f-7ccd-437e-a571-e64ba46a0bd1)
