### PR TITLE
Improve `MockQueryRunner` to reduce complexity

### DIFF
--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -55,7 +55,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_unknown_mode_with_error(): void {
-		$mock_qr = $this->create_mock_query_runner_with_result( new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_qr = $this->create_mock_query_runner_with_error( new WP_Error( 'test-error', 'Test Error' ) );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -73,7 +73,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_error_mode(): void {
-		$mock_qr = $this->create_mock_query_runner_with_result( new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_qr = $this->create_mock_query_runner_with_error( new WP_Error( 'test-error', 'Test Error' ) );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -109,7 +109,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_no_results_for_error_mode(): void {
-		$mock_qr = $this->create_mock_query_runner_with_results();
+		$mock_qr = new MockQueryRunner();
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -145,7 +145,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_error_for_empty_mode(): void {
-		$mock_qr = $this->create_mock_query_runner_with_result( new WP_Error( 'test-error', 'Test Error' ) );
+		$mock_qr = $this->create_mock_query_runner_with_error( new WP_Error( 'test-error', 'Test Error' ) );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -163,7 +163,8 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_empty_mode(): void {
-		$mock_qr = $this->create_mock_query_runner_with_results();
+		$mock_qr = new MockQueryRunner();
+		$mock_qr->setResults( [] );
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -181,7 +182,7 @@ class BlockBindingsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_render_fallback_content_with_unknown_mode_with_empty_results(): void {
-		$mock_qr = $this->create_mock_query_runner_with_results();
+		$mock_qr = new MockQueryRunner();
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
@@ -260,7 +261,11 @@ class BlockBindingsTest extends TestCase {
 				return parent::execute( $query, $input_variables );
 			}
 		};
-		$mock_qr->addResult( 'output_field', 'Test Output Value' );
+		$mock_qr->setResults( [
+			[
+				self::MOCK_OUTPUT_FIELD_NAME => [ 'value' => 'Test Output Value' ],
+			],
+		] );
 
 		$block = [
 			'context' => $this->create_block_context( [
@@ -301,7 +306,11 @@ class BlockBindingsTest extends TestCase {
 				return parent::execute( $query, $input_variables );
 			}
 		};
-		$mock_qr->addResult( 'output_field', 'Test Output Value' );
+		$mock_qr->setResults( [
+			[
+				self::MOCK_OUTPUT_FIELD_NAME => [ 'value' => 'Test Output Value' ],
+			],
+		] );
 
 		$block = [
 			'context' => $this->create_block_context( [
@@ -501,24 +510,28 @@ class BlockBindingsTest extends TestCase {
 	}
 
 	/**
-	 * Creates a mock query runner with the specified result.
+	 * Creates a mock query runner that will return a result once.
 	 *
-	 * @param mixed $result The result to return from the query runner.
+	 * @param mixed $value The result value to return from the query runner.
 	 */
-	private function create_mock_query_runner_with_result( mixed $result ): MockQueryRunner {
+	private function create_mock_query_runner_with_result( mixed $value = null ): MockQueryRunner {
 		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( self::MOCK_OUTPUT_FIELD_NAME, $result );
+		$mock_qr->setResults( [
+			[
+				self::MOCK_OUTPUT_FIELD_NAME => [ 'value' => $value ],
+			],
+		] );
 		return $mock_qr;
 	}
 
 	/**
-	 * Creates a mock query runner with the specified results.
+	 * Creates a mock query runner that will return an error once.
 	 *
-	 * @param array $results The results to return from the query runner.
+	 * @param WP_Error $error The error to return from the query runner.
 	 */
-	private function create_mock_query_runner_with_results( array $results = [] ): MockQueryRunner {
+	private function create_mock_query_runner_with_error( WP_Error $error ): MockQueryRunner {
 		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResults( $results );
+		$mock_qr->setResults( $error );
 		return $mock_qr;
 	}
 

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -113,7 +113,7 @@ class BlockBindingsTest extends TestCase {
 		$mock_block_config = $this->create_mock_block_config( $mock_qr );
 		$this->create_mock_config_store( $mock_block_config );
 
-		$this->assertFalse( BlockBindings::should_render_fallback_content(
+		$this->assertTrue( BlockBindings::should_render_fallback_content(
 			$this->create_block_context( [
 				'test_input_field' => 'test_value',
 				'another_input_field' => 'another_value',

--- a/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
+++ b/tests/inc/Integrations/VipBlockDataApi/VipBlockDataApiTest.php
@@ -146,8 +146,12 @@ class VipBlockDataApiTest extends TestCase {
 		$expected2 = 'Comedor del Presidente';
 
 		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( 'title', $expected1 );
-		$mock_qr->addResult( 'location', $expected2 );
+		$mock_qr->setResults( [
+			[
+				'title' => [ 'value' => $expected1 ],
+				'location' => [ 'value' => $expected2 ],
+			],
+		] );
 
 		$mock_query = MockQuery::create( [ 'query_runner' => $mock_qr ] );
 		register_remote_data_block( [
@@ -168,13 +172,12 @@ class VipBlockDataApiTest extends TestCase {
 		$this->assertSame( "President's dining hall", $result['innerBlocks'][1]['attributes']['content'] );
 	}
 
-	public function testResolveRemoteDataFallsBackToDbOnQuery(): void {
+	public function testResolveRemoteDataFallsBackToSerializedDataOnError(): void {
 		$error = new \WP_Error( 'rdb-uh-oh', 'uh-oh!' );
 		$mock_qr = new MockQueryRunner();
-		$mock_qr->addResult( 'title', 'Happy happy hour! No networking!' );
-		$mock_qr->addResult( 'location', $error );
-
+		$mock_qr->setResults( $error );
 		$mock_query = MockQuery::create( [ 'query_runner' => $mock_qr ] );
+
 		register_remote_data_block( [
 			'title' => 'Events',
 			'render_query' => [
@@ -189,11 +192,11 @@ class VipBlockDataApiTest extends TestCase {
 		$result = VipBlockDataApi::resolve_remote_data( self::$sourced_block1, 'remote-data-blocks/events', 12, self::$parsed_block1 );
 		$logs = $mock_logger->getLogs();
 
-		// The first binding is successful.
+		// The binding callback results in an error.
 		$this->assertSame(
 			[
-				'level' => 'info',
-				'message' => 'Successfully resolved block binding',
+				'level' => 'error',
+				'message' => 'uh-oh!',
 				'context' => [
 					'block_name' => 'core/paragraph',
 					'block_info' => [
@@ -202,32 +205,13 @@ class VipBlockDataApiTest extends TestCase {
 						],
 					],
 					'remote_data_block_name' => 'remote-data-blocks/events',
+					'error' => $error,
 					'type' => 'block-binding',
 				],
 			],
 			$logs[0]
 		);
-
-		// The first binding results in an error.
-		$this->assertSame(
-			[
-				'level' => 'error',
-				'message' => 'uh-oh!',
-				'context' => [
-					'block_name' => 'core/heading',
-					'block_info' => [
-						'source_args' => [
-							'field' => 'location',
-						],
-					],
-					'remote_data_block_name' => 'remote-data-blocks/events',
-					'error' => $error,
-					'type' => 'block-binding',
-				],
-			],
-			$logs[1]
-		);
-		$this->assertSame( 'Happy happy hour! No networking!', $result['innerBlocks'][0]['attributes']['content'] );
+		$this->assertSame( 'Happy hour &amp;amp; networking', $result['innerBlocks'][0]['attributes']['content'] );
 		$this->assertSame( 'President&#039;s dining hall', $result['innerBlocks'][1]['attributes']['content'] );
 	}
 }

--- a/tests/inc/Mocks/MockQueryRunner.php
+++ b/tests/inc/Mocks/MockQueryRunner.php
@@ -7,40 +7,31 @@ use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
 use WP_Error;
 
 class MockQueryRunner extends QueryRunner {
-	/** @var array<array|WP_Error> */
-	private array $query_results = [];
+	/** @var array|WP_Error|null */
+	protected array|WP_Error|null $query_results = null;
 
 	/** @var array<mixed> */
 	private array $execute_call_inputs = [];
 
-	public function addResult( string $field, mixed $result ): void {
-		if ( $result instanceof WP_Error ) {
-			array_push( $this->query_results, $result );
+	public function setResults( array|WP_Error $results ): void {
+		if ( $results instanceof WP_Error ) {
+			$this->query_results = $results;
 			return;
 		}
 
-		array_push( $this->query_results, [
+		$this->query_results = [
 			'is_collection' => false,
-			'results' => [
-				[
-					'result' => [
-						$field => [ 'value' => $result ],
-					],
-				],
-			],
-		] );
-	}
-
-	public function addResults( array $results ): void {
-		array_push( $this->query_results, [
-			'is_collection' => true,
-			'results' => $results,
-		] );
+			'results' => array_map( function ( $result ): array {
+				return [
+					'result' => $result,
+				];
+			}, $results ),
+		];
 	}
 
 	public function execute( HttpQueryInterface $query, array $input_variables ): array|WP_Error {
 		array_push( $this->execute_call_inputs, $input_variables );
-		return array_shift( $this->query_results ) ?? new WP_Error( 'no-results', 'No results available.' );
+		return $this->query_results ?? new WP_Error( 'no-results', 'No results available.' );
 	}
 
 	public function getLastExecuteCallInput(): array|null {


### PR DESCRIPTION
Currently `MockQueryRunner` exposes a number of methods to push results into an execution queue. This is seldom used and can result in confusion around when a result is actually popped off the queue—especially with in-memory caching. It also makes it difficult to produce edge states, like non-error empty query results.

Instead, we can be more direct and expose a single method to set the results. If a test case navigates multiple query executions, it can call the method more than once and control its timing.

This has surfaced one bug in test logic in e3d1ea87dabb2d7068793261983be30b5ba0c877.