### PR TITLE
Fix Block Bindings source label was overridden warning

### DIFF
--- a/src/block-editor/binding-sources/remote-data-binding.ts
+++ b/src/block-editor/binding-sources/remote-data-binding.ts
@@ -2,7 +2,7 @@ import { registerBlockBindingsSource } from '@wordpress/blocks';
 
 registerBlockBindingsSource( {
 	name: 'remote-data/binding',
-	label: 'Remote Data Binding',
+	label: 'Remote Data Blocks',
 	usesContext: [ 'remote-data-blocks/remoteData' ],
 	getValues() {
 		return {};


### PR DESCRIPTION
### Description

Currently, there is a warning being spat out by the plugin every time a post is loaded in the editor that looks as follows:

![CleanShot 2025-05-30 at 13 30 27](https://github.com/user-attachments/assets/bbfef697-2c15-4420-9d49-8d1d062b783f)

This is because our label is different between the PHP and TS code. So I've united this to be `Remote Data Blocks` just like it is on the PHP code.