### PR TITLE
Bugfix: Restrict `serialized_config_for` to classes (not interfaces)

### DIFF
--- a/inc/Validation/ConfigSchemas.php
+++ b/inc/Validation/ConfigSchemas.php
@@ -3,8 +3,8 @@
 namespace RemoteDataBlocks\Validation;
 
 use RemoteDataBlocks\Validation\Types;
-use RemoteDataBlocks\Config\DataSource\HttpDataSourceInterface;
-use RemoteDataBlocks\Config\Query\HttpQueryInterface;
+use RemoteDataBlocks\Config\DataSource\HttpDataSource;
+use RemoteDataBlocks\Config\Query\HttpQuery;
 use RemoteDataBlocks\Config\Query\QueryInterface;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunnerInterface;
 use RemoteDataBlocks\Editor\BlockManagement\ConfigRegistry;
@@ -89,7 +89,7 @@ final class ConfigSchemas {
 			'render_query' => Types::object( [
 				'query' => Types::one_of(
 					Types::instance_of( QueryInterface::class ),
-					Types::serialized_config_for( HttpQueryInterface::class ),
+					Types::serialized_config_for( HttpQuery::class ),
 				),
 			] ),
 			'selection_queries' => Types::nullable(
@@ -98,7 +98,7 @@ final class ConfigSchemas {
 						'display_name' => Types::nullable( Types::string() ),
 						'query' => Types::one_of(
 							Types::instance_of( QueryInterface::class ),
-							Types::serialized_config_for( HttpQueryInterface::class ),
+							Types::serialized_config_for( HttpQuery::class ),
 						),
 						'type' => Types::enum(
 							ConfigRegistry::LIST_QUERY_KEY,
@@ -158,8 +158,8 @@ final class ConfigSchemas {
 		return Types::object( [
 			'cache_ttl' => Types::nullable( Types::one_of( Types::callable(), Types::integer(), Types::null() ) ),
 			'data_source' => Types::one_of(
-				Types::instance_of( HttpDataSourceInterface::class ),
-				Types::serialized_config_for( HttpDataSourceInterface::class ),
+				Types::instance_of( HttpDataSource::class ),
+				Types::serialized_config_for( HttpDataSource::class ),
 			),
 			'endpoint' => Types::nullable( Types::one_of( Types::callable(), Types::url() ) ),
 			'image_url' => Types::nullable( Types::image_url() ),

--- a/inc/Validation/Types.php
+++ b/inc/Validation/Types.php
@@ -227,6 +227,10 @@ final class Types {
 	// This type indicates that the value is a serialized array that can be used
 	// to inflate a class instance, e.g., HttpQuery::from_array( $value ).
 	public static function serialized_config_for( string $class_ref ): array {
+		if ( ! class_exists( $class_ref ) ) {
+			throw new \InvalidArgumentException( sprintf( "Class '%s' does not exist.", esc_html( $class_ref ) ) );
+		}
+
 		return self::generate_non_primitive_type( 'serialized_config_for', $class_ref );
 	}
 

--- a/inc/Validation/Validator.php
+++ b/inc/Validation/Validator.php
@@ -226,18 +226,13 @@ final class Validator implements ValidatorInterface {
 					return $this->create_error( sprintf( 'targets class "%s" that does not implement ArraySerializableInterface', $class_ref ), $path );
 				}
 
-				// The config must provide a `__class` property so that we know which
-				// class to inflate. This allows values to target subclasses of the
-				// specified class and also provides disambiguation when the type is
-				// used in a union type (one_of).
+				// The config can provide a `__class` property to target a subclass of
+				// the specified class.
 				$class_property = ArraySerializableInterface::CLASS_REF_ATTRIBUTE;
-				$subclass = $value[ $class_property ] ?? null;
-				if ( null === $subclass ) {
-					return $this->create_error( sprintf( 'does not provide a %s property', $class_property ), $path );
-				}
+				$subclass = $value[ $class_property ] ?? $class_ref;
 
 				if ( ! class_exists( $subclass ) ) {
-					return $this->create_error( sprintf( 'targets non-existent subclass "%s"', $subclass ), $path );
+					return $this->create_error( sprintf( 'targets non-existent class "%s"', $subclass ), $path );
 				}
 
 				if ( $subclass !== $class_ref && ! is_subclass_of( $subclass, $class_ref, true ) ) {

--- a/tests/inc/Validation/ValidatorTest.php
+++ b/tests/inc/Validation/ValidatorTest.php
@@ -713,6 +713,18 @@ class ValidatorTest extends TestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( "\$serialized_config['config']['extra_value'] must be a string", $result->get_error_message() );
+
+		$result = $validator->validate( [
+			'config' => [
+				'__class' => WP_Error::class, // not a subclass of MockSerializableClass
+				'boolean_value' => true,
+				'enum_value' => 'foo',
+				'string_value' => 'hello, world!',
+			],
+		] );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( "\$serialized_config['config'] targets subclass \"WP_Error\" that does not match or extend target class \"RemoteDataBlocks\Tests\Mocks\MockSerializableClass\"", $result->get_error_message() );
 	}
 
 	public function testStringMatching(): void {


### PR DESCRIPTION
We presently allow interfaces to be targets for `Types::serialized_config_for`, which is invalid because they can never implement `ArraySerializable`.