### PR TITLE
Allow auth-less Shopify Mock Shop

### DIFF
--- a/inc/Integrations/Shopify/ShopifyDataSource.php
+++ b/inc/Integrations/Shopify/ShopifyDataSource.php
@@ -15,7 +15,7 @@ class ShopifyDataSource extends GenericHttpDataSource {
 	protected static function get_service_config_schema(): array {
 		return Types::object( [
 			'__version' => Types::integer(),
-			'access_token' => Types::skip_sanitize( Types::string() ),
+			'access_token' => Types::nullable( Types::skip_sanitize( Types::string() ) ),
 			'display_name' => Types::string(),
 			'enable_blocks' => Types::nullable( Types::boolean() ),
 			'store_name' => Types::string(),
@@ -23,13 +23,24 @@ class ShopifyDataSource extends GenericHttpDataSource {
 	}
 
 	protected static function map_service_config( array $service_config ): array {
+		// Extract the store name from the full URL, if provided.
+		$store_name = preg_replace( '#^https?://#', '', $service_config['store_name'] );
+		$store_name = preg_replace( '#\.myshopify\.com.*#', '', $store_name );
+
+		$endpoint = sprintf( 'https://%s.myshopify.com/api/2024-04/graphql.json', $store_name );
+
+		// Special case for the Shopify Mock Store, which uses a different endpoint.
+		if ( 'mock.shop' === $store_name ) {
+			$endpoint = 'https://mock.shop/api';
+		}
+
 		return [
 			'display_name' => $service_config['display_name'],
-			'endpoint' => 'https://' . $service_config['store_name'] . '.myshopify.com/api/2024-04/graphql.json',
+			'endpoint' => $endpoint,
 			'image_url' => plugins_url( './assets/shopify_logo_black.png', __FILE__ ),
 			'request_headers' => [
 				'Content-Type' => 'application/json',
-				'X-Shopify-Storefront-Access-Token' => $service_config['access_token'],
+				'X-Shopify-Storefront-Access-Token' => $service_config['access_token'] ?? '',
 			],
 		];
 	}

--- a/src/data-sources/api-clients/shopify.ts
+++ b/src/data-sources/api-clients/shopify.ts
@@ -1,16 +1,35 @@
 import { __, sprintf } from '@wordpress/i18n';
 
+export const MOCK_SHOP_STORE = 'mock.shop';
+
 export class ShopifyApi {
-	constructor( private store: string, private token: string ) {}
+	constructor( private store: string, private token?: string ) {
+		if ( ! token && store !== MOCK_SHOP_STORE ) {
+			throw new Error( 'Access token is required' );
+		}
+	}
 
 	private getGraphqlEndpointUrl() {
-		if ( ! this.store ) {
-			throw new Error( 'No store provided' );
+		// Special case for the Shopify Mock Store, which uses a different endpoint.
+		if ( MOCK_SHOP_STORE === this.store ) {
+			return 'https://mock.shop/api';
 		}
+
+		if ( this.store.endsWith( '.myshopify.com' ) ) {
+			// If the store already has the .myshopify.com domain, use it directly.
+			return `https://${ this.store }/api/2024-07/graphql.json`;
+		}
+
 		return `https://${ this.store }.myshopify.com/api/2024-07/graphql.json`;
 	}
 
-	private getAuthHeaders() {
+	private getAuthHeaders(): Record< string, string > {
+		if ( MOCK_SHOP_STORE === this.store ) {
+			return {
+				'Content-Type': 'application/json',
+			};
+		}
+
 		if ( ! this.token ) {
 			throw new Error( 'No token provided' );
 		}
@@ -45,10 +64,10 @@ export class ShopifyApi {
 	public async shopName(): Promise< string > {
 		const result = await this.query< { data?: { shop?: { name: string } } } >(
 			`query {
-                shop {
-                    name
-                }
-            }`
+				shop {
+					name
+				}
+			}`
 		);
 		return result.data?.shop?.name ?? '';
 	}

--- a/src/data-sources/hooks/useShopify.tsx
+++ b/src/data-sources/hooks/useShopify.tsx
@@ -1,8 +1,8 @@
 import { useDebounce } from '@wordpress/compose';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-import { ShopifyApi } from '@/data-sources/api-clients/shopify';
+import { ShopifyApi, MOCK_SHOP_STORE } from '@/data-sources/api-clients/shopify';
 import { getConnectionMessage } from '@/data-sources/utils';
 import { useQuery } from '@/hooks/useQuery';
 
@@ -14,13 +14,18 @@ export interface ShopifyConnection {
 export const useShopifyShopName = ( store: string, token: string ): ShopifyConnection => {
 	const [ connectionMessage, setConnectionMessage ] = useState< null | JSX.Element >( null );
 
-	const api = useMemo( () => new ShopifyApi( store, token ), [ store, token ] );
 	const queryFn = useCallback( async () => {
-		if ( ! ( store && token ) ) {
+		if ( ! store ) {
 			return null;
 		}
-		return api.shopName();
-	}, [ api, store, token ] );
+
+		if ( ! token && store !== MOCK_SHOP_STORE ) {
+			return null;
+		}
+
+		const api = new ShopifyApi( store, token );
+		return await api.shopName();
+	}, [ store, token ] );
 
 	const {
 		data: shopName,

--- a/src/data-sources/shopify/ShopifySettings.tsx
+++ b/src/data-sources/shopify/ShopifySettings.tsx
@@ -2,7 +2,8 @@ import { TextControl } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-import { DataSourceForm } from '../components/DataSourceForm';
+import { MOCK_SHOP_STORE } from '@/data-sources/api-clients/shopify';
+import { DataSourceForm } from '@/data-sources/components/DataSourceForm';
 import PasswordInputControl from '@/data-sources/components/PasswordInputControl';
 import { ConfigSource } from '@/data-sources/constants';
 import { useDataSources } from '@/data-sources/hooks/useDataSources';
@@ -33,6 +34,10 @@ export const ShopifySettings = ( {
 	);
 
 	const shouldAllowSubmit = useMemo( () => {
+		if ( MOCK_SHOP_STORE === state.store_name ) {
+			return true;
+		}
+
 		return state.store_name && state.access_token;
 	}, [ state.store_name, state.access_token ] );
 
@@ -45,10 +50,11 @@ export const ShopifySettings = ( {
 			handleOnChange( 'store_name', '' );
 			return;
 		}
-		const urlPattern = /^https?:\/\/([^.]+)\.myshopify\.com$/;
-		const match = shopNameInput.match( urlPattern );
-		const extractedShopName = match ? match[ 1 ] : shopNameInput;
-		handleOnChange( 'store_name', extractedShopName ?? '' );
+
+		// Extract hostname
+		const url = new URL( `https://${ shopNameInput.trim().replace( /^https?:\/\//, '' ) }` );
+
+		handleOnChange( 'store_name', url.hostname );
 	};
 
 	const onSaveClick = async () => {
@@ -81,10 +87,10 @@ export const ShopifySettings = ( {
 					label={ __( 'Store', 'remote-data-blocks' ) }
 					onChange={ onShopNameChange }
 					value={ state.store_name ?? '' }
-					placeholder="https://your-store.myshopify.com"
+					placeholder="your-store.myshopify.com"
 					help={
 						<>
-							{ __( 'Example: https://' ) }
+							{ __( 'Example: ' ) }
 							<strong>{ __( 'your-store' ) }</strong>
 							{ __( '.myshopify.com' ) }
 						</>
@@ -94,8 +100,10 @@ export const ShopifySettings = ( {
 					__nextHasNoMarginBottom
 				/>
 				<PasswordInputControl
+					disabled={ MOCK_SHOP_STORE === state.store_name }
 					label={ __( 'Access Token', 'remote-data-blocks' ) }
 					onChange={ onTokenInputChange }
+					placeholder={ MOCK_SHOP_STORE === state.store_name ? 'No token required' : undefined }
 					value={ state.access_token }
 					help={ connectionMessage }
 				/>


### PR DESCRIPTION
A side-effect improvement from my work on better docs and prompts. We can support [Shopify's Mock Shop](https://mock.shop) more directly.


https://github.com/user-attachments/assets/19738129-a914-41f3-9cd7-a95755adf0c7

