### PR TITLE
Ensure error with safe message extraction

### DIFF
--- a/src/blocks/remote-data-container/hooks/useRemoteData.ts
+++ b/src/blocks/remote-data-container/hooks/useRemoteData.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { REMOTE_DATA_REST_API_URL } from '@/blocks/remote-data-container/config/constants';
 import { usePaginationVariables } from '@/blocks/remote-data-container/hooks/usePaginationVariables';
 import { useSearchVariables } from '@/blocks/remote-data-container/hooks/useSearchVariables';
+import { ensureError } from '@/utils/errors';
 import { memoizeFn } from '@/utils/function';
 import { isQueryInputValid, validateQueryInput } from '@/utils/input-validation';
 import { getBlockConfig } from '@/utils/localized-block-data';
@@ -198,14 +199,14 @@ export function useRemoteData( {
 		try {
 			inputs.forEach( input => validateQueryInput( input, inputVariables ) );
 		} catch ( err: unknown ) {
-			reset( new Error( String( err ) ) );
+			reset( ensureError( err ) );
 			return;
 		}
 
 		setLoading( true );
 
 		const remoteData = await fetchRemoteData( requestData ).catch( ( err: unknown ) => {
-			reset( new Error( String( err ) ) );
+			reset( ensureError( err ) );
 		} );
 
 		if ( ! remoteData ) {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,23 @@
 export abstract class DisplayableError extends Error {
 	public abstract toString(): string;
 }
+
+export function ensureError( error: unknown ): Error {
+	if ( error instanceof Error ) {
+		return error;
+	}
+
+	if ( null === error || undefined === error ) {
+		return new Error( 'An unknown error occurred' );
+	}
+
+	if ( typeof error === 'string' ) {
+		return new Error( error );
+	}
+
+	if ( 'object' === typeof error && 'message' in error ) {
+		return new Error( String( error.message ) );
+	}
+
+	return new Error( String( error ) );
+}

--- a/tests/src/utils/errors.test.ts
+++ b/tests/src/utils/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { ensureError } from '@/utils/errors';
+
+describe( 'ensureError', () => {
+	it( 'should return the error if it is an instance of Error', () => {
+		const error = new Error( 'Test error' );
+		expect( ensureError( error ) ).toBe( error );
+	} );
+
+	it( 'should return a new Error if the input is null', () => {
+		expect( ensureError( null ) ).toEqual( new Error( 'An unknown error occurred' ) );
+	} );
+
+	it( 'should return a new Error if the input is undefined', () => {
+		expect( ensureError( undefined ) ).toEqual( new Error( 'An unknown error occurred' ) );
+	} );
+
+	it( 'should return a new Error if the input is a string', () => {
+		const message = 'This is an error message';
+		expect( ensureError( message ) ).toEqual( new Error( message ) );
+	} );
+
+	it( 'should return a new Error if the input is an object with a message property', () => {
+		const errorObject = { message: 'Object error message' };
+		expect( ensureError( errorObject ) ).toEqual( new Error( 'Object error message' ) );
+	} );
+
+	it( 'should return a new Error for any other type of input', () => {
+		const numberInput = 42;
+		expect( ensureError( numberInput ).message ).toEqual( '42' );
+	} );
+} );


### PR DESCRIPTION
In `useRemoteData`, error messages were getting swallowed because they were being stringified without first trying to inspect them and extract an error message. This introduces an `ensureError` function that inspects and extracts the error message when present.