### PR TITLE
Pass `$raw_response_data` to `generate` functions

### DIFF
--- a/docs/extending/query-output-schema.md
+++ b/docs/extending/query-output-schema.md
@@ -7,7 +7,9 @@ Note that the output schema may require updates whenever the shape or schema of 
 ## Properties
 
 - `format` (optional): A callable function that formats the output variable value.
-- `generate` (optional): A callable function that generates or extracts the output variable value from the response, as an alternative to `path`.
+- `generate` (optional): A callable function that generates or extracts the output variable value from the response, as an alternative to `path`. It receives two parameters:
+  - `array $data`: The data returned by the API, which is contains the data returned from the API at the current "level" (e.g., after the root `path` has been applied, if present).
+  - `array $raw_response_data`: The "raw" response data returned by the API, which includes the input variables (`$raw_response_data['input_variables']`), response metadata (`$raw_response_data['metadata']`), and the entire API response before any preprocessing.
 - `is_collection` (optional, default `false`): A boolean indicating whether the response data is a collection. If false, only a single item will be returned.
 - `name` (optional): The human-friendly display name of the output variable.
 - `default_value` (optional): The default value for the output variable.
@@ -66,7 +68,7 @@ And the corresponding `output_schema` definition might look like this:
 		'city_state' => [
 			'name' => 'City, State',
 			'default_value' => 'Unknown',
-			'generate' => function( array $data ): string|null {
+			'generate' => function( array $data, array $raw_response_data ): string|null {
 				if ( empty( $data['places'] ) ) {
 					return null;
 				}
@@ -82,7 +84,7 @@ And the corresponding `output_schema` definition might look like this:
 - The `is_collection` property indicates whether the output represents a single entity or a collection of entities. In this case, it is set to `false` because the API returns a single entity.
 - The `type` property at the root level begins the type definition. The `zip_code` and `city_state` array keys are "slugs" that identify the field. The array values define types that describe how to extract a value for those fields.
 - The `zip_code` field is extracted via a [JSONPath](http://jsonpath.com) expression defined in the `path` property.
-- The `city_state` field provides a callable via the `generate` property. That function receives the data and combines two elements to form the value.
+- The `city_state` field provides a callable via the `generate` property. That function receives the response data and combines two elements to form the value.
 - A `default_value` property provides a value that will be used if the provided `path` expression or `generate` function resolve to a null value.
 
 The result of applying this output schema to the example JSON response is:

--- a/example/templates/rest-api-block/rest-api-block.php
+++ b/example/templates/rest-api-block/rest-api-block.php
@@ -60,10 +60,14 @@ function register_basic_rest_api_remote_data_block(): void {
 					// Instead of a `path`, we provide a `generate` function to create the
 					// image URL. The `$data` parameter contains the data returned from the
 					// API at this "level" (e.g., after the root `path` has been applied).
-					'generate' => static function ( $data ): string {
-						return 'https://example.com/images/' . $data['image_id'] . '.jpg';
+					//
+					// It also receives the raw response data, which can be useful if you
+					// need to access input variables or other data not available in the
+					// response.
+					'generate' => static function ( array $data, array $raw_response_data ): string {
+						$item_id = $data['id'] ?? $raw_response_data['input_variables']['id'];
+						return 'https://example.com/images/items/' . $item_id . '.jpg';
 					},
-					'path' => '$.image_url',
 				],
 				// TODO: Add more fields as needed.
 			],

--- a/inc/Config/Query/HttpQuery.php
+++ b/inc/Config/Query/HttpQuery.php
@@ -145,6 +145,9 @@ class HttpQuery extends ArraySerializable implements HttpQueryInterface {
 
 	/**
 	 * Preprocess the response data before it is passed to the response parser.
+	 * This is normally not necessary since the output schema allows for flexible
+	 * data parsing and value extraction, but it can be useful when the response
+	 * shape needs significant transformation.
 	 *
 	 * @param mixed $response_data The raw deserialized response data.
 	 * @param array $input_variables The input variables for this query.

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -152,6 +152,7 @@ class QueryRunner implements QueryRunnerInterface {
 		$raw_response_string = $response->getBody()->getContents();
 
 		return [
+			'input_variables' => $input_variables,
 			'metadata' => [
 				'age' => $response->getHeaderLine( RdbCacheStrategy::CACHE_AGE_RESPONSE_HEADER ),
 				'status_code' => $response_code,
@@ -164,16 +165,17 @@ class QueryRunner implements QueryRunnerInterface {
 	 * Get the response metadata for the query, which are available as targets for
 	 * inline bindings.
 	 *
-	 * @param array $response_metadata The response metadata returned by the query runner.
-	 * @param array $query_results     The results of the query.
+	 * @param HttpQueryInterface $query The query.
+	 * @param array $raw_response_data  The raw response data from `get_raw_response_data`.
+	 * @param array $query_results      The results of the query.
 	 * @return array array<string, array{
 	 *   name:  string,
 	 *   type:  string,
 	 *   value: string|int|null,
 	 * }>,
 	 */
-	protected function get_response_metadata( HttpQueryInterface $query, array $response_metadata, array $query_results ): array {
-		$age = intval( $response_metadata['age'] ?? 0 );
+	protected function get_response_metadata( HttpQueryInterface $query, array $raw_response_data, array $query_results ): array {
+		$age = intval( $raw_response_data['metadata']['age'] ?? 0 );
 		$time = time() - $age;
 
 		$query_response_metadata = [
@@ -194,12 +196,12 @@ class QueryRunner implements QueryRunnerInterface {
 		 * inline bindings.
 		 *
 		 * @param array $query_response_metadata The query response metadata.
-		 * @param HttpQueryInterface $query The query context.
-		 * @param array $response_metadata The response metadata returned by the query runner.
+		 * @param HttpQueryInterface $query The query.
+		 * @param array $raw_response_data The raw response data from `get_raw_response_data`.
 		 * @param array $query_results The results of the query.
 		 * @return array The filtered query response metadata.
 		 */
-		return apply_filters( 'remote_data_blocks_query_response_metadata', $query_response_metadata, $query, $response_metadata, $query_results );
+		return apply_filters( 'remote_data_blocks_query_response_metadata', $query_response_metadata, $query, $raw_response_data, $query_results );
 	}
 
 	/**
@@ -261,9 +263,9 @@ class QueryRunner implements QueryRunnerInterface {
 		// ensures a consistent response shape. The requestor is expected to inspect
 		// is_collection and unwrap if necessary.
 		$parser = new QueryResponseParser();
-		$results = $parser->parse( $response_data, $output_schema );
+		$results = $parser->parse( $response_data, $output_schema, $raw_response_data );
 		$results = $is_collection ? $results : [ $results ];
-		$metadata = $this->get_response_metadata( $query, $raw_response_data['metadata'], $results );
+		$metadata = $this->get_response_metadata( $query, $raw_response_data, $results );
 
 		// Pagination schema defines how to extract pagination data from the response.
 		$pagination = null;

--- a/tests/inc/Config/QueryResponseParserTest.php
+++ b/tests/inc/Config/QueryResponseParserTest.php
@@ -86,6 +86,52 @@ final class QueryResponseParserTest extends TestCase {
 		$this->assertEquals( 'Charlie Brown', $result[0]['result']['fullName']['value'] );
 	}
 
+	public function test_generate_callback_with_raw_response_data(): void {
+		$data = [
+			[
+				'firstName' => 'Charlie',
+				'lastName' => 'Brown',
+			],
+		];
+		$raw_response_data = [
+			'input_variables' => [
+				'comic' => 'Peanuts',
+			],
+			'metadata' => [
+				'request_id' => '12345',
+			],
+			'response_data' => [
+				'data' => $data,
+			],
+		];
+
+		$schema = [
+			'is_collection' => true,
+			'type' => [
+				'fullName' => [
+					'type' => 'string',
+					'generate' => function ( $item, $raw_response_data ) {
+						return sprintf(
+							'%s %s (from %s, request ID: %s)',
+							$item['firstName'],
+							$item['lastName'],
+							$raw_response_data['input_variables']['comic'] ?? 'Unknown Comic',
+							$raw_response_data['metadata']['request_id'] ?? 'Unknown Request ID'
+						);
+					},
+				],
+			],
+		];
+
+		$result = $this->parser->parse( $data, $schema, $raw_response_data );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertArrayHasKey( 'result', $result[0] );
+		$this->assertArrayHasKey( 'uuid', $result[0] );
+		$this->assertEquals( 'Charlie Brown (from Peanuts, request ID: 12345)', $result[0]['result']['fullName']['value'] );
+	}
+
 	public function test_format_callback(): void {
 		$data = [
 			[ 'price' => 1234.56 ],


### PR DESCRIPTION
Pass `$raw_response_data` to `generate` functions in order to give them access to the query's input variables, response metadata, and other future contextual or run-time data that is not available in scope when the `generate` function is defined.