### PR TITLE
Remove the click-to-copy data attribute

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,7 @@
       "request": "launch",
       "port": 9003,
       "pathMappings": {
-        "/var/www/html/wp-content/plugins/remote-data-blocks": "${workspaceFolder}/",
-        "/var/www/html/wp-content/plugins/example": "${workspaceFolder}/example"
+        "/var/www/html/wp-content/plugins/remote-data-blocks": "${workspaceFolder}/"
       }
     },
     {

--- a/example/blocks/github-markdown-block/inc/markdown-links.php
+++ b/example/blocks/github-markdown-block/inc/markdown-links.php
@@ -53,6 +53,17 @@ function update_markdown_links( string $html, string $current_file_path = '' ): 
 		}
 	}
 
+	// Remove the data attributes that GitHub uses for click-to-copy functionality.
+	// The DOM parser is unable to keep them encoded correctly.
+	$click_to_copy_attribute = 'data-snippet-clipboard-copy-content';
+	$nodes = $xpath->query( sprintf( '//*[@%s]', $click_to_copy_attribute ) );
+	foreach ( $nodes as $node ) {
+		if ( ! $node instanceof DOMElement ) {
+			continue;
+		}
+		$node->removeAttribute( $click_to_copy_attribute );
+	}
+
 	// Save and return the updated HTML without the XML declaration.
 	return preg_replace( '/^<\?xml[^>]+\?>/', '', $dom->saveHTML() );
 }

--- a/example/blocks/github-markdown-block/inc/markdown-links.php
+++ b/example/blocks/github-markdown-block/inc/markdown-links.php
@@ -23,7 +23,7 @@ function update_markdown_links( string $html, string $current_file_path = '' ): 
 	$dom = new DOMDocument();
 
 	// Convert HTML to UTF-8 using htmlspecialchars instead of mb_convert_encoding
-	$html = '<?xml encoding="UTF-8">' . $html;
+	$html = '<?xml encoding="UTF-8"?>' . $html;
 
 	// Suppress errors due to malformed HTML
 	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
@@ -53,8 +53,8 @@ function update_markdown_links( string $html, string $current_file_path = '' ): 
 		}
 	}
 
-	// Save and return the updated HTML
-	return $dom->saveHTML();
+	// Save and return the updated HTML without the XML declaration.
+	return preg_replace( '/^<\?xml[^>]+\?>/', '', $dom->saveHTML() );
 }
 
 


### PR DESCRIPTION
- [Remove the click-to-copy data attribute](https://github.com/Automattic/remote-data-blocks/commit/eaf178cfdc9b7aceb1fc613c23e98e2d5f69032b) from the GitHub Markdown block example.
  - This data attribute contained a copy of the code in the following code fence, which GitHub uses to implement click-to-copy. GitHub properly escapes this attribute using HTML entities, but our DOM parser (used to fix Markdown links) renders them unescaped. When this attribute contains HTML markup, it ends up being rendered on the page. We don't use this attribute, so we can just remove it.

![cleanshot_2025-06-04_at_09 57 17_2x_720](https://github.com/user-attachments/assets/14596b2d-ac73-4ba4-bc92-6109b6fba111)

- [Remove the XML declaration after processing](https://github.com/Automattic/remote-data-blocks/commit/3dfdc8c4562a3d289852f8c6a61dae7fab9f9fdc). The XML attribute was being rendered in the block editor.
- [Correctly map example code in VS Code settings](https://github.com/Automattic/remote-data-blocks/commit/cffb4be452e15308ca25a09f8ac1da5555490d02) so that example code can be debugged.