### PR TITLE
Bugfix: Avoid divide-by-zero errors with pagination

### DIFF
--- a/src/blocks/remote-data-container/components/item-list/ItemList.tsx
+++ b/src/blocks/remote-data-container/components/item-list/ItemList.tsx
@@ -88,12 +88,15 @@ export function ItemList( props: ItemListProps ) {
 		enableSorting: field !== mediaField,
 	} ) );
 
+	// Calculate a default perPage value and avoid setting it to 0.
+	const defaultPerPage = perPage ?? Math.max( results.length, 10 );
+
 	// hide media and title fields from table view if defined to avoid duplication
 	const tableFields = fieldNames.filter( field => field !== mediaField && field !== titleField );
 
 	const [ view, setView ] = useState< View >( {
 		type: 'table' as const,
-		perPage: perPage ?? results.length,
+		perPage: defaultPerPage,
 		page,
 		search: searchInput,
 		fields: tableFields,
@@ -114,7 +117,7 @@ export function ItemList( props: ItemListProps ) {
 
 	function onChangeView( newView: View ) {
 		setPage( newView.page ?? 1 );
-		setPerPage( newView.perPage ?? perPage ?? results.length );
+		setPerPage( newView.perPage ?? defaultPerPage );
 		setSearchInput( newView.search ?? '' );
 		setView( newView );
 	}

--- a/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
@@ -38,6 +38,7 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 		hasNextPage,
 		loading,
 		page,
+		perPage,
 		searchInput,
 		setPage,
 		setPerPage,
@@ -117,6 +118,7 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 						onSelect={ supportsItemSelection ? save : undefined }
 						onSelectField={ onSelectField }
 						page={ page }
+						perPage={ perPage }
 						results={ loading ? undefined : data?.results }
 						searchInput={ searchInput }
 						selectionIds={ selectionIds }


### PR DESCRIPTION
Avoid divide-by-zero errors with pagination that can occur when the `perPage` is unset and a query returns no results. Also fix a bug where `perPage` is not supplied to the data view, making this bug much more likely to surface.