### PR TITLE
Updating links to patterns

### DIFF
--- a/docs/for-ai.md
+++ b/docs/for-ai.md
@@ -269,7 +269,7 @@ Create or edit a page or post, then using the Block Inserter, search for the blo
 
 ## Patterns and styling
 
-You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns and other Core Concepts](../concepts/index.md#patterns).
+You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns](../extending/block-patterns.md).
 
 Remote data blocks can be styled using the block editor's style settings, `theme.json`, or custom stylesheets. See the [example child theme](https://github.com/Automattic/remote-data-blocks/tree/trunk/example/templates/theme) for more details.
 
@@ -326,7 +326,7 @@ The loop block will return all the entries in the spreadsheet.
 
 ## Patterns and styling
 
-You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns and other Core Concepts](../concepts/index.md#patterns).
+You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns](../extending/block-patterns.md).
 
 Remote data blocks can be styled using the block editor's style settings, `theme.json`, or custom stylesheets. See the [example child theme](https://github.com/Automattic/remote-data-blocks/tree/trunk/example/templates/theme) for more details.
 
@@ -387,7 +387,7 @@ Create or edit a page or post, then using the Block Inserter, search for the blo
 
 ## Patterns and styling
 
-You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns and other Core Concepts](../concepts/index.md#patterns).
+You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns](../extending/block-patterns.md).
 
 Remote data blocks can be styled using the block editor's style settings, `theme.json`, or custom stylesheets. See the [example child theme](https://github.com/Automattic/remote-data-blocks/tree/trunk/example/templates/theme) for more details.
 

--- a/docs/tutorials/airtable.md
+++ b/docs/tutorials/airtable.md
@@ -35,7 +35,7 @@ Create or edit a page or post, then using the Block Inserter, search for the blo
 
 ## Patterns and styling
 
-You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns and other Core Concepts](../concepts/index.md#patterns).
+You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns](../extending/block-patterns.md).
 
 Remote data blocks can be styled using the block editor's style settings, `theme.json`, or custom stylesheets. See the [example child theme](https://github.com/Automattic/remote-data-blocks/tree/trunk/example/templates/theme) for more details.
 

--- a/docs/tutorials/google-sheets.md
+++ b/docs/tutorials/google-sheets.md
@@ -42,7 +42,7 @@ The loop block will return all the entries in the spreadsheet.
 
 ## Patterns and styling
 
-You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns and other Core Concepts](../concepts/index.md#patterns).
+You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns](../extending/block-patterns.md).
 
 Remote data blocks can be styled using the block editor's style settings, `theme.json`, or custom stylesheets. See the [example child theme](https://github.com/Automattic/remote-data-blocks/tree/trunk/example/templates/theme) for more details.
 

--- a/docs/tutorials/shopify.md
+++ b/docs/tutorials/shopify.md
@@ -34,7 +34,7 @@ Create or edit a page or post, then using the Block Inserter, search for the blo
 
 ## Patterns and styling
 
-You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns and other Core Concepts](../concepts/index.md#patterns).
+You can use patterns to create a consistent, reusable layout for your remote data. You can read more about [patterns](../extending/block-patterns.md).
 
 Remote data blocks can be styled using the block editor's style settings, `theme.json`, or custom stylesheets. See the [example child theme](https://github.com/Automattic/remote-data-blocks/tree/trunk/example/templates/theme) for more details.
 


### PR DESCRIPTION
The Patterns section was removed from Core Concepts in 6dff245 
Patterns are now described in extending/block-patterns.md