### PR TITLE
Add an extra filter to fix the memory caching bug in Google Sheets

### DIFF
--- a/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
@@ -11,6 +11,7 @@ use WP_Error;
 class GoogleSheetsIntegration {
 	public static function init(): void {
 		add_action( 'init', [ __CLASS__, 'register_blocks' ], 10, 0 );
+		add_filter( 'remote_data_blocks_request_details', [ __CLASS__, 'enhance_request_details' ], 10, 3 );
 	}
 
 	public static function register_blocks(): void {
@@ -185,5 +186,29 @@ class GoogleSheetsIntegration {
 		}
 
 		return $snippets;
+	}
+
+	/**
+	 * Due to the fact that we are using the same query for both the get and list queries, and
+	 * only filtering out the results based on the input variables, the in-memory cache will not
+	 * work as expected. This enhances the request details to include the input variables, so that
+	 * the in-memory cache will be able to differenciate each request.
+	 *
+	 * @param array<string, mixed> $request_details The request details.
+	 * @param string $query The query being executed.
+	 * @param array<string, mixed> $input_variables The input variables for the current request.
+	 * @return array<string, array{
+	 *   method: string,
+	 *   options: array<string, mixed>,
+	 *   origin: string,
+	 *   uri: string,
+	 * }>
+	 */
+	public static function enhance_request_details( array $request_details, string $query, array $input_variables ): array {
+		if ( isset( $request_details['origin'] ) && 'https://sheets.googleapis.com' === $request_details['origin'] && ! empty( $input_variables ) ) {
+			$request_details['input_variables'] = $input_variables;
+		}
+
+		return $request_details;
 	}
 }

--- a/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
@@ -204,7 +204,7 @@ class GoogleSheetsIntegration {
 	 *   uri: string,
 	 * }>
 	 */
-	public static function enhance_request_details( array $request_details, string $query, array $input_variables ): array {
+	public static function enhance_request_details( array $request_details, string $_query, array $input_variables ): array {
 		if ( isset( $request_details['origin'] ) && 'https://sheets.googleapis.com' === $request_details['origin'] && ! empty( $input_variables ) ) {
 			$request_details['input_variables'] = $input_variables;
 		}

--- a/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
@@ -195,7 +195,7 @@ class GoogleSheetsIntegration {
 	 * the in-memory cache will be able to differenciate each request.
 	 *
 	 * @param array<string, mixed> $request_details The request details.
-	 * @param string $query The query being executed.
+	 * @param string $_query The query being executed.
 	 * @param array<string, mixed> $input_variables The input variables for the current request.
 	 * @return array<string, array{
 	 *   method: string,


### PR DESCRIPTION
### Description

Found a bug in RDB using Google Sheets as a data source - you can't correctly select more than 1 entry from the DataViews modal. It'll always replicate the entry. It's due to [the get_request_details](https://github.com/Automattic/remote-data-blocks/blob/trunk/inc/Config/QueryRunner/QueryRunner.php#L228) method returning the same object for all the entries. That causes the in memory cache key to be the same and thereby return the same result. I haven't been able to replicate this in any other data sources, because they include some different detail in the url, etc. For Google Sheets we just get all the data and then filter out the entries we don't want.

Instead of trying to fix the request details method, I took advantage of the filter that we provide to enhance it instead. This way, if there are other data sources that run into this problem they could take on a similar approach. If we do see that this happens often, we can then add in a fix for the future.

### Testing

- Setup a Google Sheets Data Source
- Ensure that when you select more than 1 entry, they are not duplicated