### PR TITLE
Fix bug in request details filter, and update preprocess response

### DIFF
--- a/docs/extending/query.md
+++ b/docs/extending/query.md
@@ -165,17 +165,26 @@ The `image_url` property defines an image URL that represents the query in the U
 
 ### preprocess_response: callable
 
-If you need to pre-process the response in some way before the output variables are extracted, provide a `preprocess_response` function. The function will receive the deserialized response.
+If you need to pre-process the response in some way before the output schema is applied, provide a `preprocess_response` function. The function will receive the deserialized response and an array of `$request_details` which describes the HTTP request that was just executed. The function should return an associative array that will be passed to the output schema for extraction.
+
+If you need to use an input variable in the pre-processing logic, first set it via the `request_headers` property and then access it via `$request_details['options']['headers']`.
 
 #### Example
 
 ```php
-'preprocess_response' => function( mixed $response_data, array $input_variables ): array {
-	$some_computed_property = compute_property( $response_data['foo']['bar'] ?? '' );
+'request_headers' => function( array $input_variables ): array {
+	return [
+		'X-Record-ID' => $input_variables['record_id'],
+	];
+},
+'preprocess_response' => function( mixed $response_data, array $request_details ): array {
+	$record_id = $request_details['options']['headers']['X-Record-ID'] ?? '';
 
-	return array_merge(
-		$response_data,
-		[ 'computed_property' => $some_computed_property ]
+	return array_filter(
+		$response_data['data'] ?? [],
+		static function( mixed $record ) use ( $record_id ): bool {
+			return $record['id'] === $record_id;
+		}
 	);
 },
 ```

--- a/inc/Config/Query/HttpQuery.php
+++ b/inc/Config/Query/HttpQuery.php
@@ -150,10 +150,10 @@ class HttpQuery extends ArraySerializable implements HttpQueryInterface {
 	 * shape needs significant transformation.
 	 *
 	 * @param mixed $response_data The raw deserialized response data.
-	 * @param array $input_variables The input variables for this query.
+	 * @param array $request_details The request details.
 	 * @return mixed Preprocessed response data.
 	 */
-	public function preprocess_response( mixed $response_data, array $input_variables ): mixed {
-		return $this->get_or_call_from_config( 'preprocess_response', $response_data, $input_variables ) ?? $response_data;
+	public function preprocess_response( mixed $response_data, array $request_details ): mixed {
+		return $this->get_or_call_from_config( 'preprocess_response', $response_data, $request_details ) ?? $response_data;
 	}
 }

--- a/inc/Config/Query/HttpQueryInterface.php
+++ b/inc/Config/Query/HttpQueryInterface.php
@@ -17,5 +17,5 @@ interface HttpQueryInterface extends QueryInterface {
 	public function get_request_method(): string;
 	public function get_request_headers( array $input_variables ): array|WP_Error;
 	public function get_request_body( array $input_variables ): array|null;
-	public function preprocess_response( mixed $response_data, array $input_variables ): mixed;
+	public function preprocess_response( mixed $response_data, array $request_details ): mixed;
 }

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -85,7 +85,7 @@ class QueryRunner implements QueryRunnerInterface {
 		$user = $parsed_url['user'] ?? '';
 		$path = $parsed_url['path'] ?? '';
 
-		$query = ! empty( $parsed_url['query'] ?? '' ) ? '?' . $parsed_url['query'] : '';
+		$query_params = ! empty( $parsed_url['query'] ?? '' ) ? '?' . $parsed_url['query'] : '';
 		$port = ! empty( $parsed_url['port'] ?? '' ) ? ':' . $parsed_url['port'] : '';
 		$pass = ! empty( $parsed_url['pass'] ?? '' ) ? ':' . $parsed_url['pass'] : '';
 		$pass = ( $user || $pass ) ? $pass . '@' : '';
@@ -106,7 +106,7 @@ class QueryRunner implements QueryRunnerInterface {
 				RequestOptions::JSON => $body,
 			],
 			'origin' => $origin,
-			'uri' => sprintf( '%s%s%s', $origin, $path, $query ),
+			'uri' => sprintf( '%s%s%s', $origin, $path, $query_params ),
 		];
 
 		/**
@@ -253,7 +253,7 @@ class QueryRunner implements QueryRunnerInterface {
 		}
 
 		// Preprocess the response data.
-		$response_data = $this->preprocess_response( $query, $raw_response_data['response_data'], $input_variables );
+		$response_data = $this->preprocess_response( $query, $raw_response_data['response_data'], $request_details );
 
 		// Determine if the response data is expected to be a collection.
 		$output_schema = $query->get_output_schema();
@@ -362,11 +362,13 @@ class QueryRunner implements QueryRunnerInterface {
 	/**
 	 * Preprocess the response data before it is passed to the response parser.
 	 *
+	 * @param HttpQueryInterface $query The query.
 	 * @param array $response_data The raw response data.
+	 * @param array $request_details The request details.
 	 * @return array Preprocessed response. The deserialized response data or (re-)serialized JSON.
 	 */
-	protected function preprocess_response( HttpQueryInterface $query, mixed $response_data, array $input_variables ): mixed {
-		return $query->preprocess_response( $response_data, $input_variables );
+	protected function preprocess_response( HttpQueryInterface $query, mixed $response_data, array $request_details ): mixed {
+		return $query->preprocess_response( $response_data, $request_details );
 	}
 
 	/**

--- a/inc/Integrations/Google/Sheets/GoogleSheetsDataSource.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsDataSource.php
@@ -90,9 +90,8 @@ class GoogleSheetsDataSource extends GenericHttpDataSource {
 		return $response_data;
 	}
 
-	public static function preprocess_get_response( array $response_data, array $request_details ): array {
+	public static function preprocess_get_response( array $response_data, ?string $row_id = null ): array {
 		$selected_row = null;
-		$row_id = $request_details['headers']['X-Row-ID'];
 
 		if ( isset( $response_data['values'] ) && is_array( $response_data['values'] ) ) {
 			$values = $response_data['values'];

--- a/inc/Integrations/Google/Sheets/GoogleSheetsDataSource.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsDataSource.php
@@ -90,9 +90,9 @@ class GoogleSheetsDataSource extends GenericHttpDataSource {
 		return $response_data;
 	}
 
-	public static function preprocess_get_response( array $response_data, array $input_variables ): array {
+	public static function preprocess_get_response( array $response_data, array $request_details ): array {
 		$selected_row = null;
-		$row_id = $input_variables['row_id'];
+		$row_id = $request_details['headers']['X-Row-ID'];
 
 		if ( isset( $response_data['values'] ) && is_array( $response_data['values'] ) ) {
 			$values = $response_data['values'];

--- a/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
@@ -4,6 +4,7 @@ namespace RemoteDataBlocks\Integrations\Google\Sheets;
 
 use RemoteDataBlocks\Store\DataSource\DataSourceConfigManager;
 use RemoteDataBlocks\Config\Query\HttpQuery;
+use RemoteDataBlocks\Config\Query\HttpQueryInterface;
 use RemoteDataBlocks\Formatting\StringFormatter;
 use RemoteDataBlocks\Snippet\Snippet;
 use WP_Error;
@@ -103,8 +104,8 @@ class GoogleSheetsIntegration {
 			'endpoint' => $data_source->get_endpoint() . '/values/' . rawurlencode( $sheet['name'] ),
 			'input_schema' => $input_schema,
 			'output_schema' => $output_schema,
-			'preprocess_response' => function ( mixed $response_data, array $input_variables ): array {
-				return GoogleSheetsDataSource::preprocess_get_response( $response_data, $input_variables );
+			'preprocess_response' => function ( mixed $response_data, array $request_details ): array {
+				return GoogleSheetsDataSource::preprocess_get_response( $response_data, $request_details );
 			},
 		] );
 	}
@@ -124,8 +125,8 @@ class GoogleSheetsIntegration {
 			'endpoint' => $data_source->get_endpoint() . '/values/' . rawurlencode( $sheet['name'] ),
 			'input_schema' => [],
 			'output_schema' => $output_schema,
-			'preprocess_response' => function ( mixed $response_data ): array {
-				return GoogleSheetsDataSource::preprocess_list_response( $response_data );
+			'preprocess_response' => function ( mixed $response_data, array $request_details ): array {
+				return GoogleSheetsDataSource::preprocess_list_response( $response_data, $request_details );
 			},
 		] );
 	}
@@ -191,11 +192,11 @@ class GoogleSheetsIntegration {
 	/**
 	 * Due to the fact that we are using the same query for both the get and list queries, and
 	 * only filtering out the results based on the input variables, the in-memory cache will not
-	 * work as expected. This enhances the request details to include the input variables, so that
-	 * the in-memory cache will be able to differenciate each request.
+	 * work as expected. This enhances the request details to include the row ID in a special
+	 * header X-Row-ID, so that the in-memory cache will be able to differentiate each request.
 	 *
 	 * @param array<string, mixed> $request_details The request details.
-	 * @param string $_query The query being executed.
+	 * @param HttpQueryInterface $query The query being executed.
 	 * @param array<string, mixed> $input_variables The input variables for the current request.
 	 * @return array<string, array{
 	 *   method: string,
@@ -204,9 +205,11 @@ class GoogleSheetsIntegration {
 	 *   uri: string,
 	 * }>
 	 */
-	public static function enhance_request_details( array $request_details, string $_query, array $input_variables ): array {
-		if ( isset( $request_details['origin'] ) && 'https://sheets.googleapis.com' === $request_details['origin'] && ! empty( $input_variables ) ) {
-			$request_details['input_variables'] = $input_variables;
+	public static function enhance_request_details( array $request_details, HttpQueryInterface $query, array $input_variables ): array {
+		$query_input_schema = $query->get_input_schema();
+
+		if ( $query->get_data_source() instanceof GoogleSheetsDataSource && isset( $query_input_schema['row_id'] ) ) {
+			$request_details['headers']['X-Row-ID'] = $input_variables['row_id'];
 		}
 
 		return $request_details;

--- a/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
+++ b/inc/Integrations/Google/Sheets/GoogleSheetsIntegration.php
@@ -4,7 +4,6 @@ namespace RemoteDataBlocks\Integrations\Google\Sheets;
 
 use RemoteDataBlocks\Store\DataSource\DataSourceConfigManager;
 use RemoteDataBlocks\Config\Query\HttpQuery;
-use RemoteDataBlocks\Config\Query\HttpQueryInterface;
 use RemoteDataBlocks\Formatting\StringFormatter;
 use RemoteDataBlocks\Snippet\Snippet;
 use WP_Error;
@@ -12,7 +11,6 @@ use WP_Error;
 class GoogleSheetsIntegration {
 	public static function init(): void {
 		add_action( 'init', [ __CLASS__, 'register_blocks' ], 10, 0 );
-		add_filter( 'remote_data_blocks_request_details', [ __CLASS__, 'enhance_request_details' ], 10, 3 );
 	}
 
 	public static function register_blocks(): void {
@@ -104,8 +102,14 @@ class GoogleSheetsIntegration {
 			'endpoint' => $data_source->get_endpoint() . '/values/' . rawurlencode( $sheet['name'] ),
 			'input_schema' => $input_schema,
 			'output_schema' => $output_schema,
+			'request_headers' => function ( array $input_variables ) use ( $data_source ): array {
+				return array_merge(
+					$data_source->get_request_headers(),
+					[ 'X-Row-ID' => $input_variables['row_id'] ?? null ]
+				);
+			},
 			'preprocess_response' => function ( mixed $response_data, array $request_details ): array {
-				return GoogleSheetsDataSource::preprocess_get_response( $response_data, $request_details );
+				return GoogleSheetsDataSource::preprocess_get_response( $response_data, $request_details['options']['headers']['X-Row-ID'] ?? null );
 			},
 		] );
 	}
@@ -187,31 +191,5 @@ class GoogleSheetsIntegration {
 		}
 
 		return $snippets;
-	}
-
-	/**
-	 * Due to the fact that we are using the same query for both the get and list queries, and
-	 * only filtering out the results based on the input variables, the in-memory cache will not
-	 * work as expected. This enhances the request details to include the row ID in a special
-	 * header X-Row-ID, so that the in-memory cache will be able to differentiate each request.
-	 *
-	 * @param array<string, mixed> $request_details The request details.
-	 * @param HttpQueryInterface $query The query being executed.
-	 * @param array<string, mixed> $input_variables The input variables for the current request.
-	 * @return array<string, array{
-	 *   method: string,
-	 *   options: array<string, mixed>,
-	 *   origin: string,
-	 *   uri: string,
-	 * }>
-	 */
-	public static function enhance_request_details( array $request_details, HttpQueryInterface $query, array $input_variables ): array {
-		$query_input_schema = $query->get_input_schema();
-
-		if ( $query->get_data_source() instanceof GoogleSheetsDataSource && isset( $query_input_schema['row_id'] ) ) {
-			$request_details['headers']['X-Row-ID'] = $input_variables['row_id'];
-		}
-
-		return $request_details;
 	}
 }

--- a/tests/inc/Mocks/MockQuery.php
+++ b/tests/inc/Mocks/MockQuery.php
@@ -22,7 +22,7 @@ class MockQuery extends HttpQuery {
 		], $validator ?? new MockValidator() );
 	}
 
-	public function preprocess_response( mixed $response_data, array $input_variables ): mixed {
+	public function preprocess_response( mixed $response_data, array $request_details ): mixed {
 		if ( null !== $this->response_data ) {
 			return $this->response_data;
 		}


### PR DESCRIPTION
### Description

This PR is meant to update the `request_details` filter, to not overwrite the `query` with a string representation of the `query params`. Also, this implements a possible solution for the problem identified in #594 - remove the `input_variables` and replace it with `request_details` instead. The `request_details` is used to store the `row_id` in the headers if by the Google Sheets data source and then the filter is used to inject this in the pre-process response. This allows for the cache to work as expected, and for the query to return the correct response as well.

### Testing

- Setup a Google Sheets data source
- Insert a block for this data source
- Ensure this works as expected by picking a few entries, and ensuring they show up correctly
- Updating the row ID in the `query Inputs panel` should reflect this as well.