### PR TITLE
Add escaping to `get block wrapper attributes`

### DIFF
--- a/src/blocks/remote-data-pagination/render.php
+++ b/src/blocks/remote-data-pagination/render.php
@@ -20,7 +20,7 @@ $previous_page_link = $pagination_links['previous_page'] ?? null;
 $previous_page_link_label = 'Previous';
 
 ?>
-<div <?php echo get_block_wrapper_attributes(); ?>>
+<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 	<div class="remote-data-pagination">
 		<?php if ( null === $previous_page_link ) : ?>
 			<?php echo esc_html( $previous_page_link_label ); ?>

--- a/src/blocks/remote-html/render.php
+++ b/src/blocks/remote-html/render.php
@@ -10,7 +10,7 @@ $source_args = $block->attributes['metadata']['bindings']['content']['args'] ?? 
 
 ?>
 
-<div <?php echo get_block_wrapper_attributes(); ?>>
+<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 	<?php
 	$binding_value = BlockBindings::get_value( $source_args, $block, 'content' );
 


### PR DESCRIPTION
See #616. 