### PR TITLE
Update readme.txt version in release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -51,13 +51,20 @@ rm "${php_file}.bak"
 
 echo "Updated $php_file from $current_version to $new_version"
 
+# Update readme.txt
+readme_file="readme.txt"
+sed -i.bak "s/Stable tag: $current_version/Stable tag: $new_version/" "$readme_file"
+rm "${readme_file}.bak"
+
+echo "Updated $readme_file from $current_version to $new_version"
+
 echo "Version bump complete: $new_version"
 
 # Create a new branch for the release
 git checkout -b release/v"$new_version"
 
 # Commit the changes
-git add "$php_file"
+git add "$php_file" "$readme_file"
 git commit -m "v$new_version"
 
 echo "Changes committed to release/v$new_version branch. Push the branch to the remote repository and create a pull request."


### PR DESCRIPTION
WIth readme.txt added for #616 we also need to update the [Stable tag](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information) (plugin version number) in that file as part of the release script.