### PR TITLE
Include composer.json in plugin-zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "inc/",
     "vendor/",
     "functions.php",
-    "remote-data-blocks.php"
+    "remote-data-blocks.php",
+    "composer.json"
   ],
   "scripts": {
     "build": "npm run cmd:build",


### PR DESCRIPTION
The Plugin Check Plugin reports that the `composer.json` file is [missing and should be included](https://developer.wordpress.org/plugins/wordpress-org/common-issues/#included-unneeded-folders). To include it, `wp-scripts` [looks](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#advanced-information-8) at the `package.json` `files` field.