### PR TITLE
fix: update how the Remote Data Blocks pattern category is added in the plugin

### DIFF
--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -153,7 +153,7 @@ class ConfigRegistry {
 		// Create the pattern properties, allowing overrides via pattern options.
 		$pattern_properties = [
 			'blockTypes' => [ $block_name ],
-			'categories' => [ 'Remote Data' ],
+			'categories' => [ 'remote-data-blocks' ],
 			'content' => $pattern_content,
 			'inserter' => true,
 			'source' => 'plugin',

--- a/inc/Editor/BlockPatterns/BlockPatterns.php
+++ b/inc/Editor/BlockPatterns/BlockPatterns.php
@@ -112,7 +112,6 @@ class BlockPatterns {
 						$bindings['heading']['content'] = [ $field, $name ];
 						break;
 					}
-
 					$bindings['paragraphs'][] = [
 						'content' => [ $field, $name ],
 					];

--- a/inc/Editor/BlockPatterns/BlockPatterns.php
+++ b/inc/Editor/BlockPatterns/BlockPatterns.php
@@ -112,6 +112,7 @@ class BlockPatterns {
 						$bindings['heading']['content'] = [ $field, $name ];
 						break;
 					}
+
 					$bindings['paragraphs'][] = [
 						'content' => [ $field, $name ],
 					];

--- a/inc/Editor/BlockPatterns/BlockPatterns.php
+++ b/inc/Editor/BlockPatterns/BlockPatterns.php
@@ -112,7 +112,7 @@ class BlockPatterns {
 						$bindings['heading']['content'] = [ $field, $name ];
 						break;
 					}
-					
+
 					$bindings['paragraphs'][] = [
 						'content' => [ $field, $name ],
 					];
@@ -184,11 +184,17 @@ class BlockPatterns {
 			[
 				'title' => sprintf( '%s Data', $block_title ),
 				'blockTypes' => [ $block_name ],
-				'categories' => [ 'Remote Data Blocks' ],
+				'categories' => [ 'remote-data-blocks' ],
 				'content' => $content,
 				'inserter' => true,
 				'source' => 'plugin',
 			]
+		);
+
+		// Register block pattern category.
+		register_block_pattern_category(
+			'remote-data-blocks',
+			[ 'label' => __( 'Remote Data Blocks', 'remote-data-blocks' ) ]
 		);
 
 		return $pattern_name;


### PR DESCRIPTION
This PR fixes the formatting for how the Block Pattern Category "Remote Data Blocks" was being added. 

Prior to this change, any patterns created for the Remote Data Blocks were showing up under 'Uncategorized'.

## Steps to test:
1. Start on a test site with at least one Remote Data Block with a pattern that can be selected.
2. Open the Block Inserter in the editor, click the Patterns tab and note there's no "Remote Data" category. All your Remote Data patterns are appearing under "Uncategorized".
3. Apply the PR and confirm the patterns are now appearing under "Remote Data Blocks".

There were originally both a "Remote Data" and a "Remote Data Blocks" pattern categories listed; I consolidated them down to "Remote Data Blocks" but can split them back into two categories again! 
