### PR TITLE
Add loading overlay for initial data selection

### DIFF
--- a/src/blocks/remote-data-container/edit.tsx
+++ b/src/blocks/remote-data-container/edit.tsx
@@ -101,9 +101,30 @@ function RemoteDataBlockEdit( props: BlockEditProps< RemoteDataBlockAttributes >
 		refreshRemoteData();
 	}
 
+	function renderLoadingOverlay( isClickable = false ): JSX.Element {
+		return (
+			<div
+				className="remote-data-blocks-loading-overlay"
+				style={ isClickable ? { pointerEvents: 'auto' } : undefined }
+			>
+				<Spinner
+					style={ {
+						height: '50px',
+						width: '50px',
+					} }
+				/>
+			</div>
+		);
+	}
+
 	// No remote data has been selected yet, show a placeholder.
 	if ( ! data ) {
-		return <Placeholder blockConfig={ blockConfig } onSelect={ onSelectRemoteData } />;
+		return (
+			<>
+				<Placeholder blockConfig={ blockConfig } onSelect={ onSelectRemoteData } />
+				{ loading && renderLoadingOverlay( true ) }
+			</>
+		);
 	}
 
 	if ( showPatternSelection ) {
@@ -141,16 +162,7 @@ function RemoteDataBlockEdit( props: BlockEditProps< RemoteDataBlockAttributes >
 				</InspectorControls>
 			) }
 
-			{ loading && (
-				<div className="remote-data-blocks-loading-overlay">
-					<Spinner
-						style={ {
-							height: '50px',
-							width: '50px',
-						} }
-					/>
-				</div>
-			) }
+			{ loading && renderLoadingOverlay() }
 			<InnerBlocks />
 		</>
 	);


### PR DESCRIPTION
Adds a loading overlay that appears when users select data in the remote data block, providing visual feedback during the fetch process.

Addresses https://github.com/Automattic/remote-data-blocks/issues/634.

## Changes
- Reused existing overlay rendering logic and refactored it into a helper function.
- Noticed that the existing overlay allows click interactions, so added a param to conditionally apply `pointer-events: 'auto'` for blocking interactions during placeholder loading and prevent button interactions.

<img width="760" height="184" alt="image" src="https://github.com/user-attachments/assets/8241bb36-12a3-43fd-8eae-04c1f4fc0cbb" />

## Testing

1. Insert a remote data block in the editor.
2. Click the "Choose" button to open the data selection modal.
3. Select an item from the modal and confirm/save.
4. Verify that the modal closes and a translucent loading overlay appears over the placeholder.
5. Verify that clicking anywhere on the placeholder area during loading has no effect (overlay should block clicks).
6. Verify that the loading overlay disappears when the pattern selection buttons appear or blocks are inserted.
7. Refresh the editor page and make sure that there are remote data blocks added with data.
8. During load, verify that the spinner and overlay keep appearing, but you can still interact with the components behind it.