### PR TITLE
feat: improve modal selection; update buttons

### DIFF
--- a/src/blocks/remote-data-container/components/modals/BaseModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/BaseModal.tsx
@@ -47,7 +47,7 @@ export function ModalWithButtonTrigger( props: ModalWithButtonTriggerProps ) {
 
 	return (
 		<>
-			<Button variant={ buttonVariant } onClick={ onOpen }>
+			<Button variant={ buttonVariant } onClick={ onOpen } __next40pxDefaultSize>
 				{ __( props.buttonText ) }
 			</Button>
 

--- a/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
@@ -1,4 +1,4 @@
-import { BaseControl, Button, Modal, __experimentalHStack as HStack } from '@wordpress/components';
+import { Button, Modal, __experimentalHStack as HStack } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -127,7 +127,11 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 						totalPages={ totalPages }
 					/>
 					{ supportsItemSelection && ! loading && (
-						<HStack className="rdb-dataviews-bulk-actions-footer__selection-total" justify="flex-end" spacing={ 3 }>
+						<HStack
+							className="rdb-dataviews-bulk-actions-footer__selection-total"
+							justify="flex-end"
+							spacing={ 3 }
+						>
 							<Button
 								disabled={ selection.length === 0 }
 								onClick={ () => setSelectionIds( [] ) }

--- a/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
+++ b/src/blocks/remote-data-container/components/modals/DataViewsModal.tsx
@@ -28,10 +28,6 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 	// Multi-selected items
 	const [ selection, setSelection ] = useState< RemoteDataApiResult[] >( [] );
 
-	// Total selected items
-	const itemCountLabel =
-		selection.length > 1 ? __( 'items selected in total' ) : __( 'item selected in total' );
-
 	const { close, isOpen, open } = useModalState();
 	const {
 		data,
@@ -94,8 +90,8 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 	const triggerElement = renderTrigger ? (
 		renderTrigger( { onClick: open } )
 	) : (
-		<Button variant="primary" onClick={ open }>
-			{ __( 'Choose' ) }
+		<Button variant="primary" onClick={ open } __next40pxDefaultSize>
+			{ __( 'Select items' ) }
 		</Button>
 	);
 
@@ -131,35 +127,25 @@ export const DataViewsModal: React.FC< DataViewsModalProps > = props => {
 						totalPages={ totalPages }
 					/>
 					{ supportsItemSelection && ! loading && (
-						<>
-							{ selection.length > 1 && (
-								<BaseControl
-									className="rdb-dataviews-bulk-actions-footer__item-count-total"
-									__nextHasNoMarginBottom
-								>
-									<BaseControl.VisualLabel style={ { marginBottom: '0' } }>
-										{ selection.length } { itemCountLabel }
-									</BaseControl.VisualLabel>
-								</BaseControl>
-							) }
-
-							<HStack className="rdb-dataviews-bulk-actions-footer__selection-total">
-								<Button
-									disabled={ selection.length === 0 }
-									onClick={ () => setSelectionIds( [] ) }
-									variant="secondary"
-								>
-									{ __( 'Cancel' ) }
-								</Button>
-								<Button
-									disabled={ selection.length === 0 }
-									onClick={ () => save( selection ) }
-									variant="primary"
-								>
-									{ __( 'Save' ) }
-								</Button>
-							</HStack>
-						</>
+						<HStack className="rdb-dataviews-bulk-actions-footer__selection-total" justify="flex-end" spacing={ 3 }>
+							<Button
+								disabled={ selection.length === 0 }
+								onClick={ () => setSelectionIds( [] ) }
+								variant="tertiary"
+								isDestructive
+								__next40pxDefaultSize
+							>
+								{ __( 'Clear selection' ) }
+							</Button>
+							<Button
+								disabled={ selection.length === 0 }
+								onClick={ () => save( selection ) }
+								variant="primary"
+								__next40pxDefaultSize
+							>
+								{ __( 'Select items' ) }
+							</Button>
+						</HStack>
 					) }
 				</Modal>
 			) }

--- a/src/blocks/remote-data-container/components/placeholders/ItemSelectQueryType.tsx
+++ b/src/blocks/remote-data-container/components/placeholders/ItemSelectQueryType.tsx
@@ -1,8 +1,4 @@
-import {
-	Button,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 
 import { DataViewsModal } from '@/blocks/remote-data-container/components/modals/DataViewsModal';
 import { InputModal } from '@/blocks/remote-data-container/components/modals/InputModal';
@@ -20,12 +16,7 @@ export function ItemSelectQueryType( props: ItemSelectQueryTypeProps ) {
 	} = props;
 
 	return (
-		<ToggleGroupControl
-			className="remote-data-blocks-button-group"
-			label={ __( '' ) }
-			__nextHasNoMarginBottom
-			__next40pxDefaultSize
-		>
+		<>
 			{ selectors.map( selector => {
 				const title = selector.name;
 				const selectorProps = {
@@ -69,6 +60,6 @@ export function ItemSelectQueryType( props: ItemSelectQueryTypeProps ) {
 
 				return null;
 			} ) }
-		</ToggleGroupControl>
+		</>
 	);
 }

--- a/src/blocks/remote-data-container/components/popovers/InputPopover.tsx
+++ b/src/blocks/remote-data-container/components/popovers/InputPopover.tsx
@@ -69,7 +69,7 @@ export function InputPopover( props: InputPopoverProps ) {
 
 	return (
 		<>
-			<Button variant="secondary" onClick={ open }>
+			<Button variant="secondary" onClick={ open } __next40pxDefaultSize>
 				{ getDataSourceLabels( dataSourceType ).buttonText }
 			</Button>
 			{ isOpen && (

--- a/src/blocks/remote-data-container/editor.scss
+++ b/src/blocks/remote-data-container/editor.scss
@@ -121,46 +121,45 @@ remote-data-blocks-inline-field {
 // align padding with designs
 
 .rdb-dataviews-bulk-actions-modal .components-modal__content {
-	scroll-padding-bottom: 72px;
-	max-height: calc(100% - 116px);
+	scroll-padding-bottom: 121px;
+	max-height: calc(100% - 121px);
 
-	// custom total item count label
-	.rdb-dataviews-bulk-actions-footer__item-count-total {
-		position: fixed;
-		bottom: 80px;
-		left: 50%;
-		transform: translate(-50%);
-		width: max-content;
-		text-align: center;
-		color: #1e1e1e;
-		z-index: 4;
+	@media screen and (min-width: 782px) {
+		scroll-padding-bottom: 88px;
+		max-height: calc(100% - 88px);
+	}
+
+	.dataviews-view-table tr td:first-child,
+	.dataviews-view-table tr th:first-child {
+		padding-left: 32px;
 	}
 
 	// custom total item count actions
 	.rdb-dataviews-bulk-actions-footer__selection-total {
-		background: #fff;
 		position: fixed;
 		bottom: 0;
-		left: 0;
 		right: 0;
-		padding: 0 24px 24px;
-		gap: 20px;
+		padding: 0 32px 24px;
 		z-index: 3;
 
-		.components-button {
-			width: 100%;
-			display: block;
-			text-align: center;
+		@media screen and (min-width: 782px) {
+			width: auto;
 		}
 	}
 
 	// hide bulk actions in footer
 	.dataviews-footer {
+		padding: 24px 32px 0;
 		position: fixed;
-		bottom: 60px;
+		bottom: 64px;
 		left: 0;
 		right: 0;
-		background-color: transparent;
+
+		@media screen and (min-width: 782px) {
+			bottom: 0;
+			height: 88px;
+			padding-bottom: 24px;
+		}
 
 		.dataviews-bulk-actions-footer__container  .dataviews-bulk-actions-footer__action-buttons {
 			display: none;
@@ -176,10 +175,22 @@ remote-data-blocks-inline-field {
 
 	// keep header static
 	.components-modal__header {
-		position: static;
+		background-color: #fff;
+		position: sticky;
 	}
 
-	// align padding with designs
+	.dataviews__view-actions,
+	.dataviews-filters__container {
+		padding-left: 32px;
+		padding-right: 32px;
+	}
+
+	// align padding with modal
+	.dataviews-view-grid {
+		padding-left: 32px;
+		padding-right: 32px;
+	}
+
 	.dataviews-view-table {
 		padding: 4px 32px 32px;
 
@@ -190,8 +201,8 @@ remote-data-blocks-inline-field {
 			right: 0;
 			background: #fff;
 			z-index: 1;
-			padding-left: 24px;
-			padding-right: 24px;
+			padding-left: 32px;
+			padding-right: 32px;
 			text-align: center;
 		}
 


### PR DESCRIPTION
This PR adds a little bit more consistency with paddings and spacing within the modal. I've removed the unnecessary total selected since the footer checkbox already provided the same information.

The buttons have been updated to be more inline with Gutenberg Placeholder block/component. 

__Before__
<img width="2146" height="2090" alt="before placeholder" src="https://github.com/user-attachments/assets/0111446c-19a3-4c95-b0ba-2029ca9044d9" />

<img width="2146" height="2090" alt="before modal" src="https://github.com/user-attachments/assets/57644abf-0f1b-4ee6-9ef0-26ebcc563b1c" />

__After__
<img width="2146" height="2090" alt="after placeholder" src="https://github.com/user-attachments/assets/28bf449a-d5ce-49f6-98d5-1d57920f06aa" />

<img width="2146" height="2090" alt="after modal" src="https://github.com/user-attachments/assets/2d55de76-fb85-4785-b3e3-59d6939a8677" />
