### PR TITLE
Fix User-Agent header being overwritten by default

### DIFF
--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -31,10 +31,8 @@ class HttpClient {
 		$handler_stack->push( new RdbLogMiddleware(), 'remote_data_blocks_logger' );
 		$handler_stack->push( new RdbCacheMiddleware( new RdbCacheStrategy() ), 'remote_data_blocks_cache' );
 
-		// Set our User Agent header.
-		$handler_stack->push( Middleware::mapRequest( function ( RequestInterface $request ) {
-			return $request->withHeader( 'User-Agent', self::USER_AGENT_STRING );
-		} ) );
+		// Set our User Agent header only if one hasn't been set.
+		$handler_stack->push( Middleware::mapRequest([ $this, 'provideDefaultUserAgent' ] ), 'remote_data_blocks_user_agent' );
 
 		$this->client = new Client( [ 'handler' => $handler_stack ] );
 	}
@@ -65,5 +63,19 @@ class HttpClient {
 		] );
 
 		return $http_client->request( $method, $uri, $options );
+	}
+
+	/**
+	 * Provide the default User-Agent header.
+	 *
+	 * @param RequestInterface $request The request to provide the User-Agent header for.
+	 * @return RequestInterface The request with the User-Agent header.
+	 */
+	public function provideDefaultUserAgent( RequestInterface $request ): RequestInterface {
+		// Only set User-Agent if one hasn't already been set
+		if ( ! $request->hasHeader( 'User-Agent' ) ) {
+			return $request->withHeader( 'User-Agent', self::USER_AGENT_STRING );
+		}
+		return $request;
 	}
 }

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -9,12 +9,11 @@ use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
+use RemoteDataBlocks\PluginSettings\PluginSettings;
 
 defined( 'ABSPATH' ) || exit();
 
 class HttpClient {
-	public const USER_AGENT_STRING = 'WordPress Remote Data Blocks/' . REMOTE_DATA_BLOCKS__PLUGIN_VERSION;
-
 	protected Client $client;
 
 	/**
@@ -74,8 +73,12 @@ class HttpClient {
 	public function provideDefaultUserAgent( RequestInterface $request ): RequestInterface {
 		// Only set User-Agent if one hasn't already been set
 		if ( ! $request->hasHeader( 'User-Agent' ) ) {
-			return $request->withHeader( 'User-Agent', self::USER_AGENT_STRING );
+			return $request->withHeader( 'User-Agent', self::getUserAgentString() );
 		}
 		return $request;
+	}
+
+	private function getUserAgentString(): string {
+		return 'WordPress Remote Data Blocks/' . PluginSettings::get_version();
 	}
 }

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -31,7 +31,7 @@ class HttpClient {
 		$handler_stack->push( new RdbCacheMiddleware( new RdbCacheStrategy() ), 'remote_data_blocks_cache' );
 
 		// Set our User Agent header only if one hasn't been set.
-		$handler_stack->push( Middleware::mapRequest([ $this, 'provideDefaultUserAgent' ] ), 'remote_data_blocks_user_agent' );
+		$handler_stack->push( Middleware::mapRequest( [ $this, 'provide_default_user_agent' ] ), 'remote_data_blocks_user_agent' );
 
 		$this->client = new Client( [ 'handler' => $handler_stack ] );
 	}
@@ -70,15 +70,15 @@ class HttpClient {
 	 * @param RequestInterface $request The request to provide the User-Agent header for.
 	 * @return RequestInterface The request with the User-Agent header.
 	 */
-	public function provideDefaultUserAgent( RequestInterface $request ): RequestInterface {
+	public function provide_default_user_agent( RequestInterface $request ): RequestInterface {
 		// Only set User-Agent if one hasn't already been set
 		if ( ! $request->hasHeader( 'User-Agent' ) ) {
-			return $request->withHeader( 'User-Agent', self::getUserAgentString() );
+			return $request->withHeader( 'User-Agent', self::get_user_agent_string() );
 		}
 		return $request;
 	}
 
-	private function getUserAgentString(): string {
+	private function get_user_agent_string(): string {
 		return 'WordPress Remote Data Blocks/' . PluginSettings::get_version();
 	}
 }

--- a/inc/HttpClient/HttpClient.php
+++ b/inc/HttpClient/HttpClient.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\UriInterface;
 defined( 'ABSPATH' ) || exit();
 
 class HttpClient {
-	public const USER_AGENT_STRING = 'WordPress Remote Data Blocks/1.0';
+	public const USER_AGENT_STRING = 'WordPress Remote Data Blocks/' . REMOTE_DATA_BLOCKS__PLUGIN_VERSION;
 
 	protected Client $client;
 

--- a/inc/PluginSettings/PluginSettings.php
+++ b/inc/PluginSettings/PluginSettings.php
@@ -112,6 +112,10 @@ class PluginSettings {
 	 * Get the plugin version from the main plugin file.
 	 */
 	public static function get_version(): string {
+		if ( ! defined( 'REMOTE_DATA_BLOCKS__PLUGIN_VERSION' ) ) {
+			return '1.0';
+		}
+
 		return REMOTE_DATA_BLOCKS__PLUGIN_VERSION;
 	}
 

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -580,22 +580,5 @@ class HttpClientTest extends TestCase {
 		// Should preserve custom User-Agent header
 		$this->assertTrue( $result->hasHeader( 'User-Agent' ) );
 		$this->assertSame( 'CustomApp/2.0', $result->getHeaderLine( 'User-Agent' ) );
-		$this->assertNotSame( 'WordPress Remote Data Blocks/1a test.0', $result->getHeaderLine( 'User-Agent' ) );
-	}
-
-	public function testProvideDefaultUserAgentWithEmptyUserAgent(): void {
-		// Test that provideDefaultUserAgent sets default when User-Agent is empty
-		$http_client = HttpClient::instance();
-
-		// Create a request with empty User-Agent header
-		$request = new \GuzzleHttp\Psr7\Request( 'GET', '/test', [ 'User-Agent' => '' ] );
-
-		// Apply the function
-		$result = $http_client->provide_default_user_agent( $request );
-
-		// Should set default User-Agent (empty string is considered as having a header)
-		$this->assertTrue( $result->hasHeader( 'User-Agent' ) );
-		$this->assertSame( '', $result->getHeaderLine( 'User-Agent' ) );
-		$this->assertNotSame( 'WordPress Remote Data Blocks/1a test.0', $result->getHeaderLine( 'User-Agent' ) );
 	}
 }

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -551,4 +551,51 @@ class HttpClientTest extends TestCase {
 
 		$this->assertEquals( 1, $this->mock_handler->count(), 'The mock handler should still have one request left after the second request' );
 	}
+
+	public function testProvideDefaultUserAgentSetsDefaultWhenNoneExists(): void {
+		// Test that provideDefaultUserAgent sets the default User-Agent when none exists
+		$http_client = HttpClient::instance();
+
+		// Create a request without User-Agent header
+		$request = new \GuzzleHttp\Psr7\Request( 'GET', '/test' );
+
+		// Apply the function
+		$result = $http_client->provideDefaultUserAgent( $request );
+
+		// Should have added User-Agent header
+		$this->assertTrue( $result->hasHeader( 'User-Agent' ) );
+		$this->assertSame( 'WordPress Remote Data Blocks/1a test.0', $result->getHeaderLine( 'User-Agent' ) );
+	}
+
+	public function testProvideDefaultUserAgentPreservesExistingUserAgent(): void {
+		// Test that provideDefaultUserAgent preserves existing User-Agent headers
+		$http_client = HttpClient::instance();
+
+		// Create a request with custom User-Agent header
+		$request = new \GuzzleHttp\Psr7\Request( 'GET', '/test', [ 'User-Agent' => 'CustomApp/2.0' ] );
+
+		// Apply the function
+		$result = $http_client->provideDefaultUserAgent( $request );
+
+		// Should preserve custom User-Agent header
+		$this->assertTrue( $result->hasHeader( 'User-Agent' ) );
+		$this->assertSame( 'CustomApp/2.0', $result->getHeaderLine( 'User-Agent' ) );
+		$this->assertNotSame( 'WordPress Remote Data Blocks/1a test.0', $result->getHeaderLine( 'User-Agent' ) );
+	}
+
+	public function testProvideDefaultUserAgentWithEmptyUserAgent(): void {
+		// Test that provideDefaultUserAgent sets default when User-Agent is empty
+		$http_client = HttpClient::instance();
+
+		// Create a request with empty User-Agent header
+		$request = new \GuzzleHttp\Psr7\Request( 'GET', '/test', [ 'User-Agent' => '' ] );
+
+		// Apply the function
+		$result = $http_client->provideDefaultUserAgent( $request );
+
+		// Should set default User-Agent (empty string is considered as having a header)
+		$this->assertTrue( $result->hasHeader( 'User-Agent' ) );
+		$this->assertSame( '', $result->getHeaderLine( 'User-Agent' ) );
+		$this->assertNotSame( 'WordPress Remote Data Blocks/1a test.0', $result->getHeaderLine( 'User-Agent' ) );
+	}
 }

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -560,7 +560,7 @@ class HttpClientTest extends TestCase {
 		$request = new \GuzzleHttp\Psr7\Request( 'GET', '/test' );
 
 		// Apply the function
-		$result = $http_client->provideDefaultUserAgent( $request );
+		$result = $http_client->provide_default_user_agent( $request );
 
 		// Should have added User-Agent header
 		$this->assertTrue( $result->hasHeader( 'User-Agent' ) );
@@ -575,7 +575,7 @@ class HttpClientTest extends TestCase {
 		$request = new \GuzzleHttp\Psr7\Request( 'GET', '/test', [ 'User-Agent' => 'CustomApp/2.0' ] );
 
 		// Apply the function
-		$result = $http_client->provideDefaultUserAgent( $request );
+		$result = $http_client->provide_default_user_agent( $request );
 
 		// Should preserve custom User-Agent header
 		$this->assertTrue( $result->hasHeader( 'User-Agent' ) );
@@ -591,7 +591,7 @@ class HttpClientTest extends TestCase {
 		$request = new \GuzzleHttp\Psr7\Request( 'GET', '/test', [ 'User-Agent' => '' ] );
 
 		// Apply the function
-		$result = $http_client->provideDefaultUserAgent( $request );
+		$result = $http_client->provide_default_user_agent( $request );
 
 		// Should set default User-Agent (empty string is considered as having a header)
 		$this->assertTrue( $result->hasHeader( 'User-Agent' ) );

--- a/tests/inc/HttpClient/HttpClientTest.php
+++ b/tests/inc/HttpClient/HttpClientTest.php
@@ -564,7 +564,7 @@ class HttpClientTest extends TestCase {
 
 		// Should have added User-Agent header
 		$this->assertTrue( $result->hasHeader( 'User-Agent' ) );
-		$this->assertSame( 'WordPress Remote Data Blocks/1a test.0', $result->getHeaderLine( 'User-Agent' ) );
+		$this->assertSame( 'WordPress Remote Data Blocks/1.0', $result->getHeaderLine( 'User-Agent' ) );
 	}
 
 	public function testProvideDefaultUserAgentPreservesExistingUserAgent(): void {


### PR DESCRIPTION
The `User-Agent` middleware will always set the default `User-Agent` value, but if the user provides a value that they want to use, we shouldn't overwrite that.

Also, this adds the actual plugin version to the default `User-Agent` string instead of `1.0`.