### PR TITLE
Telemetry: Improve namespace reference

### DIFF
--- a/inc/Telemetry/Telemetry.php
+++ b/inc/Telemetry/Telemetry.php
@@ -32,7 +32,7 @@ class Telemetry {
 			return;
 		}
 
-		if ( null === $telemetry && class_exists( 'Automattic\VIP\Telemetry\Telemetry' ) ) {
+		if ( null === $telemetry && class_exists( '\Automattic\VIP\Telemetry\Telemetry' ) ) {
 			$telemetry = new \Automattic\VIP\Telemetry\Telemetry( self::EVENT_PREFIX, self::get_global_properties() );
 		}
 


### PR DESCRIPTION
Across `Telemetry.php`, we check for the VIP Telemetry class with a `\` before the namespace. This PR adds a missing `\` instance.