### PR TITLE
Add blueprint.json to package files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build/",
     "inc/",
     "vendor/",
+    "blueprint.json",		
     "functions.php",
     "remote-data-blocks.php",
     "composer.json"


### PR DESCRIPTION
Allows playground link on wp.org plugin directory