### PR TITLE
Improve loaded check

### DIFF
--- a/remote-data-blocks.php
+++ b/remote-data-blocks.php
@@ -18,8 +18,10 @@ namespace RemoteDataBlocks;
 
 defined( 'ABSPATH' ) || exit();
 
-// Check if the plugin is already loaded, if so, return early to prevent duplicate plugin instances.
-if ( defined( 'REMOTE_DATA_BLOCKS__LOADED' ) ) {
+// Check if the plugin is already loaded, if so, return early to prevent
+// duplicate plugin instances. REMOTE_DATA_BLOCKS__LOADED was not introduced
+// until v0.10.0.
+if ( defined( 'REMOTE_DATA_BLOCKS__LOADED' ) || defined( 'REMOTE_DATA_BLOCKS__PLUGIN_VERSION' ) ) {
 	return;
 }
 


### PR DESCRIPTION
Improve "plugin already loaded" check to additionally check for plugin version constant. The `REMOTE_DATA_BLOCKS__LOADED` constant (and check) was not introduced until `v0.10`.

Note that since the check did not exist prior to `v0.10`, there is no way to prevent loading issues if a duplicate plugin older than `v0.10` is loaded last.