### PR TITLE
Adding the Shopify online URL

### DIFF
--- a/inc/Integrations/Shopify/Queries/GetProductById.graphql
+++ b/inc/Integrations/Shopify/Queries/GetProductById.graphql
@@ -3,6 +3,7 @@ query GetProductById($id: ID!) {
 		id
 		descriptionHtml
 		title
+		onlineStoreUrl
 		featuredImage {
 			url
 			altText

--- a/inc/Integrations/Shopify/Queries/SearchProducts.graphql
+++ b/inc/Integrations/Shopify/Queries/SearchProducts.graphql
@@ -16,6 +16,7 @@ query SearchProducts($search: String!, $limit: Int!, $cursor_next: String) {
 				id
 				title
 				descriptionHtml
+				onlineStoreUrl
 				priceRange {
 					maxVariantPrice {
 						amount

--- a/inc/Integrations/Shopify/ShopifyIntegration.php
+++ b/inc/Integrations/Shopify/ShopifyIntegration.php
@@ -63,6 +63,11 @@ class ShopifyIntegration {
 							'path' => '$.data.product.featuredImage.url',
 							'type' => 'image_url',
 						],
+						'online_store_url' => [
+							'name' => 'Online Store URL',
+							'path' => '$.data.product.onlineStoreUrl',
+							'type' => 'button_url',
+						],
 						'price' => [
 							'name' => 'Item price',
 							'path' => '$.data.product.priceRange.maxVariantPrice.amount',
@@ -117,6 +122,11 @@ class ShopifyIntegration {
 							'name' => 'Item image URL',
 							'path' => '$.node.images.edges[0].node.originalSrc',
 							'type' => 'image_url',
+						],
+						'online_store_url' => [
+							'name' => 'Online Store URL',
+							'path' => '$.node.onlineStoreUrl',
+							'type' => 'button_url',
 						],
 						'price' => [
 							'name' => 'Item price',


### PR DESCRIPTION
This fixes #692 by adding the Online Store URL to both the search and product GraphQL endpoints and output schema.

A note on testing, if you use our default store, the online store URL is blank, this appears to be because our test store is behind a password. I created a new Shopify store and published it to confirm these changes work as intended.