### PR TITLE
Fix: Update GenericHttp DataSource auth add_to enum

### DIFF
--- a/inc/Integrations/GenericHttp/GenericHttpDataSource.php
+++ b/inc/Integrations/GenericHttp/GenericHttpDataSource.php
@@ -17,7 +17,7 @@ class GenericHttpDataSource extends HttpDataSource {
 			'__version' => Types::integer(),
 			'auth' => Types::nullable(
 				Types::object( [
-					'add_to' => Types::nullable( Types::enum( 'header', 'query' ) ),
+					'add_to' => Types::nullable( Types::enum( 'header', 'queryparams' ) ),
 					'key' => Types::nullable( Types::skip_sanitize( Types::string() ) ),
 					'type' => Types::enum( 'basic', 'bearer', 'api-key', 'none' ),
 					'value' => Types::skip_sanitize( Types::string() ),


### PR DESCRIPTION
This fixes https://github.com/Automattic/remote-data-blocks/issues/706 by renaming the GenericHttpDataSource `add_to` enum value from `query` to `queryparams` to match what is being expected during validation on both frontend and backend.
