### PR TITLE
Add write permissions for issues in PR build workflow

### DIFF
--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -27,6 +27,7 @@ jobs:
     if: github.repository_owner == 'Automattic' && github.event.pull_request.draft == false && github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Attempting to fix: https://github.com/Automattic/remote-data-blocks/actions/runs/22658034116/workflow?pr=720