### PR TITLE
Fix PR build workflow failing for fork contributors

### DIFF
--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -12,7 +12,6 @@ on:
       - '**/*.md'
       - '.github/**'
       - '!.github/workflows/pr-build-live-branch.yml'
-      - '!.github/workflows/scripts/generate-playground-blueprint.js'
 
 concurrency:
   # Cancel concurrent jobs on pull_request but not push, by including the run_id in the concurrency group for the latter.
@@ -27,8 +26,7 @@ jobs:
     if: github.repository_owner == 'Automattic' && github.event.pull_request.draft == false && github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -70,9 +68,12 @@ jobs:
           if-no-files-found: 'error'
           overwrite: true
 
-      - name: Comment on PR with WordPress Playground details
-        uses: actions/github-script@v7
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const { run } = require('./.github/workflows/scripts/generate-playground-blueprint');
-            	run({ github, context });
+          name: pr-number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/pr-comment-playground.yml
+++ b/.github/workflows/pr-comment-playground.yml
@@ -2,7 +2,7 @@ name: Comment Playground Link
 
 on:
   workflow_run:
-    workflows: ["Build Live Branch"]
+    workflows: ['Build Live Branch']
     types:
       - completed
 

--- a/.github/workflows/pr-comment-playground.yml
+++ b/.github/workflows/pr-comment-playground.yml
@@ -1,0 +1,44 @@
+name: Comment Playground Link
+
+on:
+  workflow_run:
+    workflows: ["Build Live Branch"]
+    types:
+      - completed
+
+concurrency:
+  group: playground-comment-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/workflows/scripts
+
+      - name: Download PR number artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR with WordPress Playground details
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { run } = require('./.github/workflows/scripts/generate-playground-blueprint');
+            run({ github, context, prNumber: ${{ steps.pr.outputs.number }} });

--- a/.github/workflows/scripts/generate-playground-blueprint.js
+++ b/.github/workflows/scripts/generate-playground-blueprint.js
@@ -1,8 +1,9 @@
-async function run( { github, context } ) {
+async function run( { github, context, prNumber } ) {
+	const issueNumber = prNumber || context.issue.number;
 	const commentInfo = {
 		owner: context.repo.owner,
 		repo: context.repo.repo,
-		issue_number: context.issue.number,
+		issue_number: issueNumber,
 	};
 
 	const comments = ( await github.rest.issues.listComments( commentInfo ) ).data;
@@ -15,7 +16,7 @@ async function run( { github, context } ) {
 		}
 	}
 
-	const body = `Test this PR in [WordPress Playground](https://playground.wordpress.net/#{"landingPage":"/wp-admin/admin.php?page=remote-data-blocks-settings","features":{"networking":true},"login":true,"preferredVersions":{"php":"8.2","wp":"latest"},"steps":[{"step":"setSiteOptions","options":{"blogname":"Remote%20Data%20Blocks%20PR#${ context.issue.number }","blogdescription":"Explore%20the%20Remote%20Data%20Blocks%20plugin%20in%20a%20WordPress%20Playground"}},{"step":"installPlugin","pluginData":{"caption":"Installing%20RDB","resource":"url","url":"https://playground.wordpress.net/plugin-proxy.php?org=Automattic&repo=remote-data-blocks&workflow=Build%20Live%20Branch&artifact=remote-data-blocks-${ context.issue.number }&pr=${ context.issue.number }"},"options":{"activate":true,"targetFolderName":"remote-data-blocks"}}]}).`;
+	const body = `Test this PR in [WordPress Playground](https://playground.wordpress.net/#{"landingPage":"/wp-admin/admin.php?page=remote-data-blocks-settings","features":{"networking":true},"login":true,"preferredVersions":{"php":"8.2","wp":"latest"},"steps":[{"step":"setSiteOptions","options":{"blogname":"Remote%20Data%20Blocks%20PR#${ issueNumber }","blogdescription":"Explore%20the%20Remote%20Data%20Blocks%20plugin%20in%20a%20WordPress%20Playground"}},{"step":"installPlugin","pluginData":{"caption":"Installing%20RDB","resource":"url","url":"https://playground.wordpress.net/plugin-proxy.php?org=Automattic&repo=remote-data-blocks&workflow=Build%20Live%20Branch&artifact=remote-data-blocks-${ issueNumber }&pr=${ issueNumber }"},"options":{"activate":true,"targetFolderName":"remote-data-blocks"}}]}).`;
 
 	if ( existingCommentId ) {
 		await github.rest.issues.updateComment( {

--- a/tests/.github/workflows/scripts/generate-playground-blueprint.test.ts
+++ b/tests/.github/workflows/scripts/generate-playground-blueprint.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { run } = require( '../../../../.github/workflows/scripts/generate-playground-blueprint' );
+
+function createMockGithub(
+	comments: Array< { id: number; user: { type: string }; body: string } > = []
+) {
+	return {
+		rest: {
+			issues: {
+				listComments: vi.fn().mockResolvedValue( { data: comments } ),
+				createComment: vi.fn().mockResolvedValue( {} ),
+				updateComment: vi.fn().mockResolvedValue( {} ),
+			},
+		},
+	};
+}
+
+function createMockContext( issueNumber = 42 ) {
+	return {
+		repo: { owner: 'Automattic', repo: 'remote-data-blocks' },
+		issue: { number: issueNumber },
+	};
+}
+
+describe( 'generate-playground-blueprint', () => {
+	it( 'should create a new comment when no existing comment is found', async () => {
+		const github = createMockGithub();
+		const context = createMockContext( 42 );
+
+		await run( { github, context } );
+
+		expect( github.rest.issues.listComments ).toHaveBeenCalled();
+		const listCall = github.rest.issues.listComments.mock.calls[ 0 ][ 0 ];
+		expect( listCall.owner ).toBe( 'Automattic' );
+		expect( listCall.repo ).toBe( 'remote-data-blocks' );
+		expect( listCall.issue_number ).toBe( 42 );
+		const createCall = github.rest.issues.createComment.mock.calls[ 0 ][ 0 ];
+		expect( createCall.owner ).toBe( 'Automattic' );
+		expect( createCall.repo ).toBe( 'remote-data-blocks' );
+		expect( createCall.issue_number ).toBe( 42 );
+		expect( createCall.body ).toContain( 'Test this PR in' );
+		expect( github.rest.issues.updateComment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should update an existing bot comment', async () => {
+		const existingComment = {
+			id: 999,
+			user: { type: 'Bot' },
+			body: 'Test this PR in WordPress Playground',
+		};
+		const github = createMockGithub( [ existingComment ] );
+		const context = createMockContext( 42 );
+
+		await run( { github, context } );
+
+		expect( github.rest.issues.updateComment ).toHaveBeenCalledWith( {
+			owner: 'Automattic',
+			repo: 'remote-data-blocks',
+			comment_id: 999,
+			body: expect.stringContaining( 'Test this PR in' ),
+		} );
+		expect( github.rest.issues.createComment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should skip non-bot comments when searching for existing comment', async () => {
+		const userComment = {
+			id: 888,
+			user: { type: 'User' },
+			body: 'Test this PR in some other context',
+		};
+		const github = createMockGithub( [ userComment ] );
+		const context = createMockContext();
+
+		await run( { github, context } );
+
+		expect( github.rest.issues.createComment ).toHaveBeenCalled();
+		expect( github.rest.issues.updateComment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should skip bot comments that do not contain the marker text', async () => {
+		const unrelatedBotComment = {
+			id: 777,
+			user: { type: 'Bot' },
+			body: 'Some other bot comment',
+		};
+		const github = createMockGithub( [ unrelatedBotComment ] );
+		const context = createMockContext();
+
+		await run( { github, context } );
+
+		expect( github.rest.issues.createComment ).toHaveBeenCalled();
+		expect( github.rest.issues.updateComment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should use prNumber parameter instead of context.issue.number', async () => {
+		const github = createMockGithub();
+		const context = createMockContext( 42 );
+
+		await run( { github, context, prNumber: 100 } );
+
+		expect( github.rest.issues.listComments ).toHaveBeenCalledWith(
+			expect.objectContaining( { issue_number: 100 } )
+		);
+		expect( github.rest.issues.createComment ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				issue_number: 100,
+				body: expect.stringContaining( 'remote-data-blocks-100' ),
+			} )
+		);
+	} );
+
+	it( 'should fall back to context.issue.number when prNumber is not provided', async () => {
+		const github = createMockGithub();
+		const context = createMockContext( 55 );
+
+		await run( { github, context } );
+
+		expect( github.rest.issues.listComments ).toHaveBeenCalledWith(
+			expect.objectContaining( { issue_number: 55 } )
+		);
+		expect( github.rest.issues.createComment ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				issue_number: 55,
+				body: expect.stringContaining( 'remote-data-blocks-55' ),
+			} )
+		);
+	} );
+
+	it( 'should include the correct PR number in the playground URL', async () => {
+		const github = createMockGithub();
+		const context = createMockContext();
+
+		await run( { github, context, prNumber: 123 } );
+
+		const call = github.rest.issues.createComment.mock.calls[ 0 ][ 0 ];
+		expect( call.body ).toContain( 'artifact=remote-data-blocks-123' );
+		expect( call.body ).toContain( 'pr=123' );
+		expect( call.body ).toContain( 'PR#123' );
+	} );
+} );


### PR DESCRIPTION
## Summary
- Split pr-build-live-branch.yml into two workflows to fix the `Resource not accessible by integration` error that occurs when external contributors open PRs from forks
- The **build workflow** (`pull_request` trigger) keeps read-only permissions — safe for untrusted fork code
- A new **comment workflow** (`workflow_run` trigger) runs after the build completes with write permissions to post the WordPress Playground link, running in the base repo context so it always has the necessary permissions
- Updated `generate-playground-blueprint.js` to accept a `prNumber` parameter since `context.issue.number` is not available in `workflow_run` context

## Context
Fork PRs (e.g. #720) fail because the `GITHUB_TOKEN` for `pull_request`-triggered workflows from forks is restricted to read-only, regardless of declared permissions. The two-workflow split is the GitHub-recommended pattern for this scenario.

## Test plan
- [ ] Verify the build workflow succeeds for both fork and non-fork PRs
- [ ] Verify the comment workflow triggers after build completion and posts the Playground link
- [ ] Verify draft PRs and bot PRs are still skipped