### PR TITLE
Fix block navigation by adding missing block props wrapper

### DIFF
--- a/src/blocks/remote-data-template/edit.tsx
+++ b/src/blocks/remote-data-template/edit.tsx
@@ -40,8 +40,16 @@ export function Edit( props: BlockEditProps< RemoteDataTemplateBlockAttributes >
 	}
 
 	if ( 1 === remoteData.results.length ) {
-		return <div { ...innerBlocksProps } />;
+		return (
+			<div { ...blockProps }>
+				<div { ...innerBlocksProps } />
+			</div>
+		);
 	}
 
-	return <LoopTemplate getInnerBlocks={ getInnerBlocks } remoteData={ remoteData } />;
+	return (
+		<div { ...blockProps }>
+			<LoopTemplate getInnerBlocks={ getInnerBlocks } remoteData={ remoteData } />
+		</div>
+	);
 }


### PR DESCRIPTION
## Summary

Block navigation is broken on single and loop blocks because the block props attributes are missing. As a result, users cannot see whether the main block is selected or not when using the child-to-parent block navigator button.

Closes: #727

### Before
https://github.com/user-attachments/assets/722ef104-b26e-45d2-9863-e84ef47a9e92

### After
https://github.com/user-attachments/assets/1c16d1d6-2bf3-41c4-80eb-7e2d300f7681