### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,23 +21,23 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: 'weekly'
+      day: 'monday'
     open-pull-requests-limit: 10
     groups:
       actions-minor-patch:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
       actions-major:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "major"
+          - 'major'
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,24 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install subversion
 
       - name: Push to WordPress.org
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:
           SLUG: remote-data-blocks
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
 

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.2'
 

--- a/.github/workflows/pr-comment-playground.yml
+++ b/.github/workflows/pr-comment-playground.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Expose built artifact
         id: expose
-        uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+        uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@06d6a7e5e287101f5a496ef3361aa07967448813 # v2.0.1
         with:
           artifact-name: remote-data-blocks-pr${{ steps.pr.outputs.number }}-${{ steps.pr.outputs.sha }}
           artifact-filename: remote-data-blocks.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Setup PHP
         if: steps.version_check.outputs.new_version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create Release
         if: steps.version_check.outputs.new_version
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: v${{ steps.version_check.outputs.new_version }}
           files: remote-data-blocks.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php-version }}
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.php-version == '8.3' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: ./coverage/phpunit/clover.xml
         env:
@@ -59,7 +59,7 @@ jobs:
         run: npm run test:js:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: ./coverage/vitest/clover.xml
         env:


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

Tracking: DEVPROD-1072

Changes:
- Pins 5 distinct third-party action refs to full commit SHAs with readable version comments.
- Updates: .github/dependabot.yml, .github/workflows/deploy.yml, .github/workflows/lint.yml, .github/workflows/pr-build-live-branch.yml, .github/workflows/pr-comment-playground.yml, .github/workflows/release.yml, .github/workflows/test.yml
- Dependabot GitHub Actions coverage: appended (.github/dependabot.yml)

Verification commands:

```bash
# 10up/action-wordpress-plugin-deploy # 2.3.0 -> 54bd289b8525fd23a5c365ec369185f2966529c2
gh api repos/10up/action-wordpress-plugin-deploy/commits/2.3.0 --jq '.sha'
# expected: 54bd289b8525fd23a5c365ec369185f2966529c2

# codecov/codecov-action # v4.6.0 -> b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
gh api repos/codecov/codecov-action/commits/v4.6.0 --jq '.sha'
# expected: b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# softprops/action-gh-release # v2.6.2 -> 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
gh api repos/softprops/action-gh-release/commits/v2.6.2 --jq '.sha'
# expected: 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65

# WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url # v2.0.1 -> 06d6a7e5e287101f5a496ef3361aa07967448813
gh api repos/WordPress/action-wp-playground-pr-preview/commits/v2.0.1 --jq '.sha'
# expected: 06d6a7e5e287101f5a496ef3361aa07967448813
```
