### PR TITLE
Fix Playground PR comment URL encoding

### DIFF
--- a/.github/workflows/pr-comment-playground.yml
+++ b/.github/workflows/pr-comment-playground.yml
@@ -82,7 +82,7 @@ jobs:
               ],
             });
 
-            const playgroundUrl = `https://playground.wordpress.net/#${blueprint}`;
+            const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(blueprint)}`;
             const body = `Test this PR in [WordPress Playground](${playgroundUrl}).`;
 
             const commentInfo = {


### PR DESCRIPTION
## Summary
- URL-encode the WordPress Playground blueprint before embedding it in the PR comment Markdown link
- Prevent spaces and punctuation in blueprint values like `blogname` from breaking GitHub comment formatting

## Testing
- `npm run format:check -- .github/workflows/pr-comment-playground.yml`
