### PR TITLE
Complete HTTP data source tutorial

### DIFF
--- a/docs/tutorials/http.md
+++ b/docs/tutorials/http.md
@@ -16,8 +16,84 @@ This page will walk you through registering a remote data block that loads data 
 
 ## Register the block
 
-In code, we'll define a query using the data source we just created. Follow the [Zip code block example](https://github.com/Automattic/remote-data-blocks/tree/trunk/example/blocks/zip-code-block/zip-code-block.php), but remove the data source definition. In its place, use this code to load the data source we just created by its UUID:
+Next, define a query and register a block using the data source you just created. Add this code to your theme's `functions.php` file or a custom plugin, replacing `{{ Data source UUID }}` with the UUID you copied from the data source list.
 
 ```php
-$data_source = HttpDataSource::from_uuid( '{{ Data source UUID }}' );
+<?php
+
+use RemoteDataBlocks\Config\DataSource\HttpDataSource;
+
+function register_zip_code_remote_data_block(): void {
+	$zip_code_data_source = HttpDataSource::from_uuid( '{{ Data source UUID }}' );
+
+	if ( is_wp_error( $zip_code_data_source ) ) {
+		return;
+	}
+
+	$zip_code_query = [
+		'data_source' => $zip_code_data_source,
+		'display_name' => 'Get location by Zip code',
+		'endpoint' => function ( array $input_variables ) use ( $zip_code_data_source ): string {
+			return $zip_code_data_source->get_endpoint() . $input_variables['zip_code'];
+		},
+		'input_schema' => [
+			'zip_code' => [
+				'name' => 'Zip Code',
+				'type' => 'string',
+			],
+		],
+		'output_schema' => [
+			'is_collection' => false,
+			'type' => [
+				'zip_code' => [
+					'name' => 'Zip Code',
+					'path' => '$["post code"]',
+					'type' => 'string',
+				],
+				'city' => [
+					'name' => 'City',
+					'path' => '$.places[0]["place name"]',
+					'type' => 'string',
+				],
+				'state' => [
+					'name' => 'State',
+					'path' => '$.places[0].state',
+					'type' => 'string',
+				],
+			],
+		],
+	];
+
+	register_remote_data_block( [
+		'title' => 'Zip Code',
+		'render_query' => [
+			'query' => $zip_code_query,
+		],
+	] );
+}
+add_action( 'init', 'register_zip_code_remote_data_block' );
 ```
+
+This code:
+
+1. Loads the data source by UUID using `HttpDataSource::from_uuid()`.
+2. Defines a render query that accepts a zip code, appends it to the data source endpoint, and maps the response fields to block outputs.
+3. Registers a "Zip Code" block that uses the render query.
+
+For example, if the editor provides `90210`, the query requests `https://api.zippopotam.us/us/90210` and maps the `post code`, `place name`, and `state` fields from the API response.
+
+## Insert the block
+
+Create or edit a page or post, then search for "Zip Code" in the block inserter. After inserting the block, enter a valid US zip code, such as `90210`, to fetch and display location data.
+
+## Patterns and styling
+
+The plugin registers an unstyled block pattern for each remote data block. You can duplicate that default pattern in the Site Editor and associate a custom pattern with your block later. Read more in [Block patterns](../extending/block-patterns.md).
+
+Remote data blocks can also be styled with the block editor's style settings, `theme.json`, or custom stylesheets.
+
+## Code reference
+
+The [Zip Code block example](https://github.com/Automattic/remote-data-blocks/tree/trunk/example/blocks/zip-code-block/zip-code-block.php) shows a similar block with the data source defined entirely in code.
+
+The [REST API block from UI-created data source template](https://github.com/Automattic/remote-data-blocks/tree/trunk/example/templates/rest-api-block-from-ui-data-source) shows a larger template for APIs that need both render and selection queries.

--- a/inc/Config/DataSource/HttpDataSource.php
+++ b/inc/Config/DataSource/HttpDataSource.php
@@ -30,13 +30,7 @@ class HttpDataSource extends ArraySerializable implements HttpDataSourceInterfac
 	}
 
 	public static function from_uuid( string $uuid ): DataSourceInterface|WP_Error {
-		$config = DataSourceCrud::get_config_by_uuid( $uuid );
-
-		if ( is_wp_error( $config ) ) {
-			return $config;
-		}
-
-		return static::from_array( $config );
+		return DataSourceCrud::get_inflated_config_by_uuid( $uuid );
 	}
 
 	/**

--- a/tests/inc/Docs/HttpTutorialExampleTest.php
+++ b/tests/inc/Docs/HttpTutorialExampleTest.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types = 1);
+
+namespace RemoteDataBlocks\Tests\Docs;
+
+use PHPUnit\Framework\TestCase;
+use RemoteDataBlocks\Config\DataSource\HttpDataSource;
+use RemoteDataBlocks\Config\Query\HttpQuery;
+use RemoteDataBlocks\Editor\BlockManagement\ConfigRegistry;
+use RemoteDataBlocks\Editor\BlockManagement\ConfigStore;
+use RemoteDataBlocks\Tests\Mocks\MockLogger;
+use RemoteDataBlocks\Tests\Mocks\MockWordPressFunctions;
+use RemoteDataBlocks\WpdbStorage\DataSourceCrud;
+
+use function register_remote_data_block;
+
+class HttpTutorialExampleTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		ConfigRegistry::init( new MockLogger() );
+	}
+
+	protected function tearDown(): void {
+		MockWordPressFunctions::reset();
+	}
+
+	public function test_http_data_source_tutorial_example_registers_block(): void {
+		$data_source_config = DataSourceCrud::create_config( [
+			'service' => REMOTE_DATA_BLOCKS_GENERIC_HTTP_SERVICE,
+			'service_config' => [
+				'__version' => 1,
+				'auth' => [
+					'type' => 'none',
+					'value' => '',
+				],
+				'display_name' => 'Zip Code API',
+				'endpoint' => 'https://api.zippopotam.us/us/',
+			],
+			'uuid' => '00000000-0000-4000-8000-000000000001',
+		] );
+
+		$this->assertIsArray( $data_source_config );
+
+		$zip_code_data_source = HttpDataSource::from_uuid( $data_source_config['uuid'] );
+
+		if ( is_wp_error( $zip_code_data_source ) ) {
+			$this->fail( $zip_code_data_source->get_error_message() );
+		}
+
+		$zip_code_query = [
+			'data_source' => $zip_code_data_source,
+			'display_name' => 'Get location by Zip code',
+			'endpoint' => function ( array $input_variables ) use ( $zip_code_data_source ): string {
+				return $zip_code_data_source->get_endpoint() . $input_variables['zip_code'];
+			},
+			'input_schema' => [
+				'zip_code' => [
+					'name' => 'Zip Code',
+					'type' => 'string',
+				],
+			],
+			'output_schema' => [
+				'is_collection' => false,
+				'type' => [
+					'zip_code' => [
+						'name' => 'Zip Code',
+						'path' => '$["post code"]',
+						'type' => 'string',
+					],
+					'city' => [
+						'name' => 'City',
+						'path' => '$.places[0]["place name"]',
+						'type' => 'string',
+					],
+					'state' => [
+						'name' => 'State',
+						'path' => '$.places[0].state',
+						'type' => 'string',
+					],
+				],
+			],
+		];
+
+		$registration_result = register_remote_data_block( [
+			'title' => 'Zip Code',
+			'render_query' => [
+				'query' => $zip_code_query,
+			],
+		] );
+
+		$this->assertTrue( $registration_result );
+
+		$block_config = ConfigStore::get_block_configuration( 'remote-data-blocks/zip-code' );
+		$this->assertIsArray( $block_config );
+		$this->assertInstanceOf( HttpQuery::class, $block_config['queries']['display'] );
+		$this->assertSame(
+			'https://api.zippopotam.us/us/90210',
+			$block_config['queries']['display']->get_endpoint( [ 'zip_code' => '90210' ] )
+		);
+	}
+}


### PR DESCRIPTION
## What
- Completes the HTTP data source tutorial with an end-to-end Zip Code block registration example.
- Fixes `HttpDataSource::from_uuid()` so UI-created/stored data sources are inflated before use.
- Adds a PHPUnit smoke test that follows the tutorial path: create a stored generic HTTP data source, load it by UUID, register the block, and verify the generated endpoint.

## Verification
- `npm run format:check -- docs/tutorials/http.md tests/inc/Docs/HttpTutorialExampleTest.php inc/Config/DataSource/HttpDataSource.php`
- `vendor/bin/phpcs inc/Config/DataSource/HttpDataSource.php tests/inc/Docs/HttpTutorialExampleTest.php`
- `vendor/bin/phpunit tests/inc/Docs/HttpTutorialExampleTest.php`
- `vendor/bin/phpunit tests/inc/Config/HttpDataSourceTest.php`
- `vendor/bin/phpunit tests/inc/WpdbStorage/DataSourceCrudTest.php`
- `curl -fsSL https://api.zippopotam.us/us/90210 | jq '{post_code:."post code", city:.places[0]."place name", state:.places[0].state}'`

Local caveats:
- Full `vendor/bin/phpunit` currently fails under local PHP 8.5 on three unrelated deprecation/runtime notices.
- `vendor/bin/psalm.phar --no-cache` cannot run under local PHP 8.5 because the phar supports PHP through 8.4.x.

Fixes #710
Supersedes #711