### PR TITLE
Fix WordPress.org deploy version dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,13 @@ on:
     types: [published, released]
   # Allow manual triggering of the workflow.
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Plugin version to deploy, without the v prefix.'
+        required: true
+      ref:
+        description: 'Git ref to build and deploy.'
+        required: true
 
 jobs:
   release:
@@ -13,6 +20,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Determine deploy version
+        run: |
+          VERSION="${INPUT_VERSION:-${GITHUB_REF_NAME#v}}"
+          echo "DEPLOY_VERSION=${VERSION}" >> "$GITHUB_ENV"
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
 
       - name: Build
         run: |
@@ -30,3 +46,4 @@ jobs:
           SLUG: remote-data-blocks
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          VERSION: ${{ env.DEPLOY_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,4 +57,8 @@ jobs:
         if: steps.version_check.outputs.new_version
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run deploy.yml --ref trunk
+        run: |
+          gh workflow run deploy.yml \
+            --ref trunk \
+            -f version=${{ steps.version_check.outputs.new_version }} \
+            -f ref=v${{ steps.version_check.outputs.new_version }}


### PR DESCRIPTION
## Summary
- pass the release version and tag ref when the release workflow dispatches the WordPress.org deploy workflow
- make the deploy workflow check out the requested release ref and pass the clean plugin version to the 10up deploy action

## Testing
- Parsed updated workflow YAML locally with Ruby

## Notes
This fixes the failed v1.6.0 deploy where the deploy action saw `refs/heads/trunk` as the version and tried to copy to `tags/refs/heads` in SVN.
