### PR TITLE
Fix item template editor grid layout

### DIFF
--- a/src/blocks/remote-data-template/editor.scss
+++ b/src/blocks/remote-data-template/editor.scss
@@ -1,3 +1,8 @@
+[data-type="remote-data-blocks/template"],
+.remote-data-blocks-loop-template {
+	display: contents;
+}
+
 .remote-data-blocks-loop-template {
 	list-style: none;
 	padding: 0;


### PR DESCRIPTION
Summary
- Make the Item Template block editor wrapper layout-transparent with display: contents.
- Make the editor preview list layout-transparent so preview items can participate in parent grid/flex layouts.

Verification
- npm run lint:css
- npm run build

Fixes Automattic/remote-data-blocks#729