### PR TITLE
Add auto-register blocks default filter

### DIFF
--- a/docs/extending/hooks.md
+++ b/docs/extending/hooks.md
@@ -52,6 +52,14 @@ Filter whether to register the included example API block ("Conference Event") (
 add_filter( 'remote_data_blocks_register_example_block', '__return_false' );
 ```
 
+### remote_data_blocks_auto_register_blocks_default
+
+Filter the default value of the "Auto-register blocks" option when adding a data source in the plugin settings screen (default: `true`).
+
+```php
+add_filter( 'remote_data_blocks_auto_register_blocks_default', '__return_false' );
+```
+
 ### remote_data_blocks_allowed_url_schemes
 
 Filter the allowed URL schemes for this request. Only HTTPS is allowed by default, but it might be useful to relax this restriction in local environments.

--- a/inc/PluginSettings/PluginSettings.php
+++ b/inc/PluginSettings/PluginSettings.php
@@ -69,9 +69,20 @@ class PluginSettings {
 			'REMOTE_DATA_BLOCKS_SETTINGS',
 			[
 				...( self::is_dev() ? self::get_build() : [] ),
+				'auto_register_blocks_default' => self::get_auto_register_blocks_default(),
 				'version' => self::get_version(),
 			]
 		);
+	}
+
+	public static function get_auto_register_blocks_default(): bool {
+		/**
+		 * Filter the default value of the "Auto-register blocks" option for newly
+		 * configured data sources.
+		 *
+		 * @param bool $auto_register_blocks_default Whether the option should be enabled by default.
+		 */
+		return (bool) apply_filters( 'remote_data_blocks_auto_register_blocks_default', true );
 	}
 
 	/**

--- a/src/data-sources/airtable/AirtableSettings.tsx
+++ b/src/data-sources/airtable/AirtableSettings.tsx
@@ -7,6 +7,7 @@ import { DataSourceForm } from '@/data-sources/components/DataSourceForm';
 import { FieldsSelection } from '@/data-sources/components/FieldsSelection';
 import PasswordInputControl from '@/data-sources/components/PasswordInputControl';
 import { ConfigSource } from '@/data-sources/constants';
+import { getAutoRegisterBlocksDefault } from '@/data-sources/defaults';
 import {
 	useAirtableApiBases,
 	useAirtableApiTables,
@@ -44,7 +45,7 @@ export const AirtableSettings = ( {
 	const { state, handleOnChange, validState } = useForm< AirtableServiceConfig >( {
 		initialValues: config?.service_config ?? {
 			__version: SERVICE_CONFIG_VERSION,
-			enable_blocks: true,
+			enable_blocks: getAutoRegisterBlocksDefault(),
 		},
 	} );
 	const { fetchingUserId, userId, userIdError } = useAirtableApiUserId( state.access_token ?? '' );

--- a/src/data-sources/defaults.ts
+++ b/src/data-sources/defaults.ts
@@ -1,0 +1,3 @@
+export function getAutoRegisterBlocksDefault(): boolean {
+	return window.REMOTE_DATA_BLOCKS_SETTINGS?.auto_register_blocks_default ?? true;
+}

--- a/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
+++ b/src/data-sources/google-sheets/GoogleSheetsSettings.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { DataSourceForm } from '@/data-sources/components/DataSourceForm';
 import { FieldsSelection } from '@/data-sources/components/FieldsSelection';
 import { GOOGLE_SHEETS_API_SCOPES, ConfigSource } from '@/data-sources/constants';
+import { getAutoRegisterBlocksDefault } from '@/data-sources/defaults';
 import { useDataSources } from '@/data-sources/hooks/useDataSources';
 import {
 	useGoogleSheetsWithFields,
@@ -62,7 +63,7 @@ export const GoogleSheetsSettings = ( {
 	const { state, errors, handleOnChange, validState } = useForm< GoogleSheetsServiceConfig >( {
 		initialValues: config?.service_config ?? {
 			__version: SERVICE_CONFIG_VERSION,
-			enable_blocks: true,
+			enable_blocks: getAutoRegisterBlocksDefault(),
 		},
 		validationRules,
 	} );

--- a/src/data-sources/shopify/ShopifySettings.tsx
+++ b/src/data-sources/shopify/ShopifySettings.tsx
@@ -6,6 +6,7 @@ import { MOCK_SHOP_STORE } from '@/data-sources/api-clients/shopify';
 import { DataSourceForm } from '@/data-sources/components/DataSourceForm';
 import PasswordInputControl from '@/data-sources/components/PasswordInputControl';
 import { ConfigSource } from '@/data-sources/constants';
+import { getAutoRegisterBlocksDefault } from '@/data-sources/defaults';
 import { useDataSources } from '@/data-sources/hooks/useDataSources';
 import { useShopifyShopName } from '@/data-sources/hooks/useShopify';
 import { SettingsComponentProps, ShopifyConfig, ShopifyServiceConfig } from '@/data-sources/types';
@@ -24,7 +25,7 @@ export const ShopifySettings = ( {
 	const { state, handleOnChange, validState } = useForm< ShopifyServiceConfig >( {
 		initialValues: config?.service_config ?? {
 			__version: SERVICE_CONFIG_VERSION,
-			enable_blocks: true,
+			enable_blocks: getAutoRegisterBlocksDefault(),
 		},
 	} );
 

--- a/tests/inc/PluginSettings/PluginSettingsTest.php
+++ b/tests/inc/PluginSettings/PluginSettingsTest.php
@@ -76,4 +76,11 @@ class PluginSettingsTest extends TestCase {
 			$output
 		);
 	}
+
+	public function testGetAutoRegisterBlocksDefaultUsesFilteredValue(): void {
+		MockWordPressFunctions::add_mock_filter( 'remote_data_blocks_auto_register_blocks_default', false );
+
+		$this->assertFalse( PluginSettings::get_auto_register_blocks_default() );
+		$this->assertSame( [], MockWordPressFunctions::get_done_filter( 'remote_data_blocks_auto_register_blocks_default' ) );
+	}
 }

--- a/types/localized-settings.d.ts
+++ b/types/localized-settings.d.ts
@@ -1,4 +1,5 @@
 interface LocalizedSettingsData {
+	auto_register_blocks_default: boolean;
 	branch: string;
 	hash: string;
 	version: string;


### PR DESCRIPTION
Summary
- Add the `remote_data_blocks_auto_register_blocks_default` PHP filter for the default value of the settings-screen "Auto-register blocks" option.
- Localize the filtered default into the settings app and use it for new Airtable, Google Sheets, and Shopify data sources.
- Document the hook and add focused PHP test coverage.

Verification
- `vendor/bin/phpunit --filter PluginSettingsTest`
- `npm run check-types`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `vendor/bin/phpcs --standard=phpcs.xml inc/PluginSettings/PluginSettings.php tests/inc/PluginSettings/PluginSettingsTest.php`
- `npm run test:js`

Note: `vendor/bin/phpunit` was also attempted locally on PHP 8.5.7, but the full suite hit unrelated PHP 8.5 deprecation errors in `Pagination`, URL validation, and email validation tests. The targeted PluginSettings test passes.

Fixes Automattic/remote-data-blocks#725
