### PR TITLE
Add alignment support to generated remote data blocks

### DIFF
--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -105,6 +105,9 @@ class BlockRegistration {
 			'settings' => [
 				'category' => self::$block_category['slug'],
 				'icon' => $config['icon'] ?? 'cloud',
+				'supports' => [
+					'align' => true,
+				],
 				'title' => $config['title'],
 			],
 		];

--- a/src/blocks/remote-data-container/block.json
+++ b/src/blocks/remote-data-container/block.json
@@ -11,6 +11,7 @@
     "remote-data-blocks/remoteData": "remoteData"
   },
   "supports": {
+    "align": true,
     "background": {
       "backgroundImage": true,
       "backgroundSize": true

--- a/tests/inc/Editor/BlockRegistrationTest.php
+++ b/tests/inc/Editor/BlockRegistrationTest.php
@@ -382,6 +382,47 @@ class BlockRegistrationTest extends TestCase {
 		$this->assertArrayHasKey( 'selectors', $block_config );
 	}
 
+	public function test_register_block_configuration_includes_alignment_support(): void {
+		$test_query_runner = $this->get_query_runner_with_response( [] );
+
+		$test_data_source = HttpDataSource::from_array( [
+			'__version' => 1,
+			'display_name' => 'Test API',
+			'endpoint' => 'https://example.com/test-api',
+		] );
+
+		$test_query = HttpQuery::from_array( [
+			'data_source' => $test_data_source,
+			'query_runner' => $test_query_runner,
+			'output_schema' => [
+				'is_collection' => false,
+				'type' => [
+					'title' => [
+						'name' => 'Title',
+						'path' => '$.title',
+						'type' => 'string',
+					],
+				],
+			],
+		] );
+
+		$registration_result = register_remote_data_block( [
+			'title' => 'Alignable Test Block',
+			'name' => 'alignable-test-block',
+			'render_query' => [
+				'query' => $test_query,
+			],
+		] );
+
+		$this->assertTrue( $registration_result );
+
+		[ $block_config ] = BlockRegistration::register_block_configuration(
+			ConfigStore::get_block_configuration( 'remote-data-blocks/alignable-test-block' )
+		);
+
+		$this->assertTrue( $block_config['settings']['supports']['align'] );
+	}
+
 	/**
 	 * Create a mock query runner for testing.
 	 *

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -25,6 +25,19 @@ function register_block_pattern( string $_name, array $_options ): void {
 	// Do nothing
 }
 
+function register_block_pattern_category( string $_name, array $_options ): void {
+	// Do nothing
+}
+
+function register_block_type( string $_block_path, array $_options = [] ): object {
+	return (object) [
+		'editor_script_handles' => [ 'remote-data-blocks-container-editor-script' ],
+		'name' => $_options['name'] ?? 'remote-data-blocks/container',
+		'supports' => $_options['supports'] ?? [],
+		'title' => $_options['title'] ?? 'Remote Data Container',
+	];
+}
+
 function is_multisite(): void {
 	// Do nothing
 }

--- a/types/localized-block-data.d.ts
+++ b/types/localized-block-data.d.ts
@@ -44,6 +44,9 @@ interface BlockConfig {
 		category: string;
 		description?: string;
 		icon?: ReactElement | IconType | ComponentType;
+		supports?: {
+			align?: boolean | Array< 'left' | 'center' | 'right' | 'wide' | 'full' >;
+		};
 		title: string;
 	};
 }


### PR DESCRIPTION
## Summary
- Enable core alignment support on generated Remote Data Block containers.
- Pass the same support flag through localized block settings so the auto-registered editor block exposes alignment controls.
- Add a focused registration test for the localized support config.

## Verification
- `composer test -- --filter BlockRegistrationTest`
- `npm run check-types`
- `npm run build` (passes with existing webpack size warnings)
- `npm run lint`
- `npm run format:check`
- `composer phpcs` (passes with existing PHPCS deprecation warnings)

Psalm was not runnable locally because the installed Homebrew PHP is 8.5.7 and the Psalm box only allows supported PHP versions through 8.4.x.

Fixes Automattic/remote-data-blocks#313.
