### PR TITLE
Fix Safari inline binding selection styling

### DIFF
--- a/src/blocks/remote-data-container/editor.scss
+++ b/src/blocks/remote-data-container/editor.scss
@@ -46,7 +46,16 @@ h4.remote-data-blocks-new-item-heading {
 remote-data-blocks-inline-field {
 	background-color: #bfdbfe;
 	border-radius: 0.5rem;
+	display: inline-block;
 	padding: 0.15rem 0.35rem;
+	-webkit-user-select: none;
+	user-select: none;
+	vertical-align: baseline;
+}
+
+.rich-text span[data-rich-text-bogus]:has(> remote-data-blocks-inline-field) {
+	-webkit-user-select: none;
+	user-select: none;
 }
 
 .rich-text:focus remote-data-blocks-inline-field[data-rich-text-format-boundary] {


### PR DESCRIPTION
## What

Fixes #705 by making inline binding objects behave as atomic, non-selectable editor elements in WebKit/Safari.

## Why

Inline bindings are stored as non-editable rich-text replacements. WordPress renders those with a generated `span[data-rich-text-bogus]` wrapper around the `remote-data-blocks-inline-field` element. RDB was styling only the inner custom element, so Safari could still paint native text selection across the wrapper/nearby text when the inline binding was pressed.

This makes both the inline field and its generated rich-text wrapper non-selectable, and renders the field as `inline-block` so WebKit treats it as a single inline object.

## Testing

- `npm run lint:css`
- `npm run check-types`
- `npm run format:check`
- `npm run build`
- Playwright WebKit sanity check confirming `:has()` support and `-webkit-user-select: none` computed on the generated wrapper pattern

I could not run native Safari WebDriver locally because enabling `safaridriver` prompts for the macOS password, but the patch targets the WebKit/Safari selection behavior directly.
