### PR TITLE
Move Psalm to level 6

### DIFF
--- a/example/templates/airtable-map-block/src/leaflet-map/render.php
+++ b/example/templates/airtable-map-block/src/leaflet-map/render.php
@@ -2,6 +2,7 @@
 
 use RemoteDataBlocks\Integrations\Airtable\AirtableDataSource;
 use RemoteDataBlocks\Integrations\Airtable\AirtableIntegration;
+use RemoteDataBlocks\Config\Query\HttpQuery;
 
 $access_token = '{{ Airtable access token }}'; // Airtable access token ("pat...")
 $base_id = '{{ Airtable base ID }}'; // Airtable base ID ("app...")
@@ -51,19 +52,22 @@ $map_data_source = AirtableDataSource::from_array( [
 	],
 ] );
 
-$get_locations_query = AirtableIntegration::get_list_query( $map_data_source, $table );
-$response = $get_locations_query->execute( [] );
 $coordinates = [];
 
-if ( ! is_wp_error( $response ) ) {
-	$coordinates = array_map( function ( $value ) {
-		$result = $value['result'];
-		return [
-			'name' => $result['name']['value'],
-			'x' => $result['x']['value'],
-			'y' => $result['y']['value'],
-		];
-	}, $response['results'] );
+if ( ! is_wp_error( $map_data_source ) ) {
+	$get_locations_query = HttpQuery::from_array( AirtableIntegration::get_list_query( $map_data_source, $table ) );
+	$response = is_wp_error( $get_locations_query ) ? $get_locations_query : $get_locations_query->execute( [] );
+
+	if ( ! is_wp_error( $response ) ) {
+		$coordinates = array_map( function ( $value ) {
+			$result = $value['result'];
+			return [
+				'name' => $result['name']['value'],
+				'x' => $result['x']['value'],
+				'y' => $result['y']['value'],
+			];
+		}, $response['results'] );
+	}
 }
 
 ?>

--- a/example/templates/rest-api-block-from-ui-data-source/rest-api-block-from-ui-data-source.php
+++ b/example/templates/rest-api-block-from-ui-data-source/rest-api-block-from-ui-data-source.php
@@ -15,13 +15,17 @@ use RemoteDataBlocks\Config\DataSource\HttpDataSource;
 function register_basic_rest_api_remote_data_block_from_uuid(): void {
 	$api_data_source = HttpDataSource::from_uuid( '{{ UUID of the data source }}' );
 
+	if ( is_wp_error( $api_data_source ) ) {
+		return;
+	}
+
 	// Get item query: Fetch one record by ID.
 	$get_item_query = [
 		'data_source' => $api_data_source,
 		// Provide a callable (closure) to dynamically generate the endpoint using
 		// the base endpoint from the data source and the input variables.
 		'endpoint' => function ( array $input_variables ) use ( $api_data_source ): string {
-			$endpoint = $api_data_source['endpoint'];
+			$endpoint = $api_data_source->get_endpoint();
 			$item_id = $input_variables['id'] ?? '';
 
 			return $endpoint . '/items/' . $item_id;
@@ -69,7 +73,7 @@ function register_basic_rest_api_remote_data_block_from_uuid(): void {
 		// Provide a callable (closure) to dynamically generate the endpoint using
 		// the base endpoint from the data source and the input variables.
 		'endpoint' => function ( array $input_variables ) use ( $api_data_source ): string {
-			$endpoint = $api_data_source['endpoint'] . '/items';
+			$endpoint = $api_data_source->get_endpoint() . '/items';
 
 			$query_params = [];
 

--- a/inc/Config/ArraySerializableInterface.php
+++ b/inc/Config/ArraySerializableInterface.php
@@ -6,6 +6,7 @@ use RemoteDataBlocks\Validation\ValidatorInterface;
 use WP_Error;
 
 interface ArraySerializableInterface {
+	/** @psalm-suppress AmbiguousConstantInheritance */
 	final public const CLASS_REF_ATTRIBUTE = '__class';
 
 	/**

--- a/inc/Config/BlockAttribute/RemoteDataBlockAttribute.php
+++ b/inc/Config/BlockAttribute/RemoteDataBlockAttribute.php
@@ -50,7 +50,8 @@ class RemoteDataBlockAttribute extends ArraySerializable {
 				'uuid' => wp_generate_uuid4(),
 				'result' => array_reduce(
 					array_keys( $result ),
-					function ( array $carry, string $name ) use ( $result ): array {
+					function ( array $carry, mixed $name ) use ( $result ): array {
+						$name = strval( $name );
 						$carry[ $name ] = [
 							'name' => $name, // We have lost the name, use the slug.
 							'type' => 'unknown', // We have lost the type information.

--- a/inc/Config/QueryRunner/QueryRunner.php
+++ b/inc/Config/QueryRunner/QueryRunner.php
@@ -130,9 +130,10 @@ class QueryRunner implements QueryRunnerInterface {
 	 *
 	 * @param array<string, mixed> $request_details The parsed request details for the current request.
 	 * @param array<string, mixed> $input_variables The input variables for the current request.
-	 * @return array{
+	 * @return WP_Error|array{
+	 *   input_variables: array<string, mixed>,
 	 *   metadata:      array<string, string|int|null>,
-	 *   response_data: string|array|object|null|WP_Error,
+	 *   response_data: string|array|object|null,
 	 * }
 	 */
 	protected function get_raw_response_data( array $request_details, array $input_variables ): array|WP_Error {
@@ -166,13 +167,13 @@ class QueryRunner implements QueryRunnerInterface {
 	 * inline bindings.
 	 *
 	 * @param HttpQueryInterface $query The query.
-	 * @param array $raw_response_data  The raw response data from `get_raw_response_data`.
-	 * @param array $query_results      The results of the query.
-	 * @return array array<string, array{
+	 * @param array<string, mixed> $raw_response_data The raw response data from `get_raw_response_data`.
+	 * @param array<int, array<string, mixed>> $query_results The results of the query.
+	 * @return array<string, array{
 	 *   name:  string,
 	 *   type:  string,
 	 *   value: string|int|null,
-	 * }>,
+	 * }>
 	 */
 	protected function get_response_metadata( HttpQueryInterface $query, array $raw_response_data, array $query_results ): array {
 		$age = intval( $raw_response_data['metadata']['age'] ?? 0 );
@@ -265,6 +266,7 @@ class QueryRunner implements QueryRunnerInterface {
 		$parser = new QueryResponseParser();
 		$results = $parser->parse( $response_data, $output_schema, $raw_response_data );
 		$results = $is_collection ? $results : [ $results ];
+		/** @var array<int, array<string, mixed>> $results */
 		$metadata = $this->get_response_metadata( $query, $raw_response_data, $results );
 
 		// Pagination schema defines how to extract pagination data from the response.
@@ -272,7 +274,9 @@ class QueryRunner implements QueryRunnerInterface {
 		$pagination_schema = $query->get_pagination_schema();
 
 		if ( is_array( $pagination_schema ) ) {
-			$pagination_data = $parser->parse( $response_data, [ 'type' => $pagination_schema ] )['result'] ?? null;
+			$parsed_pagination_data = $parser->parse( $response_data, [ 'type' => $pagination_schema ] );
+			/** @var array<string, mixed> $parsed_pagination_data */
+			$pagination_data = $parsed_pagination_data['result'] ?? null;
 
 			if ( is_array( $pagination_data ) ) {
 				$pagination = [];
@@ -293,14 +297,14 @@ class QueryRunner implements QueryRunnerInterface {
 	}
 
 	/**
-	 * @inheritDoc
+	 * @param array<int, array<string, mixed>> $array_of_input_variables An array of input variables for each request.
 	 */
 	public function execute_batch( HttpQueryInterface $query, array $array_of_input_variables ): array|WP_Error {
 		// If the query supports a `id:list` input variable and the query inputs
 		// consist entirely of variables that match that variable type, we can
 		// consolidate the queries into a single request.
 		$input_schema = $query->get_input_schema();
-		$id_list_input = array_filter( $input_schema, function ( string $slug ) use ( $input_schema ): bool {
+		$id_list_input = array_filter( $input_schema, function ( mixed $slug ) use ( $input_schema ): bool {
 			return 'id:list' === $input_schema[ $slug ]['type'];
 		}, ARRAY_FILTER_USE_KEY );
 

--- a/inc/Editor/BlockManagement/BlockRegistration.php
+++ b/inc/Editor/BlockManagement/BlockRegistration.php
@@ -12,7 +12,7 @@ use function register_block_type;
 
 class BlockRegistration {
 	/**
-	 * @var array<string, string>
+	 * @var array{icon: string|null, slug: string, title: string}
 	 */
 	public static array $block_category = [
 		'icon' => null,

--- a/inc/Editor/BlockManagement/ConfigRegistry.php
+++ b/inc/Editor/BlockManagement/ConfigRegistry.php
@@ -53,6 +53,10 @@ class ConfigRegistry {
 		}
 
 		$display_query = self::inflate_query( $block_config[ self::RENDER_QUERY_KEY ]['query'] );
+		if ( is_wp_error( $display_query ) ) {
+			return $display_query;
+		}
+
 		$input_schema = $display_query->get_input_schema();
 		$output_schema = $display_query->get_output_schema();
 		$is_collection = true === ( $output_schema['is_collection'] ?? false );
@@ -93,6 +97,10 @@ class ConfigRegistry {
 		// selecting data for display by the block.
 		foreach ( $block_config[ self::SELECTION_QUERIES_KEY ] ?? [] as $selection_query ) {
 			$from_query = self::inflate_query( $selection_query['query'] );
+			if ( is_wp_error( $from_query ) ) {
+				return $from_query;
+			}
+
 			$from_query_type = $selection_query['type'];
 			$to_query = $display_query;
 
@@ -155,6 +163,7 @@ class ConfigRegistry {
 		$pattern_name = 'remote-data-blocks/' . sanitize_title_with_dashes( $pattern_title, '', 'save' );
 
 		// Create the pattern properties, allowing overrides via pattern options.
+		/** @var array<string, mixed> $pattern_properties */
 		$pattern_properties = [
 			'blockTypes' => [ $block_name ],
 			'categories' => [ 'remote-data-blocks' ],
@@ -176,7 +185,7 @@ class ConfigRegistry {
 		return new WP_Error( 'block_registration_error', $error_message );
 	}
 
-	private static function inflate_query( array|QueryInterface $config ): QueryInterface {
+	private static function inflate_query( array|QueryInterface $config ): QueryInterface|WP_Error {
 		if ( is_array( $config ) ) {
 			return HttpQuery::from_array( $config );
 		}

--- a/inc/Editor/BlockPatterns/BlockPatterns.php
+++ b/inc/Editor/BlockPatterns/BlockPatterns.php
@@ -21,12 +21,12 @@ class BlockPatterns {
 			return;
 		}
 
-		self::$templates['columns'] = file_get_contents( __DIR__ . '/templates/columns.html', false );
-		self::$templates['empty'] = file_get_contents( __DIR__ . '/templates/empty.html', false );
-		self::$templates['heading'] = file_get_contents( __DIR__ . '/templates/heading.html', false );
-		self::$templates['image'] = file_get_contents( __DIR__ . '/templates/image.html', false );
-		self::$templates['paragraph'] = file_get_contents( __DIR__ . '/templates/paragraph.html', false );
-		self::$templates['html'] = file_get_contents( __DIR__ . '/templates/html.html', false );
+		self::$templates['columns'] = file_get_contents( __DIR__ . '/templates/columns.html', false ) ?: '';
+		self::$templates['empty'] = file_get_contents( __DIR__ . '/templates/empty.html', false ) ?: '';
+		self::$templates['heading'] = file_get_contents( __DIR__ . '/templates/heading.html', false ) ?: '';
+		self::$templates['image'] = file_get_contents( __DIR__ . '/templates/image.html', false ) ?: '';
+		self::$templates['paragraph'] = file_get_contents( __DIR__ . '/templates/paragraph.html', false ) ?: '';
+		self::$templates['html'] = file_get_contents( __DIR__ . '/templates/html.html', false ) ?: '';
 	}
 
 	private static function generate_attribute_bindings( string $block_name, array $bindings ): array {
@@ -178,17 +178,17 @@ class BlockPatterns {
 
 		$pattern_name = sprintf( '%s/pattern', $block_name );
 
-		register_block_pattern(
-			$pattern_name,
-			[
-				'title' => sprintf( '%s Data', $block_title ),
-				'blockTypes' => [ $block_name ],
-				'categories' => [ 'remote-data-blocks' ],
-				'content' => $content,
-				'inserter' => true,
-				'source' => 'plugin',
-			]
-		);
+		/** @var array<string, mixed> $pattern_properties */
+		$pattern_properties = [
+			'title' => sprintf( '%s Data', $block_title ),
+			'blockTypes' => [ $block_name ],
+			'categories' => [ 'remote-data-blocks' ],
+			'content' => $content,
+			'inserter' => true,
+			'source' => 'plugin',
+		];
+
+		register_block_pattern( $pattern_name, $pattern_properties );
 
 		// Register block pattern category.
 		register_block_pattern_category(

--- a/inc/Editor/DataBinding/BlockBindings.php
+++ b/inc/Editor/DataBinding/BlockBindings.php
@@ -125,6 +125,10 @@ class BlockBindings {
 		return $block_type_args;
 	}
 
+	/**
+	 * @param array<string, mixed> $block_context Remote data block context.
+	 * @return array<string, mixed>|WP_Error
+	 */
 	private static function execute_queries( array $block_context ): array|WP_Error {
 		// Load the attribute data and validate it.
 		$remote_data = RemoteDataBlockAttribute::from_array( $block_context );
@@ -199,9 +203,21 @@ class BlockBindings {
 		}
 	}
 
-	private static function execute_queries_with_cache( array $block_context, array $source_args = [] ): array|WP_Error {
+	/**
+	 * @param array<string, mixed> $block_context Remote data block context.
+	 * @param array<string, mixed> $source_args Binding source args.
+	 * @return array{config_id: string, response: array<string, mixed>|WP_Error}
+	 */
+	private static function execute_queries_with_cache( array $block_context, array $source_args = [] ): array {
 		// Migrate the config early so that we can access and use values without defensive checks.
 		$block_context = RemoteDataBlockAttribute::migrate_config( $block_context, $source_args );
+
+		if ( is_wp_error( $block_context ) ) {
+			return [
+				'config_id' => '',
+				'response' => $block_context,
+			];
+		}
 
 		$config_id = $block_context['configId'];
 
@@ -472,16 +488,18 @@ class BlockBindings {
 		}
 
 		// Create an updated block with the new inner blocks and content.
-		$updated_block = new WP_Block( $block->parsed_block );
+		/** @var array{attrs?: array<array-key, mixed>, blockName?: null|string, innerBlocks?: array<array-key, mixed>, innerContent?: array<array-key, mixed>, innerHTML?: string} $parsed_block */
+		$parsed_block = $block->parsed_block;
+		$updated_block = new WP_Block( $parsed_block );
 
 		// Render the updated block but set dynamic to false so that we don't
 		// have recursion. Save the rendered output in a property on the
 		// parsed block, which will not be persisted. This is needed because
 		// our container block can trigger a non-dynamic re-render. This helps
 		// avoid descendant dynamic blocks from being rendered twice.
-		$block->parsed_block[ self::$prerendered_content_key ] = $updated_block->render( [ 'dynamic' => false ] );
+		$block->parsed_block[ self::$prerendered_content_key ] = strval( $updated_block->render( [ 'dynamic' => false ] ) );
 
-		return $block->parsed_block[ self::$prerendered_content_key ];
+		return strval( $block->parsed_block[ self::$prerendered_content_key ] ?? '' );
 	}
 
 	/**

--- a/inc/ExampleApi/Data/ExampleApiData.php
+++ b/inc/ExampleApi/Data/ExampleApiData.php
@@ -20,7 +20,8 @@ class ExampleApiData {
 		}
 
 		if ( is_null( self::$api_data ) ) {
-			self::$api_data = wp_json_file_decode( __DIR__ . '/items.json', [ 'associative' => true ] );
+			$api_data = wp_json_file_decode( __DIR__ . '/items.json', [ 'associative' => true ] );
+			self::$api_data = is_array( $api_data ) ? $api_data : null;
 		}
 
 		// If $api_data is *still* null, it could not be loaded. Store an error so

--- a/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
+++ b/inc/ExampleApi/Queries/ExampleApiQueryRunner.php
@@ -4,6 +4,7 @@ namespace RemoteDataBlocks\ExampleApi\Queries;
 
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
 use RemoteDataBlocks\ExampleApi\Data\ExampleApiData;
+use WP_Error;
 
 defined( 'ABSPATH' ) || exit();
 
@@ -17,17 +18,29 @@ defined( 'ABSPATH' ) || exit();
  *
  */
 class ExampleApiQueryRunner extends QueryRunner {
-	protected function get_raw_response_data( array $request_details, array $input_variables ): array {
+	protected function get_raw_response_data( array $request_details, array $input_variables ): array|WP_Error {
 		if ( isset( $input_variables['record_id'] ) ) {
+			$response_data = ExampleApiData::get_item( $input_variables['record_id'] );
+			if ( is_wp_error( $response_data ) ) {
+				return $response_data;
+			}
+
 			return [
+				'input_variables' => $input_variables,
 				'metadata' => [],
-				'response_data' => ExampleApiData::get_item( $input_variables['record_id'] ),
+				'response_data' => $response_data,
 			];
 		}
 
+		$response_data = ExampleApiData::get_items();
+		if ( is_wp_error( $response_data ) ) {
+			return $response_data;
+		}
+
 		return [
+			'input_variables' => $input_variables,
 			'metadata' => [],
-			'response_data' => ExampleApiData::get_items(),
+			'response_data' => $response_data,
 		];
 	}
 }

--- a/inc/Integrations/GenericHttp/GenericHttpDataSource.php
+++ b/inc/Integrations/GenericHttp/GenericHttpDataSource.php
@@ -31,9 +31,9 @@ class GenericHttpDataSource extends HttpDataSource {
 	public static function get_endpoint_from_service_config( array $service_config ): string {
 		$endpoint = $service_config['endpoint'];
 		$auth_config = $service_config['auth'] ?? null;
-		$auth_type = $auth_config['type'] ?? null;
+		$auth_type = is_array( $auth_config ) ? $auth_config['type'] ?? null : null;
 
-		if ( 'api-key' === $auth_type && 'queryparams' === $auth_config['add_to'] ) {
+		if ( 'api-key' === $auth_type && is_array( $auth_config ) && 'queryparams' === $auth_config['add_to'] ) {
 			return add_query_arg( $auth_config['key'], $auth_config['value'], $endpoint );
 		}
 
@@ -42,7 +42,7 @@ class GenericHttpDataSource extends HttpDataSource {
 
 	public static function get_request_headers_from_service_config( array $service_config ): array {
 		$auth_config = $service_config['auth'] ?? null;
-		$auth_type = $auth_config['type'] ?? null;
+		$auth_type = is_array( $auth_config ) ? $auth_config['type'] ?? null : null;
 
 		switch ( $auth_type ) {
 			case 'bearer':
@@ -52,7 +52,11 @@ class GenericHttpDataSource extends HttpDataSource {
 				return [ 'Authorization' => 'Basic ' . base64_encode( $auth_config['value'] ) ];
 
 			case 'api-key':
-				if ( 'header' === $auth_config['add_to'] ) {
+				if (
+					is_array( $auth_config ) &&
+					'header' === $auth_config['add_to'] &&
+					is_string( $auth_config['key'] )
+				) {
 					return [ $auth_config['key'] => $auth_config['value'] ];
 				}
 		}
@@ -73,13 +77,15 @@ class GenericHttpDataSource extends HttpDataSource {
 	}
 
 	/**
-	 * @inheritDoc
+	 * @param array<string, mixed> $config The data source config.
+	 * @return array<string, mixed>|WP_Error
 	 *
 	 * NOTE: This method uses late static bindings to allow child classes to
 	 * define their own validation schema.
 	 */
 	public static function preprocess_config( array $config ): array|WP_Error {
 		$service_config = $config['service_config'] ?? [];
+		$service_config = is_array( $service_config ) ? $service_config : [];
 		$validator = new Validator( static::get_service_config_schema(), static::class, '$service_config' );
 		$validated = $validator->validate( $service_config );
 

--- a/inc/Integrations/VipBlockDataApi/VipBlockDataApi.php
+++ b/inc/Integrations/VipBlockDataApi/VipBlockDataApi.php
@@ -42,7 +42,7 @@ class VipBlockDataApi {
 			'attributes' => array_diff_key( $sourced_block['attributes'], [ 'remoteData' => '' ] ),
 		];
 
-		$block_callback = function ( $block ) use ( $block_context ) {
+		$block_callback = function ( array $block ) use ( $block_context ): array {
 			// @TODO: look at this more closely. This is a hack to get around the fact that the block data API
 			// sometimes returns objects for attributes, but the block bindings code expects arrays.
 			if ( is_object( $block['attributes'] ) ) {

--- a/inc/PluginSettings/PluginSettings.php
+++ b/inc/PluginSettings/PluginSettings.php
@@ -166,9 +166,9 @@ class PluginSettings {
 		if ( $is_error ) {
 			self::show_settings_error( __( 'Error decrypting remote-data-blocks settings.', 'remote-data-blocks' ) );
 			return [];
-		} else {
-			return json_decode( $decrypted, true );
 		}
+
+		return json_decode( strval( $decrypted ), true );
 	}
 
 	private static function show_settings_error( string $message ): void {

--- a/inc/REST/DataSourceController.php
+++ b/inc/REST/DataSourceController.php
@@ -259,23 +259,60 @@ class DataSourceController extends WP_REST_Controller {
 
 	// These all require manage_options for now, but we can adjust as needed
 
-	public function get_item_permissions_check( mixed $request ): bool|WP_Error {
-		return current_user_can( 'manage_options' );
+	private function manage_options_permissions_check(): bool|WP_Error {
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Sorry, you are not allowed to manage Remote Data Blocks data sources.', 'remote-data-blocks' ),
+			[ 'status' => rest_authorization_required_code() ]
+		);
 	}
 
-	public function get_items_permissions_check( mixed $request ): bool|WP_Error {
-		return current_user_can( 'manage_options' );
+	// PHP 8.1 does not support the native `true` return type required by the parent REST controller stubs.
+	// phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+
+	/**
+	 * @return true|WP_Error
+	 */
+	public function get_item_permissions_check( mixed $request ) {
+		$result = $this->manage_options_permissions_check();
+		return is_wp_error( $result ) ? $result : true;
 	}
 
-	public function create_item_permissions_check( mixed $request ): bool|WP_Error {
-		return current_user_can( 'manage_options' );
+	/**
+	 * @return true|WP_Error
+	 */
+	public function get_items_permissions_check( mixed $request ) {
+		$result = $this->manage_options_permissions_check();
+		return is_wp_error( $result ) ? $result : true;
 	}
 
-	public function update_item_permissions_check( mixed $request ): bool|WP_Error {
-		return current_user_can( 'manage_options' );
+	/**
+	 * @return true|WP_Error
+	 */
+	public function create_item_permissions_check( mixed $request ) {
+		$result = $this->manage_options_permissions_check();
+		return is_wp_error( $result ) ? $result : true;
 	}
 
-	public function delete_item_permissions_check( mixed $request ): bool|WP_Error {
-		return current_user_can( 'manage_options' );
+	/**
+	 * @return true|WP_Error
+	 */
+	public function update_item_permissions_check( mixed $request ) {
+		$result = $this->manage_options_permissions_check();
+		return is_wp_error( $result ) ? $result : true;
 	}
+
+	/**
+	 * @return true|WP_Error
+	 */
+	public function delete_item_permissions_check( mixed $request ) {
+		$result = $this->manage_options_permissions_check();
+		return is_wp_error( $result ) ? $result : true;
+	}
+
+	// phpcs:enable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
 }

--- a/inc/Snippet/Snippet.php
+++ b/inc/Snippet/Snippet.php
@@ -59,7 +59,7 @@ class Snippet implements JsonSerializable {
 		return array_map( [ __CLASS__, 'strip_template_comments' ], $snippets );
 	}
 
-	protected static function strip_template_comments( Snippet $snippet ): Snippet {
+	public static function strip_template_comments( Snippet $snippet ): Snippet {
 		// Match PHPDoc blocks that contain @template tags and any preceding blank lines
 		$updated_code = preg_replace(
 			'/\n*\/\*\*\s*\n\s*\*\s*@template-.*?\*\/\n*/s',

--- a/inc/Store/DataSource/DataSourceConfigManager.php
+++ b/inc/Store/DataSource/DataSourceConfigManager.php
@@ -77,7 +77,7 @@ class DataSourceConfigManager {
 	 *   uuid?: string,
 	 *   service: string,
 	 *   service_config: array<string, mixed>,
-	 *   config_source: string,
+	 *   config_source: 'constant'|'storage',
 	 *   __metadata?: array{
 	 *     created_at: string,
 	 *     updated_at: string
@@ -158,16 +158,7 @@ class DataSourceConfigManager {
 	 * Get a data source by its UUID.
 	 *
 	 * @param string $uuid The UUID of the data source to get.
-	 * @return array{
-	 *   uuid: string,
-	 *   service: string,
-	 *   service_config: array<string, mixed>,
-	 *   config_source: string,
-	 *   __metadata?: array{
-	 *     created_at: string,
-	 *     updated_at: string
-	 *   }
-	 * }|WP_Error
+	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function get( string $uuid ): array|WP_Error {
 		$from_constant = ConstantConfigStore::get_config_by_uuid( $uuid );
@@ -197,16 +188,7 @@ class DataSourceConfigManager {
 	 * Create a new data source.
 	 *
 	 * @param array $config The configuration for the new data source.
-	 * @return array{
-	 *   uuid: string,
-	 *   service: string,
-	 *   service_config: array<string, mixed>,
-	 *   config_source: string,
-	 *   __metadata: array{
-	 *     created_at: string,
-	 *     updated_at: string
-	 *   }
-	 * }|WP_Error
+	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function create( array $config ): array|WP_Error {
 		$result = DataSourceCrud::create_config( $config );
@@ -222,16 +204,7 @@ class DataSourceConfigManager {
 	 *
 	 * @param string $uuid The UUID of the data source to update.
 	 * @param array $config The new configuration for the data source.
-	 * @return array{
-	 *   uuid: string,
-	 *   service: string,
-	 *   service_config: array<string, mixed>,
-	 *   config_source: string,
-	 *   __metadata: array{
-	 *     created_at: string,
-	 *     updated_at: string
-	 *   }
-	 * }|WP_Error
+	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function update( string $uuid, array $config ): array|WP_Error {
 		if (
@@ -260,7 +233,7 @@ class DataSourceConfigManager {
 	 * Delete a data source.
 	 *
 	 * @param string $uuid The UUID of the data source to delete.
-	 * @return true|WP_Error True on success, WP_Error on failure.
+	 * @return bool|WP_Error True on success, false or WP_Error on failure.
 	 */
 	public static function delete( string $uuid ): bool|WP_Error {
 		return DataSourceCrud::delete_config_by_uuid( $uuid );

--- a/inc/Telemetry/Telemetry.php
+++ b/inc/Telemetry/Telemetry.php
@@ -66,8 +66,9 @@ class Telemetry {
 		add_action( 'remote_data_blocks_track_event', [ $this, 'record_event' ], 10, 2 );
 
 		// Enable the Pendo JavaScript library for tracking.
-		if ( class_exists( '\Automattic\VIP\Telemetry\Pendo' ) ) {
-			add_action( 'admin_init', [ \Automattic\VIP\Telemetry\Pendo::class, 'enable_javascript_library' ] );
+		$pendo_callback = [ \Automattic\VIP\Telemetry\Pendo::class, 'enable_javascript_library' ];
+		if ( class_exists( '\Automattic\VIP\Telemetry\Pendo' ) && is_callable( $pendo_callback ) ) {
+			add_action( 'admin_init', $pendo_callback );
 		}
 	}
 

--- a/inc/WpdbStorage/DataSourceCrud.php
+++ b/inc/WpdbStorage/DataSourceCrud.php
@@ -44,7 +44,11 @@ class DataSourceCrud {
 
 				// If the data source is valid, set a transient field with the errors encountered when inflating the config.
 				// We get the errors from the instance, otherwise there'll be an errors field in the errors field in the config.
-				$config['errors'] = is_wp_error( $instance ) ? [ $instance->errors ] : [];
+				if ( $instance instanceof DataSourceInterface ) {
+					$config['errors'] = [];
+				} else {
+					$config['errors'] = [ $instance->get_error_messages() ];
+				}
 
 				// Give back the same config with the errors field set, not the inflated instance.
 				return $config;

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="7"
+    errorLevel="6"
     resolveFromConfigFile="true"
     phpVersion="8.1"
     allConstantsGlobal="true"

--- a/tests/inc/Config/QueryResponseParserTest.php
+++ b/tests/inc/Config/QueryResponseParserTest.php
@@ -47,7 +47,7 @@ final class QueryResponseParserTest extends TestCase {
 
 		$result = $this->parser->parse( $data, $schema );
 
-		$this->assertIsArray( $result );
+		$result = $this->assertCollectionResult( $result );
 		$this->assertCount( 2, $result );
 		$this->assertArrayHasKey( 'result', $result[0] );
 		$this->assertArrayHasKey( 'uuid', $result[0] );
@@ -79,7 +79,7 @@ final class QueryResponseParserTest extends TestCase {
 
 		$result = $this->parser->parse( $data, $schema );
 
-		$this->assertIsArray( $result );
+		$result = $this->assertCollectionResult( $result );
 		$this->assertCount( 1, $result );
 		$this->assertArrayHasKey( 'result', $result[0] );
 		$this->assertArrayHasKey( 'uuid', $result[0] );
@@ -125,7 +125,7 @@ final class QueryResponseParserTest extends TestCase {
 
 		$result = $this->parser->parse( $data, $schema, $raw_response_data );
 
-		$this->assertIsArray( $result );
+		$result = $this->assertCollectionResult( $result );
 		$this->assertCount( 1, $result );
 		$this->assertArrayHasKey( 'result', $result[0] );
 		$this->assertArrayHasKey( 'uuid', $result[0] );
@@ -152,7 +152,7 @@ final class QueryResponseParserTest extends TestCase {
 
 		$result = $this->parser->parse( $data, $schema );
 
-		$this->assertIsArray( $result );
+		$result = $this->assertCollectionResult( $result );
 		$this->assertCount( 1, $result );
 		$this->assertArrayHasKey( 'result', $result[0] );
 		$this->assertArrayHasKey( 'uuid', $result[0] );
@@ -184,7 +184,7 @@ final class QueryResponseParserTest extends TestCase {
 
 		$result = $this->parser->parse( $data, $schema );
 
-		$this->assertIsArray( $result );
+		$result = $this->assertSingleResult( $result );
 		$this->assertArrayHasKey( 'result', $result );
 		$this->assertArrayHasKey( 'uuid', $result );
 		$this->assertEquals( 'Gadget', $result['result']['productName']['value'] );
@@ -249,6 +249,7 @@ final class QueryResponseParserTest extends TestCase {
 
 		$result = $this->parser->parse( $data, $schema );
 
+		$result = $this->assertCollectionResult( $result );
 		$this->assertCount( 2, $result );
 		$this->assertEquals( 'Unknown', $result[0]['result']['itemColor']['value'] );
 		$this->assertEquals( 'Yellow', $result[1]['result']['itemColor']['value'] );
@@ -293,6 +294,7 @@ final class QueryResponseParserTest extends TestCase {
 
 		$result = $this->parser->parse( $data, $schema );
 
+		$result = $this->assertCollectionResult( $result );
 		$this->assertCount( 1, $result );
 
 		$customer_info = $result[0]['result']['customerInfo']['value'];
@@ -301,5 +303,23 @@ final class QueryResponseParserTest extends TestCase {
 		$this->assertArrayHasKey( 'result', $customer_info );
 		$this->assertEquals( 'David', $customer_info['result']['customerName']['value'] );
 		$this->assertEquals( 'david@example.com', $customer_info['result']['customerEmail']['value'] );
+	}
+
+	/**
+	 * @return array<int, array{result: array<string, array{name?: string, type?: string, value: mixed}>, uuid?: string}>
+	 */
+	private function assertCollectionResult( mixed $result ): array {
+		$this->assertIsArray( $result );
+
+		return $result;
+	}
+
+	/**
+	 * @return array{result: array<string, array{name?: string, type?: string, value: mixed}>, uuid?: string}
+	 */
+	private function assertSingleResult( mixed $result ): array {
+		$this->assertIsArray( $result );
+
+		return $result;
 	}
 }

--- a/tests/inc/Config/QueryRunnerTest.php
+++ b/tests/inc/Config/QueryRunnerTest.php
@@ -3,6 +3,7 @@
 namespace RemoteDataBlocks\Tests\Config;
 
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RemoteDataBlocks\Config\QueryRunner\QueryRunner;
 use RemoteDataBlocks\HttpClient\HttpClient;
@@ -13,7 +14,7 @@ use WP_Error;
 class QueryRunnerTest extends TestCase {
 	private MockDataSource $http_data_source;
 	private MockQuery $query;
-	private HttpClient $http_client;
+	private HttpClient&MockObject $http_client;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/inc/Editor/DataBinding/BlockBindingsTest.php
+++ b/tests/inc/Editor/DataBinding/BlockBindingsTest.php
@@ -256,7 +256,7 @@ class BlockBindingsTest extends TestCase {
 		 * Mock the QueryRunner to return a result.
 		 */
 		$mock_qr = new class() extends MockQueryRunner {
-			public function execute( HttpQueryInterface $query, array $input_variables ): array {
+			public function execute( HttpQueryInterface $query, array $input_variables ): array|\WP_Error {
 				$input_variables['test_input_field'] .= ' ' . $input_variables['another_input_field'];
 				return parent::execute( $query, $input_variables );
 			}
@@ -301,7 +301,7 @@ class BlockBindingsTest extends TestCase {
 		 * Mock the QueryRunner to return a result.
 		 */
 		$mock_qr = new class() extends MockQueryRunner {
-			public function execute( HttpQueryInterface $query, array $input_variables ): array {
+			public function execute( HttpQueryInterface $query, array $input_variables ): array|\WP_Error {
 				$input_variables['test_input_field'] .= ' transformed';
 				return parent::execute( $query, $input_variables );
 			}

--- a/tests/inc/Mocks/MockDataSource.php
+++ b/tests/inc/Mocks/MockDataSource.php
@@ -29,6 +29,9 @@ class MockDataSource extends HttpDataSource {
 
 	/**
 	 * Override the migrate_config method to adjust the config for testing.
+	 *
+	 * @param array<string, mixed> $config The config to migrate.
+	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function migrate_config( array $config ): array|WP_Error {
 		if ( ! isset( $config['request_headers'] ) ) {

--- a/tests/inc/Store/DataSource/DataSourceConfigManagerTest.php
+++ b/tests/inc/Store/DataSource/DataSourceConfigManagerTest.php
@@ -478,9 +478,12 @@ class DataSourceConfigManagerTest extends TestCase {
 		$mock_config_store->shouldReceive( 'get_data_sources_as_array' )
 			->andReturn( [] );
 
-		$result = DataSourceConfigManager::get_all( [
+		/** @var array<string, mixed> $filters */
+		$filters = [
 			'display_name' => 'Test Airtable',
-		] );
+		];
+
+		$result = DataSourceConfigManager::get_all( $filters );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'invalid_filter', $result->get_error_code() );
@@ -501,10 +504,13 @@ class DataSourceConfigManagerTest extends TestCase {
 		$mock_config_store->shouldReceive( 'get_data_sources_as_array' )
 			->andReturn( [] );
 
-		$result = DataSourceConfigManager::get_all( [
+		/** @var array<string, mixed> $filters */
+		$filters = [
 			'service' => self::AIRTABLE_SERVICE,
 			'display_name' => 'Test Airtable',
-		] );
+		];
+
+		$result = DataSourceConfigManager::get_all( $filters );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'invalid_filter', $result->get_error_code() );

--- a/tests/inc/WpdbStorage/DataSourceCrudTest.php
+++ b/tests/inc/WpdbStorage/DataSourceCrudTest.php
@@ -81,6 +81,8 @@ class DataSourceCrudTest extends TestCase {
 			],
 			'uuid' => '00000000-0000-4000-8000-000000000002',
 		] );
+		$this->assertIsArray( $source1 );
+		$this->assertIsArray( $source2 );
 
 		$all_sources = DataSourceCrud::get_configs();
 		$this->assertCount( 2, $all_sources );
@@ -111,8 +113,10 @@ class DataSourceCrudTest extends TestCase {
 			],
 			'uuid' => wp_generate_uuid4(),
 		] );
+		$this->assertIsArray( $source );
 
 		$retrieved_source = DataSourceCrud::get_config_by_uuid( $source['uuid'] );
+		$this->assertIsArray( $retrieved_source );
 		$this->assertArrayHasKey( '__metadata', $retrieved_source );
 		$this->assertArrayHasKey( 'created_at', $retrieved_source['__metadata'] );
 		$this->assertArrayHasKey( 'updated_at', $retrieved_source['__metadata'] );
@@ -139,6 +143,7 @@ class DataSourceCrudTest extends TestCase {
 			],
 			'uuid' => wp_generate_uuid4(),
 		] );
+		$this->assertIsArray( $source );
 
 		$updated_source = DataSourceCrud::update_config_by_uuid( $source['uuid'], [
 			'access_token' => 'updated_token',
@@ -169,6 +174,7 @@ class DataSourceCrudTest extends TestCase {
 			],
 			'uuid' => wp_generate_uuid4(),
 		] );
+		$this->assertIsArray( $source );
 
 		$result = DataSourceCrud::delete_config_by_uuid( $source['uuid'] );
 		$this->assertTrue( $result );

--- a/tests/inc/stubs.php
+++ b/tests/inc/stubs.php
@@ -118,8 +118,8 @@ function get_option( string $option, mixed $default = false ): mixed {
 	return MockWordPressFunctions::get_option( $option, $default );
 }
 
-function get_page_by_path( string $path ): string {
-	return $path ?? 'fake WP_Post';
+function get_page_by_path( string $path ): ?array {
+	return [ 'post_name' => $path ];
 }
 
 function get_query_var( string $var_name, mixed $default_value = null ): ?string {
@@ -130,8 +130,8 @@ function wp_generate_uuid4(): string {
 	return '00000000-0000-4000-8000-000000000000';
 }
 
-function is_email( mixed $email ): bool {
-	return filter_var( $email, FILTER_VALIDATE_EMAIL ) !== false;
+function is_email( mixed $email ): string|false {
+	return false === filter_var( $email, FILTER_VALIDATE_EMAIL ) ? false : strval( $email );
 }
 
 function wp_is_uuid( mixed $uuid, ?int $version = null ): bool {
@@ -164,5 +164,9 @@ class WP_Error {
 
 	public function get_error_message(): string {
 		return $this->message;
+	}
+
+	public function get_error_messages(): array {
+		return [ $this->message ];
 	}
 }

--- a/tests/integration/RDBTestCase.php
+++ b/tests/integration/RDBTestCase.php
@@ -149,6 +149,7 @@ class RDBTestCase extends WP_UnitTestCase {
 	protected function assertDomIdHasTextContent( DOMDocument $dom, string $html_id, string $expected_content ): void {
 		$id_nodes = $this->get_dom_element_by_html_id( $dom, $html_id );
 
+		$this->assertNotFalse( $id_nodes );
 		$this->assertCount( 1, $id_nodes, sprintf( "Should be 1 matching node with HTML ID '%s' but %d found.", $html_id, count( $id_nodes ) ) );
 		$this->assertEquals( $expected_content, $id_nodes[0]->textContent, sprintf( "Expected '%s' in node with HTML ID '%s', but found '%s' instead.", $expected_content, $html_id, $id_nodes[0]->textContent ) );
 	}
@@ -156,6 +157,7 @@ class RDBTestCase extends WP_UnitTestCase {
 	protected function assertDomIdHasHtmlContent( DOMDocument $dom, string $html_id, string $expected_content ): void {
 		$id_nodes = $this->get_dom_element_by_html_id( $dom, $html_id );
 
+		$this->assertNotFalse( $id_nodes );
 		$this->assertCount( 1, $id_nodes, sprintf( "Should be 1 matching node with HTML ID '%s' but %d found.", $html_id, count( $id_nodes ) ) );
 
 		// DOM nodes don't have an innerHTML, so build one from child nodes

--- a/tests/integration/blocks/RemoteDataTemplateBlockTest.php
+++ b/tests/integration/blocks/RemoteDataTemplateBlockTest.php
@@ -62,6 +62,7 @@ class RemoteDataTemplateBlockTest extends RDBTestCase {
 		// The content is inside the template block, so it should be rendered for each result.
 		$content_nodes = $this->get_dom_elements_by_html_class( $dom, 'field-content' );
 
+		$this->assertNotFalse( $content_nodes );
 		$this->assertCount( 3, $content_nodes );
 		$this->assertEquals( 'Product 1 details', $content_nodes[0]->textContent );
 		$this->assertEquals( 'Product 2 details', $content_nodes[1]->textContent );


### PR DESCRIPTION
## What

Fixes #117 by moving Psalm from level 7 to level 6 and resolving the level-6 error set without adding a baseline.

## Notes

The level-6 pass exposed a mix of production-code contracts and test typing fallout:

- Added guards for `WP_Error`/failed inflation paths in block registration, data binding, example templates, and example query execution.
- Tightened query runner response/pagination result shapes.
- Returned a proper `WP_Error` from data-source REST permission failures while preserving PHP 8.1 compatibility.
- Fixed WordPress/test stub return shapes used by validation and data-source tests.
- Added explicit test assertions/annotations for parser result shapes, PHPUnit mocks, and DOM query results.

## Testing

Run under Docker PHP 8.1 to match the configured Psalm target and avoid local PHP 8.5 incompatibility:

- `php vendor/bin/psalm.phar --no-cache`
- `php vendor/bin/phpunit`
- `php vendor/bin/phpcs --cache=/tmp/phpcs-cache`
- `git diff --check`

PHPCS still prints existing ruleset/sniff deprecation warnings, but exits successfully.
