### PR TITLE
Fix WordPress.org deploy artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
   release:
     name: New release to WordPress.org
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.event_name != 'release' || !github.event.release.prerelease }}
     steps:
       - name: Checkout
@@ -30,10 +31,12 @@ jobs:
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
 
-      - name: Build
+      - name: Build release artifact
         run: |
-          npm install
-          npm run build
+          npm ci
+          npm run plugin-zip
+          mkdir -p /tmp/remote-data-blocks-deploy
+          unzip -q remote-data-blocks.zip -d /tmp/remote-data-blocks-deploy
 
       - name: Install SVN (Subversion)
         run: |
@@ -47,3 +50,4 @@ jobs:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           VERSION: ${{ env.DEPLOY_VERSION }}
+          BUILD_DIR: /tmp/remote-data-blocks-deploy/remote-data-blocks


### PR DESCRIPTION
## Summary
- build the WordPress.org deploy payload with `npm run plugin-zip`
- extract the generated release zip and deploy only that packaged plugin directory via `BUILD_DIR`
- add a 30 minute timeout so a bad deploy cannot sit in SVN publishing for hours

## Why
The deploy workflow previously ran `npm install && npm run build`, then let `10up/action-wordpress-plugin-deploy` rsync the whole CI workspace. Because `.distignore` did not exclude `node_modules`, SVN tried to publish the full dependency tree into `trunk` and the release tag.

## Testing
- `npm run plugin-zip`
- `unzip -Z1 remote-data-blocks.zip | rg '(^|/)node_modules/' || true`
- `git diff --check`
- `npx prettier --check .github/workflows/deploy.yml`
